### PR TITLE
fix: make the documented install command actually install something

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`install.sh` and `install.ps1` no longer fail out of the box.** Both default
+  to the latest *stable* release, and every stable release so far is an
+  extension-only one carrying no daemon archive — so the documented
+  copy-and-paste command ended in `release v3.2.0 has no asset named bbb-…` and
+  installed nothing. Each now reports that and falls back to the newest
+  prerelease that does have a build for the platform. The fallback needs no
+  undoing later: the first stable release shipping daemon archives is resolved
+  and installed normally
+- **`install.sh` can finish `bbb setup` under `curl … | bash`.** Standard input
+  there is the pipe the script itself arrived on, already read to the end, so
+  setup was handed an immediate EOF and died on its first question. It is now
+  run against the terminal, and where there is no terminal at all the install
+  completes and says to run `bbb setup` by hand
+
 ### Changed
 
 - **The daemon's default port is now 52222** (was 47321). Several browsers on

--- a/README.md
+++ b/README.md
@@ -60,39 +60,16 @@ Or load manually:
 3. Open `about:debugging#/runtime/this-firefox`
 4. Click **Load Temporary Add-on** and select any file inside `dist-firefox/`
 
-### Daemon (optional)
+### Daemon (optional, beta)
 
 The extension can also point at a local `bbb` daemon — a small background
 process that serves your bookmarks from a folder of Markdown files instead of
 the browser's own bookmark store, over `127.0.0.1`/`localhost` only. This is
-entirely optional; browser and standalone modes need nothing described here.
+entirely optional; browser and standalone modes need nothing from it.
 
