### PR TITLE
test: stop assuming two bookmarks share a creation second

### DIFF
--- a/crates/bbb/tests/ordering.rs
+++ b/crates/bbb/tests/ordering.rs
@@ -1123,12 +1123,24 @@ async fn losing_the_order_file_falls_back_to_migration_order_and_is_repaired_by_
     harness.post("/api/v1/rescan", &json!({})).await;
 
     // The migration order: folders first, then bookmarks, each group by the
-    // creation timestamp they carry and then by identity. These four were made
-    // within the same second, so identity decides throughout.
+    // creation timestamp they carry and then by identity. A folder carries no
+    // timestamp, so identity alone decides there. A bookmark does, and two
+    // bookmarks created back to back still land either side of a second
+    // boundary often enough to matter on a loaded CI runner — so the expected
+    // order is built from the timestamps the vault actually recorded, not from
+    // an assumption that they match. `dateAdded` is those same timestamps in
+    // epoch milliseconds, which orders identically to the RFC 3339 text the
+    // migration key compares, and a bookmark without one sorts last.
+    let tree = harness.tree().await;
+    let created_at =
+        |id: &str| find_node(&tree, id).expect("the bookmark is in the tree")["dateAdded"].as_i64();
     let mut folders = [dev.clone(), ops.clone()];
     folders.sort();
     let mut bookmarks = [one.clone(), two.clone()];
-    bookmarks.sort();
+    bookmarks.sort_by_key(|id| {
+        let created = created_at(id);
+        (created.is_none(), created, id.clone())
+    });
     let migration: Vec<String> = folders.iter().chain(bookmarks.iter()).cloned().collect();
     assert_eq!(
         harness.child_ids(&root).await,


### PR DESCRIPTION
`losing_the_order_file_falls_back_to_migration_order_and_is_repaired_by_the_next_change` is the test that periodically turns `rust-windows` red for reasons unrelated to the diff under test. It failed the release run for `v4.0.0-beta.3`:

```
test losing_the_order_file_falls_back_to_migration_order_and_is_repaired_by_the_next_change ... FAILED
crates\bbb\tests\ordering.rs:1133:
assertion `left == right` failed: the arrangement is lost, and what is left is deterministic
```

## Why it flakes

The test built its expected migration order like this:

```rust
// These four were made within the same second, so identity decides throughout.
let mut bookmarks = [one.clone(), two.clone()];
bookmarks.sort();
```

But `migration_key` (`crates/bbb-vault-core/src/scan.rs:833`) sorts a bookmark on its **creation timestamp first**, and only then on identity. Two creates issued back to back usually do share a second — and on a loaded Windows runner, sometimes do not. When they straddle a boundary the real order is timestamp order and the expectation is identity order, and the two disagree exactly when the ids happen to be the other way round.

Nothing about the assertion's intent was wrong; the shortcut it took to express it was.

## The fix

The expected order now comes from the timestamps the vault actually recorded, read back via `dateAdded` — the same instants in epoch milliseconds, which order identically to the RFC 3339 text the migration key compares — with a missing one sorting last, as the key does.

Folders keep sorting on identity alone. That one is not an assumption: `migration_key` gives every folder `created = None`, so identity is genuinely all there is.

## Verification

`cargo test -p bbb --test ordering` — 43 pass. `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --check` clean.