### PR TITLE
ci: install libc6-dev-arm64-cross for the aarch64 cross-linker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,7 +339,10 @@ jobs:
             # The only target needing anything extra, and it needs exactly one
             # thing: a cross-linker. Kept as matrix data rather than an `if`
             # ladder so a sixth target is a row, not a new branch.
-            apt_packages: gcc-aarch64-linux-gnu
+            # libc6-dev-arm64-cross ships Scrt1.o/crti.o/crtn.o. It's only a
+            # Recommends of gcc-aarch64-linux-gnu, so --no-install-recommends
+            # below needs it listed explicitly or the final link step fails.
+            apt_packages: gcc-aarch64-linux-gnu libc6-dev-arm64-cross
             linker: aarch64-linux-gnu-gcc
           - target: x86_64-apple-darwin
             runner: macos-latest


### PR DESCRIPTION
## Summary
- Release run 30562094861... (job 90940201158) failed to build `bbb` for `aarch64-unknown-linux-gnu`: the linker could not find `Scrt1.o` and `crti.o`.
- Root cause: the "Install the cross-linker" step runs `apt-get install --no-install-recommends gcc-aarch64-linux-gnu`. `libc6-dev-arm64-cross` — the package that ships `Scrt1.o`/`crti.o`/`crtn.o` — is only a *Recommends* of `gcc-aarch64-linux-gnu`, so `--no-install-recommends` skips it.
- Fix: add `libc6-dev-arm64-cross` to the `apt_packages` matrix entry for `aarch64-unknown-linux-gnu` in `.github/workflows/release.yml`, so it's installed explicitly alongside the cross-compiler.

CI-only change; no application source, versions, secrets, or the existing `v4.0.0-beta.1` tag were touched.

## Validation
- Reproduced the exact failure in `ubuntu:noble` (the runner image): installing only `gcc-aarch64-linux-gnu` with `--no-install-recommends` leaves the box with no `Scrt1.o`/`crti.o`/`crtn.o` anywhere under `/usr`.
- Installing `gcc-aarch64-linux-gnu libc6-dev-arm64-cross` in the same image produces `/usr/aarch64-linux-gnu/lib/{Scrt1.o,crti.o,crtn.o}`, and `aarch64-linux-gnu-gcc -o hello hello.c` links successfully (exit 0).
- Validated the workflow YAML parses and diffed the change to confirm it's scoped to the single `apt_packages` line plus an explanatory comment.

## Test plan
- [ ] CI re-run of the `aarch64-unknown-linux-gnu` job in this PR should pass the "Build the daemon" step
- [ ] Other matrix targets (x86_64-unknown-linux-gnu, macOS, Windows) remain unaffected (no changes to their steps)