-Install it with:
-
-```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/farhadeidi/bookmarks-but-better/main/install.sh | bash
-
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/farhadeidi/bookmarks-but-better/main/install.ps1 | iex
-```
-
-Both scripts install to a user-local directory (no administrator/`sudo`
-prompt), verify the downloaded release against its published SHA-256
-checksum before installing anything, and finish by running `bbb setup` to
-create a vault. Pass `--beta` (`-Beta` on Windows) to install the latest
-prerelease instead of the latest stable release, or `--version vX.Y.Z` to pin
-an exact one. See [crates/bbb/README.md](crates/bbb/README.md) for the daemon
-itself — the HTTP API, the background-service integration for each OS, and
-what `bbb service install` does.
-
-Once it's running, open the extension's Settings → **Bookmark Source** →
-**Daemon**, enter the daemon's address (`127.0.0.1:52222` by default) and
-click **Connect**. The extension only requests permission to reach loopback
-addresses at that point — never at install time — and only switches to the
-daemon if a real health check against it succeeds; a daemon that can't be
-reached is reported as an error, never a silent fall back to your browser
-bookmarks.
+The daemon has no stable release yet — it ships only as a prerelease. See
+[docs/DAEMON.md](docs/DAEMON.md) for how to install it, what the install
+scripts do, and how to point the extension at it.
 
 ## Screenshots
 

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -1,0 +1,99 @@
+# The `bbb` daemon
+
+The extension can point at a local `bbb` daemon — a small background process
+that serves your bookmarks from a folder of Markdown files instead of the
+browser's own bookmark store, over `127.0.0.1`/`localhost` only.
+
+This is entirely optional. Browser and standalone modes need nothing on this
+page.
+
+## Status: beta, no stable release yet
+
+The daemon has never been part of a stable release. Every stable release so far
+(up to and including `v3.2.0`) ships the Chrome and Firefox extensions and
+nothing else — there is no `bbb` binary in any of them.
+
+The daemon is published only as **prereleases** (`v4.0.0-beta.N`), so
+everything below installs a prerelease, by fallback or because you asked for
+one by name. Treat it as beta software: it is versioned, checksummed and
+upgradable in place, but the stable-channel guarantees the extensions have do
+not apply to it yet.
+
+## Install
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/farhadeidi/bookmarks-but-better/main/install.sh | bash
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/farhadeidi/bookmarks-but-better/main/install.ps1 | iex
+```
+
+Both scripts default to the latest stable release. Because no stable release
+carries a daemon build yet, they report that and fall back to the newest
+prerelease that does:
+
+```
+resolving the latest stable release
+the latest stable release (v3.2.0) ships no bbb daemon build for x86_64-unknown-linux-gnu
+falling back to the latest prerelease — pass --version <tag> to pin a specific release
+installing v4.0.0-beta.2 (version 4.0.0-beta.2)
+```
+
+The fallback is announced, never silent, and it disappears on its own the day a
+stable release carries a daemon build: from then on the same command installs
+that instead.
+
+To choose explicitly rather than rely on the fallback:
+
+| What you want | macOS / Linux | Windows |
+| --- | --- | --- |
+| The latest prerelease | `bash -s -- --beta` | `-Beta` |
+| One exact release | `bash -s -- --version v4.0.0-beta.2` | `-Version v4.0.0-beta.2` |
+| Install without running setup | `bash -s -- --skip-setup` | `-SkipSetup` |
+
+With `curl … | bash`, arguments go after `-s --`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/farhadeidi/bookmarks-but-better/main/install.sh | bash -s -- --beta
+```
+
+Pipe into `bash`, not `sh`: the script uses `set -o pipefail`, which is a bash
+builtin option, and `/bin/sh` is dash on Debian and Ubuntu.
+
+## What the install scripts do
+
+- Install into a user-local directory — `~/.local/share/bbb` and
+  `~/.local/bin` on macOS and Linux, `%LOCALAPPDATA%\bbb` on Windows. No
+  `sudo`, no administrator prompt, nothing system-wide.
+- Verify the downloaded archive against its published SHA-256 checksum and
+  refuse to install if it does not match.
+- Unpack into a versioned directory and only then repoint `current` at it, so a
+  failed download or a binary that will not run leaves the previous install
+  untouched and rollback-able.
+- Finish by running `bbb setup`, which asks where your vault should live and
+  which port to serve it on. Setup is a conversation, so it needs a terminal; if
+  there is none (CI, a container), the install still completes and tells you to
+  run `bbb setup` yourself.
+
+Uninstalling is deleting the install directory and the `bbb` symlink. Your
+vault is a directory of Markdown files that neither script has ever heard of.
+
+## Connecting the extension
+
+Once the daemon is running, open the extension's Settings → **Bookmark
+Source** → **Daemon**, enter the daemon's address (`127.0.0.1:52222` by
+default) and click **Connect**.
+
+The extension only requests permission to reach loopback addresses at that
+point — never at install time — and only switches to the daemon if a real
+health check against it succeeds. A daemon that cannot be reached is reported
+as an error, never a silent fall back to your browser bookmarks.
+
+## More
+
+See [crates/bbb/README.md](../crates/bbb/README.md) for the daemon itself — the
+HTTP API, the background-service integration for each OS, and what
+`bbb service install` does.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -317,6 +317,16 @@ sidecar's naming (`<archive>.sha256`, content `<hash>  <filename>`), or the
 top-level directory inside the archive is a breaking change for both
 scripts and needs to update them alongside `release.yml`.
 
