### PR TITLE
fix: update stale docs/screenshots references to marketing/ paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 <p align="center">
   <a href="https://chromewebstore.google.com/detail/nflojekghnganlcjncbepnnnkgakghif?utm_source=github">
-    <img src="docs/screenshots/dashboard-dark.png" width="700" alt="Dashboard in dark mode" />
+    <img src="marketing/output/01-dashboard.png" width="700" alt="Dashboard in dark mode" />
   </a>
 </p>
 
@@ -50,19 +50,15 @@ Or load manually:
 ## Screenshots
 
 <p align="center">
-  <img src="docs/screenshots/dashboard-theme.png" width="700" alt="Dashboard with Cyberpunk theme" />
+  <img src="marketing/output/03-themes.png" width="700" alt="5 color themes side by side" />
 </p>
 
 <p align="center">
-  <img src="docs/screenshots/hover-card.png" width="700" alt="Bookmark hover card with actions" />
+  <img src="marketing/output/02-organizer.png" width="700" alt="Bookmark Organizer tree editor" />
 </p>
 
 <p align="center">
-  <img src="docs/screenshots/settings.png" width="700" alt="Settings dialog" />
-</p>
-
-<p align="center">
-  <img src="docs/screenshots/onboarding.png" width="700" alt="First-run onboarding wizard" />
+  <img src="marketing/output/04-settings.png" width="700" alt="Settings dialog" />
 </p>
 
 ## Development

--- a/marketing/scripts/feature-walkthrough.ts
+++ b/marketing/scripts/feature-walkthrough.ts
@@ -71,7 +71,7 @@ async function run() {
   } finally {
     fs.rmSync(TMP, { recursive: true, force: true })
   }
-  console.log('✓ feature-walkthrough.mp4 and .gif written to docs/screenshots/')
+  console.log('✓ feature-walkthrough.mp4 and .gif written to marketing/output/videos/')
 }
 
 run().catch(err => { console.error(err); process.exit(1) })

--- a/marketing/scripts/promo.ts
+++ b/marketing/scripts/promo.ts
@@ -189,7 +189,7 @@ async function run() {
     await browser.close().catch(() => {})
   }
 
-  console.log('✓ promo-small.png and promo-marquee.png written to docs/screenshots/')
+  console.log('✓ promo-small.png and promo-marquee.png written to marketing/output/')
 }
 
 run().catch(err => { console.error(err); process.exit(1) })

--- a/marketing/scripts/theme-showcase.ts
+++ b/marketing/scripts/theme-showcase.ts
@@ -79,7 +79,7 @@ async function run() {
     fs.rmSync(TMP, { recursive: true, force: true })
   }
 
-  console.log('✓ theme-showcase.mp4 and .gif written to docs/screenshots/')
+  console.log('✓ theme-showcase.mp4 and .gif written to marketing/output/videos/')
 }
 
 run().catch(err => { console.error(err); process.exit(1) })


### PR DESCRIPTION
## Summary

- README hero image and screenshots section updated from `docs/screenshots/` to `marketing/output/`
- `console.log` output messages in `feature-walkthrough.ts`, `theme-showcase.ts`, and `promo.ts` updated to reflect actual output paths

## Why

These were missed in the previous reorganization PR — the files were moved but these string references weren't caught.