### PR TITLE
fix: replace Google's default globe favicon with letter fallback

### DIFF
--- a/src/browser/favicon/detect-default-globe.test.ts
+++ b/src/browser/favicon/detect-default-globe.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest"
+import { isGoogleDefaultGlobe } from "./detect-default-globe"
+
+const V2_URL =
+  "https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https%3A%2F%2Fexample.com&size=64"
+
+describe("isGoogleDefaultGlobe", () => {
+  it("returns false for non-Google URLs even at 16x16", () => {
+    expect(isGoogleDefaultGlobe("https://example.com/favicon.ico", 16, 16)).toBe(
+      false
+    )
+  })
+
+  it("returns false for empty URL", () => {
+    expect(isGoogleDefaultGlobe("", 16, 16)).toBe(false)
+  })
+
+  it("returns true when Google favicon is 16x16", () => {
+    expect(isGoogleDefaultGlobe(V2_URL, 16, 16)).toBe(true)
+  })
+
+  it("returns false when Google favicon is 32x32 (real favicon)", () => {
+    expect(isGoogleDefaultGlobe(V2_URL, 32, 32)).toBe(false)
+  })
+
+  it("returns false when Google favicon is 64x64 (real favicon)", () => {
+    expect(isGoogleDefaultGlobe(V2_URL, 64, 64)).toBe(false)
+  })
+
+  it("returns false for non-square 16 (unexpected shape)", () => {
+    expect(isGoogleDefaultGlobe(V2_URL, 16, 24)).toBe(false)
+  })
+
+  it("returns true for s2 endpoint too", () => {
+    expect(
+      isGoogleDefaultGlobe(
+        "https://www.google.com/s2/favicons?domain=example.com&sz=64",
+        16,
+        16
+      )
+    ).toBe(true)
+  })
+})

--- a/src/browser/favicon/detect-default-globe.ts
+++ b/src/browser/favicon/detect-default-globe.ts
@@ -1,0 +1,24 @@
+const GLOBE_NATURAL_SIZE = 16
+
+const GOOGLE_FAVICON_HOSTS = [
+  "https://t0.gstatic.com/faviconV2",
+  "https://t1.gstatic.com/faviconV2",
+  "https://t2.gstatic.com/faviconV2",
+  "https://t3.gstatic.com/faviconV2",
+  "https://www.google.com/s2/favicons",
+]
+
+function isGoogleFaviconUrl(url: string): boolean {
+  return GOOGLE_FAVICON_HOSTS.some((prefix) => url.startsWith(prefix))
+}
+
+export function isGoogleDefaultGlobe(
+  url: string,
+  naturalWidth: number,
+  naturalHeight: number
+): boolean {
+  if (!url || !isGoogleFaviconUrl(url)) return false
+  return (
+    naturalWidth === GLOBE_NATURAL_SIZE && naturalHeight === GLOBE_NATURAL_SIZE
+  )
+}

--- a/src/features/bookmark-item/favicon.tsx
+++ b/src/features/bookmark-item/favicon.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
+import { isGoogleDefaultGlobe } from "@/browser/favicon/detect-default-globe"
 
 interface FaviconProps {
   url: string
@@ -35,6 +36,16 @@ export function Favicon({
     }
   }, [failed, fallbackSrc])
 
+  const handleLoad = React.useCallback(
+    (e: React.SyntheticEvent<HTMLImageElement>) => {
+      const img = e.currentTarget
+      if (isGoogleDefaultGlobe(src, img.naturalWidth, img.naturalHeight)) {
+        handleError()
+      }
+    },
+    [src, handleError]
+  )
+
   if (failed && (!fallbackSrc || src === fallbackSrc)) {
     // Final fallback: first letter of domain
     let letter = "?"
@@ -66,6 +77,7 @@ export function Favicon({
       className={cn("shrink-0 rounded-sm object-contain", className)}
       style={{ width: size, height: size, minWidth: size, minHeight: size }}
       onError={handleError}
+      onLoad={handleLoad}
       loading="lazy"
     />
   )


### PR DESCRIPTION
## Summary
- Google's `faviconV2` endpoint returns a **16×16 globe PNG with HTTP 404** for domains that have no favicon. Browsers render the image body from 4xx responses, so `<img onerror>` never fires — users see generic globes across the grid/list.
- Detect the globe purely from intrinsic pixel dimensions on `<img onLoad>`: Google never upscales its fallback, so a Google favicon URL that loads at 16×16 (when we requested `size=64`) is the globe.
- When detected, route through the existing fallback chain → Chrome `_favicon` API (MV3) or the letter-in-a-box placeholder (standalone/Firefox).

## Why this approach
- No `fetch` — avoids CORS issues both in dev and in extension contexts
- Zero network cost; reuses the image the browser already loaded
- Short-circuits immediately for non-Google URLs (single `startsWith` check)

## Test plan
- [x] `bun x vitest run` — 33 tests pass (7 new in `detect-default-globe.test.ts`)
- [x] `bun x tsc --noEmit` clean
- [x] Manually verified in dev (`http://localhost:5173/?screenshot=true`): bookmarks pointing at `example.com` and `example.org` now render as "E" letter-in-a-box instead of the Google globe
- [ ] Verify in loaded Chrome extension build
- [ ] Verify in loaded Firefox extension build