+Both also default to the latest *stable* release, which today is an
+extension-only one carrying no daemon archive at all. Rather than fail on that,
+each reports it and falls back to the newest prerelease that does have a build
+for the platform (see [DAEMON.md](DAEMON.md)). The fallback is not a switch
+anyone has to flip off later: the first stable release that ships daemon
+archives is resolved and installed normally, and the fallback stops being
+reached. What it does mean is that until then, the plain copy-and-paste install
+command installs a prerelease — so anything published under it is what users
+get.
+
 `.github/workflows/ci.yml`'s `install-scripts` job guards the scripts
 themselves — `shellcheck`, a syntax check of `install.ps1`, and
 `tests/install/smoke-test.sh`, which runs `install.sh` end to end (download,

--- a/install.ps1
+++ b/install.ps1
@@ -11,7 +11,10 @@
 
     1. Resolves which release to install: the latest *stable* release by
        default, the latest prerelease with -Beta, or an exact tag with
-       -Version.
+       -Version. Until the daemon has a stable release, the latest stable
+       release is an extension-only one carrying no `bbb` archive at all;
+       when that is what the default resolves to, this falls back to the
+       latest prerelease that does have a Windows build, and says so.
     2. Downloads that archive and its .sha256 sidecar, and refuses to
        install unless the archive's hash matches it.
     3. Unpacks into a versioned directory under $InstallRoot and only then
@@ -73,6 +76,28 @@ function Invoke-GitHubApi {
   Invoke-RestMethod -Uri $Url -Headers $headers
 }
 
+# The archive this platform needs from a given release. Every release names it
+# after its own version, so this can only be computed per release — which is
+# exactly why the fallback below has to look inside each candidate rather than
+# just taking the newest thing it finds.
+function Get-ArchiveName {
+  param([string]$Tag)
+  "bbb-$($Tag.TrimStart('v'))-$Target.zip"
+}
+
+# True when a release actually ships a daemon build for Windows. An
+# extension-only release (every stable release up to and including v3.2.0)
+# does not, and installing from one is not a thing that can succeed.
+function Test-ReleaseHasDaemon {
+  param($Release)
+  if (-not $Release) { return $false }
+  $names = $Release.PSObject.Properties.Name
+  if (($names -notcontains "tag_name") -or ($names -notcontains "assets")) { return $false }
+  if (-not $Release.tag_name) { return $false }
+  $wanted = Get-ArchiveName $Release.tag_name
+  return [bool]($Release.assets | Where-Object { $_.name -eq $wanted } | Select-Object -First 1)
+}
+
 Write-Host "platform: $Target"
 
 # ---------------------------------------------------------------------------
@@ -100,6 +125,25 @@ if ($Version) {
 } else {
   Write-Host "resolving the latest stable release"
   $release = Invoke-GitHubApi "$ApiBase/repos/$Repo/releases/latest"
+
+  # The daemon has no stable release yet: the latest stable release is an
+  # extension-only one, and resolving to it is how `irm … | iex` ends in
+  # "release vX has no asset named bbb-…". Fall back to the newest prerelease
+  # that does carry a Windows build, loudly — a prerelease is normally
+  # something you have to ask for, and this is the one case where the
+  # alternative is not installing at all.
+  if (-not (Test-ReleaseHasDaemon $release)) {
+    $stableTag = if ($release -and $release.tag_name) { $release.tag_name } else { "unknown" }
+    Write-Host "the latest stable release ($stableTag) ships no bbb daemon build for $Target"
+    Write-Host "falling back to the latest prerelease — pass -Version <tag> to pin a specific release"
+    $releases = Invoke-GitHubApi "$ApiBase/repos/$Repo/releases?per_page=20"
+    $release = $releases |
+      Where-Object { -not $_.draft -and $_.prerelease -and (Test-ReleaseHasDaemon $_) } |
+      Select-Object -First 1
+    if (-not $release) {
+      throw "no stable or prerelease release has a bbb build for $Target yet"
+    }
+  }
 }
 
 $tag = $release.tag_name
@@ -107,7 +151,7 @@ if (-not $tag) { throw "the resolved release had no tag" }
 $version = $tag.TrimStart("v")
 Write-Host "installing $tag (version $version)"
 
-$archiveName = "bbb-$version-$Target.zip"
+$archiveName = Get-ArchiveName $tag
 $checksumName = "$archiveName.sha256"
 
 $archiveAsset = $release.assets | Where-Object { $_.name -eq $archiveName } | Select-Object -First 1

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,10 @@
 #
 #   1. Resolves which release to install: the latest *stable* release by
 #      default, or the latest (or a named) prerelease with --beta /
-#      --version.
+#      --version. Until the daemon has a stable release, the latest stable
+#      release is an extension-only one carrying no `bbb` archive at all; when
+#      that is what the default resolves to, this falls back to the latest
+#      prerelease that does have a build for this platform, and says so.
 #   2. Downloads that platform's archive and its .sha256 sidecar, and refuses
 #      to install unless the archive's hash matches it.
 #   3. Unpacks into a versioned directory under $BBB_INSTALL_ROOT and only
@@ -135,6 +138,26 @@ api_get() {
   fi
 }
 
+# The archive this platform needs from a given release. Every release names it
+# after its own version, so this can only be computed per release — which is
+# exactly why the fallback below has to look inside each candidate rather than
+# just taking the newest thing it finds.
+archive_name_for() {
+  printf 'bbb-%s-%s.tar.gz' "${1#v}" "$TARGET"
+}
+
+# True when a release actually ships a daemon build for this platform. An
+# extension-only release (every stable release up to and including v3.2.0) does
+# not, and installing from one is not a thing that can succeed.
+release_has_daemon() {
+  local json="$1" release_tag
+  release_tag=$(printf '%s' "$json" | jq -r '.tag_name // ""')
+  [ -n "$release_tag" ] && [ "$release_tag" != "null" ] || return 1
+  printf '%s' "$json" \
+    | jq -e --arg name "$(archive_name_for "$release_tag")" \
+        '[.assets[]?.name] | index($name) != null' >/dev/null
+}
+
 release_json=""
 if [ -n "$EXPLICIT_VERSION" ]; then
   tag="${EXPLICIT_VERSION#v}"
@@ -152,6 +175,28 @@ else
   log "resolving the latest stable release"
   release_json=$(api_get "$API_BASE/repos/$REPO/releases/latest") \
     || die "could not fetch the latest release"
+
+  # The daemon has no stable release yet: the latest stable release is an
+  # extension-only one, and resolving to it is how `curl … | bash` ends in
+  # "release vX has no asset named bbb-…". Fall back to the newest prerelease
+  # that does carry a build for this platform, loudly — a prerelease is
+  # normally something you have to ask for, and this is the one case where the
+  # alternative is not installing at all.
+  if ! release_has_daemon "$release_json"; then
+    stable_tag=$(printf '%s' "$release_json" | jq -r '.tag_name // "unknown"')
+    log "the latest stable release ($stable_tag) ships no bbb daemon build for $TARGET"
+    log "falling back to the latest prerelease — pass --version <tag> to pin a specific release"
+    releases_json=$(api_get "$API_BASE/repos/$REPO/releases?per_page=20") \
+      || die "could not list releases"
+    release_json=$(printf '%s' "$releases_json" | jq -c --arg target "$TARGET" '
+      [ .[]
+        | select(.draft == false and .prerelease == true)
+        | select(. as $release | .assets | any(
+            .name == ("bbb-" + ($release.tag_name | ltrimstr("v")) + "-" + $target + ".tar.gz")))
+      ] | first')
+    [ -n "$release_json" ] && [ "$release_json" != "null" ] \
+      || die "no stable or prerelease release has a bbb build for $TARGET yet"
+  fi
 fi
 
 tag=$(printf '%s' "$release_json" | jq -r '.tag_name')
@@ -161,7 +206,7 @@ fi
 version="${tag#v}"
 log "installing $tag (version $version)"
 
-archive_name="bbb-$version-$TARGET.tar.gz"
+archive_name=$(archive_name_for "$tag")
 archive_url=$(printf '%s' "$release_json" | jq -r --arg name "$archive_name" '.assets[] | select(.name == $name) | .browser_download_url')
 checksum_url=$(printf '%s' "$release_json" | jq -r --arg name "$archive_name.sha256" '.assets[] | select(.name == $name) | .browser_download_url')
 
@@ -262,4 +307,23 @@ if [ "$SKIP_SETUP" -eq 1 ]; then
 fi
 
 log ""
-exec "$BIN_DIR/bbb" setup
+
+# `bbb setup` is a conversation: it reads answers from standard input. Under
+# `curl … | bash` standard input is the pipe curl wrote this script into, which
+# bash has already read to the end, so setup would be handed an immediate EOF
+# and die with "setup needs answers, and standard input ended" the moment it
+# asked its first question. Reconnect it to the terminal instead — and when
+# there is no terminal at all (CI, a container, a `bash < install.sh`), say so
+# and stop rather than starting a conversation nobody can answer. The install
+# itself is finished and correct either way.
+if [ -t 0 ]; then
+  exec "$BIN_DIR/bbb" setup
+elif (exec 3</dev/tty) 2>/dev/null; then
+  # An open, not a `test -r`: in a container /dev/tty exists and looks readable
+  # right up until opening it fails with ENXIO because no terminal is attached.
+  exec "$BIN_DIR/bbb" setup </dev/tty
+else
+  log "No terminal is attached, so setup — which asks questions — was not started."
+  log "Run \"$BIN_DIR/bbb\" setup from a terminal to finish."
+  exit 0
+fi

--- a/install.sh
+++ b/install.sh
@@ -194,8 +194,9 @@ else
         | select(. as $release | .assets | any(
             .name == ("bbb-" + ($release.tag_name | ltrimstr("v")) + "-" + $target + ".tar.gz")))
       ] | first')
-    [ -n "$release_json" ] && [ "$release_json" != "null" ] \
-      || die "no stable or prerelease release has a bbb build for $TARGET yet"
+    if [ -z "$release_json" ] || [ "$release_json" = "null" ]; then
+      die "no stable or prerelease release has a bbb build for $TARGET yet"
+    fi
   fi
 fi
 

--- a/src/features/settings/__tests__/daemon-connection-panel.test.tsx
+++ b/src/features/settings/__tests__/daemon-connection-panel.test.tsx
@@ -140,6 +140,18 @@ describe("DaemonConnectionPanel", () => {
   })
 
   /**
+   * The daemon ships only as a prerelease, and the install command shown here
+   * has no flag saying so — it relies on the scripts' fallback. Someone
+   * copying it is entitled to know they are getting beta software.
+   */
+  it("says the install guide gets a prerelease, since no stable release ships the daemon", () => {
+    render(<DaemonConnectionPanel />)
+    fireEvent.click(screen.getByRole("button", { name: "Advanced" }))
+
+    expect(screen.getByText(/still in beta/)).toBeTruthy()
+  })
+
+  /**
    * `install.sh` is a bash script — `set -o pipefail` alone makes it one — and
    * `/bin/sh` is dash on Debian and Ubuntu, where `| sh` fails on the first
    * line with `set: Illegal option -o pipefail`. This is a command the user

--- a/src/features/settings/daemon-connection-panel.tsx
+++ b/src/features/settings/daemon-connection-panel.tsx
@@ -51,6 +51,12 @@ function guessPlatform(): Platform {
  * makes it one) and `/bin/sh` is dash on Debian and Ubuntu, where piping it to
  * `sh` dies on line 1 with `set: Illegal option -o pipefail` — before the
  * script can say anything useful about what went wrong.
+ *
+ * No flag selects the prerelease here even though the daemon only exists as
+ * one: both scripts resolve the latest stable release, notice it carries no
+ * daemon build, and fall back to the newest prerelease that does — so this
+ * plain command keeps working unchanged the day a stable release ships the
+ * daemon. See docs/DAEMON.md.
  */
 const INSTALL_COMMANDS: Record<Platform, string> = {
   macos: "curl -fsSL https://bookmarks-but-better.dev/install.sh | bash",
@@ -93,6 +99,10 @@ function InstallGuide() {
       <code className="overflow-x-auto rounded bg-muted px-2 py-1.5 text-xs whitespace-pre">
         {INSTALL_COMMANDS[platform]}
       </code>
+      <p className="text-xs text-muted-foreground">
+        The daemon is still in beta: there is no stable release of it yet, so
+        this installs the latest prerelease.
+      </p>
       <p className="text-xs text-muted-foreground">
         Then run <code>bbb setup</code> to create a vault and{" "}
         <code>bbb service install --vault &lt;path&gt;</code> to run it in the

--- a/tests/install/smoke-test.sh
+++ b/tests/install/smoke-test.sh
@@ -84,6 +84,24 @@ EOF
 EOF
 }
 
+# A stable release carrying only browser-extension zips and no daemon archive
+# — the shape of every stable release the project has actually published so
+# far, and the one a default install has to cope with rather than die on.
+build_extension_only_stable() {
+  local version="$1"
+  cat > "$work/releases_latest.json" <<EOF
+{
+  "tag_name": "v$version",
+  "prerelease": false,
+  "draft": false,
+  "assets": [
+    {"name": "bookmarks-but-better-chrome-v$version.zip", "browser_download_url": "http://127.0.0.1:$port/asset/nope.zip"},
+    {"name": "bookmarks-but-better-firefox-v$version.zip", "browser_download_url": "http://127.0.0.1:$port/asset/nope.zip"}
+  ]
+}
+EOF
+}
+
 # A fake prerelease, listed alongside the stable one so --beta has something
 # to pick that a plain stable install would never resolve to.
 build_beta_release() {
@@ -263,7 +281,45 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 6: nothing advertises this script to a shell that cannot run it.
+# Test 6: a stable release that ships no daemon build at all — which is what
+# every stable release up to and including v3.2.0 is, an extension-only one —
+# falls back to the newest prerelease that does have one, instead of dying with
+# "release vX has no asset named bbb-…" and installing nothing.
+# ---------------------------------------------------------------------------
+build_extension_only_stable "3.2.0"
+install_root="$work/root4"
+bin_dir="$work/bin4"
+output="$work/fallback.log"
+if run_install >"$output" 2>&1; then
+  ok "a daemon-less stable release falls back instead of failing"
+else
+  bad "a daemon-less stable release falls back instead of failing (output: $(cat "$output"))"
+fi
+if [ "$("$bin_dir/bbb" --version)" = "bbb 4.1.0-beta.1 (smoke test beta)" ]; then
+  ok "the fallback installs the newest prerelease that has a build"
+else
+  bad "the fallback installs the newest prerelease that has a build"
+fi
+if grep -q "falling back to the latest prerelease" "$output"; then
+  ok "the fallback says so rather than installing a prerelease silently"
+else
+  bad "the fallback says so rather than installing a prerelease silently"
+fi
+
+# The other half of the same rule: when nothing anywhere has a build for this
+# platform, that is an error, not a silent no-op.
+printf '%s\n' "[]" > "$work/releases_list.json"
+install_root="$work/root5"
+bin_dir="$work/bin5"
+if run_install >/dev/null 2>&1; then
+  bad "no daemon build anywhere is an error"
+else
+  ok "no daemon build anywhere is an error"
+fi
+build_beta_release "4.1.0-beta.1"
+
+# ---------------------------------------------------------------------------
+# Test 7: nothing advertises this script to a shell that cannot run it.
 #
 # install.sh is bash — `set -o pipefail` alone makes it so — and /bin/sh is
 # dash on Debian and Ubuntu, where `curl … | sh` dies on the first line with


### PR DESCRIPTION
`curl -fsSL .../install.sh | bash` — the command in the README and in the extension's own install guide — printed four lines and installed nothing:

```
platform: x86_64-unknown-linux-gnu
resolving the latest stable release
installing v3.2.0 (version 3.2.0)
error: release v3.2.0 has no asset named bbb-3.2.0-x86_64-unknown-linux-gnu.tar.gz
```

Two independent problems, both fixed here.

## 1. The default resolves to a release that has no daemon in it

Both scripts default to the latest **stable** release. Every stable release so far is extension-only — `v3.2.0` carries `bookmarks-but-better-chrome-v3.2.0.zip` and `…-firefox-v3.2.0.zip`, and no `bbb` archive. The daemon exists only as prereleases.

Each script now checks whether the release it resolved actually ships a build for this platform and, when it does not, reports that and falls back to the newest prerelease that does:

```
resolving the latest stable release
the latest stable release (v3.2.0) ships no bbb daemon build for x86_64-unknown-linux-gnu
falling back to the latest prerelease — pass --version <tag> to pin a specific release
installing v4.0.0-beta.2 (version 4.0.0-beta.2)
```

Announced, never silent. And nothing has to be undone later: the first stable release that ships daemon archives resolves and installs normally, and the fallback stops being reached.

## 2. `bbb setup` cannot run under `curl … | bash`

`bbb setup` reads answers from standard input. Under `curl … | bash` standard input *is* the pipe the script arrived on, already read to the end by bash — so setup would be handed an immediate EOF and die on its first question with "setup needs answers, and standard input ended". It now runs against `/dev/tty`, and where no terminal is attached at all the install completes and says to run `bbb setup` by hand.

## Docs

The daemon's install instructions move out of `README.md` into `docs/DAEMON.md`, which says plainly that the daemon has no stable release yet and that these commands install a prerelease — the README's "instead of the latest stable release" framing described a thing that does not exist. The extension's install guide says the same in one line.

## Tests

`tests/install/smoke-test.sh` grows two cases against its fake release server: an extension-only stable release falls back to the prerelease *and* says so, and a world where nothing anywhere has a build for this platform is an error rather than a silent no-op. 17 pass, 0 fail. The default install was also run against the real GitHub API into a throwaway directory, where it now resolves and installs `v4.0.0-beta.2`.

`shellcheck` and the `install.ps1` syntax check are not installed locally; CI's `install-scripts` job covers both.

## Known follow-up, not in this PR

The published `v4.0.0-beta.2` binary predates the `setup` and `service` subcommands (`bbb --help` there lists only `serve`, `init`, `doctor`, `rescan`), so the last step of an install still fails until a `v4.0.0-beta.3` is cut from `main`.