### PR TITLE
fix: store preferences in local storage instead of sync (#24)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -271,6 +271,7 @@ export function App() {
                     indexedDB.deleteDatabase("bookmarks-but-better")
                     indexedDB.deleteDatabase("bookmarks-but-better-prefs")
                     chrome?.storage?.sync?.clear?.()
+                    chrome?.storage?.local?.clear?.()
                     window.location.reload()
                   }}
                   aria-label="Reset data (dev)"

--- a/src/browser/chrome/storage.ts
+++ b/src/browser/chrome/storage.ts
@@ -2,7 +2,7 @@ import type { StorageAdapter } from "../types"
 
 export class ChromeStorageAdapter implements StorageAdapter {
   async get<T>(key: string): Promise<T | null> {
-    const result = await chrome.storage.sync.get(key)
+    const result = await chrome.storage.local.get(key)
     if (key in result) {
       return result[key] as T
     }
@@ -10,10 +10,10 @@ export class ChromeStorageAdapter implements StorageAdapter {
   }
 
   async set<T>(key: string, value: T): Promise<void> {
-    await chrome.storage.sync.set({ [key]: value })
+    await chrome.storage.local.set({ [key]: value })
   }
 
   async remove(key: string): Promise<void> {
-    await chrome.storage.sync.remove(key)
+    await chrome.storage.local.remove(key)
   }
 }

--- a/src/browser/detect.ts
+++ b/src/browser/detect.ts
@@ -10,6 +10,32 @@ import { StandaloneStorageAdapter } from "./standalone/storage"
 import { StandaloneFaviconAdapter } from "./standalone/favicon"
 
 const ADAPTER_PREF_KEY = "adapterMode"
+const SYNC_MIGRATION_FLAG = "__syncToLocalMigrated"
+
+/**
+ * One-time migration of preferences from chrome.storage.sync to
+ * chrome.storage.local. Preferences used to sync across devices, but the
+ * stored `rootFolderId` is a browser-assigned bookmark node id that is local
+ * to each profile/OS, so syncing it broke the root folder on other machines.
+ *
+ * Copies all existing sync keys (including rootFolderId) into local once, then
+ * sets a flag so it never runs again. Sync storage is intentionally left
+ * untouched so devices that haven't updated yet keep reading their settings.
+ */
+async function migrateSyncToLocal(): Promise<void> {
+  try {
+    const flag = await chrome.storage.local.get(SYNC_MIGRATION_FLAG)
+    if (flag[SYNC_MIGRATION_FLAG]) return
+
+    const synced = await chrome.storage.sync.get(null)
+    if (Object.keys(synced).length > 0) {
+      await chrome.storage.local.set(synced)
+    }
+    await chrome.storage.local.set({ [SYNC_MIGRATION_FLAG]: true })
+  } catch {
+    // Best-effort: if sync storage is unavailable there is nothing to migrate.
+  }
+}
 
 function isBrowserExtension(): boolean {
   try {
@@ -79,7 +105,6 @@ function createFirefoxAdapter(): BrowserAdapter {
     favicon: new FirefoxFaviconAdapter(),
     capabilities: {
       openInManager: false,
-      syncNote: "Your preferences sync across devices via Firefox Sync. If you're not signed into Firefox Sync, settings are saved locally on this device only.",
     },
   }
 }
@@ -103,14 +128,17 @@ export async function detectAdapter(): Promise<BrowserAdapter> {
   }
 
   if (isFirefoxBuild() && isBrowserExtension()) {
+    await migrateSyncToLocal()
     return createFirefoxAdapter()
   }
 
   if (preference === "browser" && isBrowserExtension()) {
+    await migrateSyncToLocal()
     return createChromeAdapter()
   }
 
   if (isBrowserExtension()) {
+    await migrateSyncToLocal()
     return createChromeAdapter()
   }
 

--- a/src/browser/firefox/storage.ts
+++ b/src/browser/firefox/storage.ts
@@ -2,7 +2,7 @@ import type { StorageAdapter } from "../types"
 
 export class FirefoxStorageAdapter implements StorageAdapter {
   async get<T>(key: string): Promise<T | null> {
-    const result = await chrome.storage.sync.get(key)
+    const result = await chrome.storage.local.get(key)
     if (key in result) {
       return result[key] as T
     }
@@ -10,10 +10,10 @@ export class FirefoxStorageAdapter implements StorageAdapter {
   }
 
   async set<T>(key: string, value: T): Promise<void> {
-    await chrome.storage.sync.set({ [key]: value })
+    await chrome.storage.local.set({ [key]: value })
   }
 
   async remove(key: string): Promise<void> {
-    await chrome.storage.sync.remove(key)
+    await chrome.storage.local.remove(key)
   }
 }

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -44,8 +44,6 @@ export interface FaviconProvider {
 export interface AdapterCapabilities {
   /** Whether "open in bookmark manager" is supported. False on Firefox and Standalone. */
   openInManager: boolean
-  /** Optional note to display in Settings about storage sync behaviour. Only set on Firefox. */
-  syncNote?: string
 }
 
 export interface BrowserAdapter {

--- a/src/features/settings/settings-dialog.tsx
+++ b/src/features/settings/settings-dialog.tsx
@@ -32,7 +32,6 @@ export function SettingsDialog() {
   const tree = useBookmarkStore((s) => s.tree)
   const adapter = useBookmarkStore((s) => s.adapter)
   const refresh = useBookmarkStore((s) => s.refresh)
-  const syncNote = adapter?.capabilities.syncNote
   const adapterMode = usePreferencesStore((s) => s.adapterMode)
   const setAdapterMode = usePreferencesStore((s) => s.setAdapterMode)
   const maxColumns = usePreferencesStore((s) => s.maxColumns)
@@ -133,11 +132,6 @@ export function SettingsDialog() {
 
         <div className="-mx-4 no-scrollbar max-h-[50vh] overflow-y-auto px-4">
           <div className="flex flex-col gap-6">
-            {syncNote && (
-              <div className="rounded-md bg-muted px-3 py-2.5 text-xs text-muted-foreground">
-                {syncNote}
-              </div>
-            )}
             {/* Bookmarks section */}
             <RootFolderSelect
               value={rootFolderId}


### PR DESCRIPTION
Closes #24

## Problem

All user preferences flow through the Chrome/Firefox `StorageAdapter`s into `chrome.storage.sync`. One synced key, `rootFolderId`, stores a **browser-assigned bookmark node id** that is local to each browser profile/OS. When synced, that id lands on another machine where it points to nothing — so the chosen root folder breaks and has to be re-selected every time you switch between Linux / Mac / Windows.

## Fix

Keep all preferences **local** instead of synced.

- Switch `ChromeStorageAdapter` and `FirefoxStorageAdapter` from `chrome.storage.sync` to `chrome.storage.local` (these two adapters are the only direct sync users, so every preference is now device-local).
- Add a one-time `sync -> local` migration in `detectAdapter()` that copies all existing sync keys (including `rootFolderId`) into local, guarded by a `__syncToLocalMigrated` flag so it runs once. Sync storage is intentionally **left untouched** so devices that haven't updated yet keep reading their settings.
- Remove the now-inaccurate Firefox `syncNote` ("syncs across devices via Firefox Sync") and its unused capability field / settings render.
- Dev reset button also clears local storage now.

## Verification

- `bun run typecheck` ✓
- `bun run lint` ✓
- `bun run test` ✓ (33/33)

### Manual smoke test (suggested)
1. Before updating, in the extension page console: `chrome.storage.sync.set({ colorTheme: "rose", rootFolderId: "123", maxColumns: 5 })`.
2. Load the updated build; confirm `chrome.storage.local.get(null)` now holds those keys plus `__syncToLocalMigrated: true`, and the UI reflects them.
3. Reload again; confirm migration does not re-run and local values are preserved.
4. Confirm picking a root folder writes to `chrome.storage.local` (not sync), and a fresh profile/OS starts clean with no stale `rootFolderId`.