### PR TITLE
chore: bump version to 3.2.0

### DIFF
--- a/manifests/manifest.chrome.json
+++ b/manifests/manifest.chrome.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Bookmarks - But Better",
   "description": "A clean, beautiful bookmarks dashboard for your new tab with themes, dark mode, and full bookmark management.",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "chrome_url_overrides": {
     "newtab": "index.html"
   },

--- a/manifests/manifest.firefox.json
+++ b/manifests/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Bookmarks - But Better",
   "description": "A clean, beautiful bookmarks dashboard for your new tab with themes, dark mode, and full bookmark management.",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "browser_specific_settings": {
     "gecko": {
       "id": "bookmarks@farhadeidi.com",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmarks-but-better",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bumps the version to **3.2.0** across `package.json` and both manifests for the release that includes:

- Local preferences storage, fixing the cross-OS root folder bug (#24, #25)
- Firefox Homepage option (#22, #23)

Also realigns `package.json` (was lagging at `3.0.0`) with the manifests (were `3.1.0`) so all three now match at `3.2.0`.