### PR TITLE
allow selecting this extension as Homepage for Firefox

### DIFF
--- a/manifests/manifest.firefox.json
+++ b/manifests/manifest.firefox.json
@@ -18,6 +18,9 @@
   "chrome_url_overrides": {
     "newtab": "index.html"
   },
+  "chrome_settings_overrides": {
+    "homepage": "index.html"
+  },
   "permissions": ["bookmarks", "storage"],
   "host_permissions": ["https://t1.gstatic.com/*"],
   "icons": {


### PR DESCRIPTION
Fixes #22

It turned out to be just a simple setting in manifest.firefox.json:

```
"chrome_settings_overrides": {
   "homepage": "index.html"
},
```

I tested with a local .xpi build, setting it as Homepage in Firefox now works.