### PR TITLE
First-run UX, working create actions, and import/export that works everywhere

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,21 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <style>
+      html,
+      body {
+        margin: 0;
+        background: oklch(0.145 0 0);
+        color-scheme: dark;
+      }
+
+      html.light,
+      html.light body {
+        background: white;
+        color-scheme: light;
+      }
+    </style>
+    <script src="/theme-bootstrap.js"></script>
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">

--- a/public/theme-bootstrap.js
+++ b/public/theme-bootstrap.js
@@ -1,0 +1,25 @@
+;(() => {
+  const root = document.documentElement
+
+  try {
+    const savedTheme = localStorage.getItem("theme")
+    const theme =
+      savedTheme === "light" ||
+      savedTheme === "dark" ||
+      savedTheme === "system"
+        ? savedTheme
+        : "dark"
+    const resolvedTheme =
+      theme === "system"
+        ? window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light"
+        : theme
+
+    root.classList.add(resolvedTheme)
+    root.style.colorScheme = resolvedTheme
+  } catch {
+    root.classList.add("dark")
+    root.style.colorScheme = "dark"
+  }
+})()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,12 +66,9 @@ const OnboardingWizard = React.lazy(() =>
 )
 
 export function App() {
-  const {
-    showOnboarding,
-    setShowOnboarding,
-    onboardingChecked,
-    screenshotMode,
-  } = useAppBootstrap()
+  const { onboardingChecked, screenshotMode } = useAppBootstrap()
+  const onboardingOpen = useUIStore((s) => s.onboardingOpen)
+  const closeOnboarding = useUIStore((s) => s.closeOnboarding)
   const openSettings = useUIStore((s) => s.openSettings)
   const isLoading = useBookmarkStore((s) => s.isLoading)
   const status = useBookmarkStore((s) => s.status)
@@ -292,8 +289,8 @@ export function App() {
         <BookmarkEditorDialog />
         <DeleteConfirmDialog />
         <BookmarkOrganizerSheet />
-        {showOnboarding && onboardingChecked && (
-          <OnboardingWizard onComplete={() => setShowOnboarding(false)} />
+        {onboardingOpen && onboardingChecked && (
+          <OnboardingWizard onComplete={closeOnboarding} />
         )}
       </React.Suspense>
     </ScrollArea>

--- a/src/browser/daemon/index.ts
+++ b/src/browser/daemon/index.ts
@@ -26,6 +26,9 @@ function daemonAdapterFor(client: DaemonClient): BrowserAdapter {
       // ignores the index. Ordering is a separate capability below.
       reorder: false,
       setChildOrder: true,
+      // The vault root is a real, addressable folder — `create()` accepts
+      // it as a parent with no special-casing on the server.
+      rootIsCreatable: true,
     },
   }
 }

--- a/src/browser/detect.ts
+++ b/src/browser/detect.ts
@@ -101,8 +101,9 @@ function createStandaloneAdapter(): BrowserAdapter {
       // Ordering here travels on `move(id, {index})`; there is no
       // whole-folder ordering endpoint to replace it.
       setChildOrder: false,
-      // The standalone store's top-level rows have no synthetic root — its
-      // "root" is just "no parentId" — so creating there is always valid.
+      // `getTree()` wraps the stored rows in a synthetic root
+      // (`STANDALONE_ROOT_ID`) that `create()` accepts as a parent and maps
+      // back to "no parentId", so `tree[0]` really is a creatable folder here.
       rootIsCreatable: true,
     },
   }

--- a/src/browser/detect.ts
+++ b/src/browser/detect.ts
@@ -64,6 +64,9 @@ function createChromeAdapter(): BrowserAdapter {
       // Ordering here travels on `move(id, {index})`; there is no
       // whole-folder ordering endpoint to replace it.
       setChildOrder: false,
+      // Chrome rejects parentId "0" ("Can't modify the root bookmark
+      // folders"); a real child folder (e.g. the Bookmarks Bar) is required.
+      rootIsCreatable: false,
     },
   }
 }
@@ -80,6 +83,8 @@ function createFirefoxAdapter(): BrowserAdapter {
       // Ordering here travels on `move(id, {index})`; there is no
       // whole-folder ordering endpoint to replace it.
       setChildOrder: false,
+      // Same WebExtensions bookmarks API as Chrome, same synthetic root.
+      rootIsCreatable: false,
     },
   }
 }
@@ -96,6 +101,9 @@ function createStandaloneAdapter(): BrowserAdapter {
       // Ordering here travels on `move(id, {index})`; there is no
       // whole-folder ordering endpoint to replace it.
       setChildOrder: false,
+      // The standalone store's top-level rows have no synthetic root — its
+      // "root" is just "no parentId" — so creating there is always valid.
+      rootIsCreatable: true,
     },
   }
 }

--- a/src/browser/import-export/netscape-parser.test.ts
+++ b/src/browser/import-export/netscape-parser.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest"
+import type { BookmarkNode } from "../types"
+import { deriveBookmarkTitle, parseNetscapeBookmarks } from "./netscape-parser"
+
+function wrap(body: string): string {
+  return `<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+${body}
+</DL><p>`
+}
+
+function flatten(nodes: BookmarkNode[]): string[] {
+  return nodes.flatMap((node) => [
+    node.url ? `${node.title} -> ${node.url}` : `[${node.title}]`,
+    ...flatten(node.children ?? []),
+  ])
+}
+
+describe("parseNetscapeBookmarks", () => {
+  it("parses a Chrome-shaped export, including nested folders", () => {
+    const html =
+      wrap(`    <DT><H3 ADD_DATE="1700000000" PERSONAL_TOOLBAR_FOLDER="true">Bookmarks bar</H3>
+    <DL><p>
+        <DT><A HREF="https://a.com" ADD_DATE="1700000002">A</A>
+        <DT><H3>Sub</H3>
+        <DL><p>
+            <DT><A HREF="https://b.com">B</A>
+        </DL><p>
+        <DT><A HREF="https://c.com">C</A>
+    </DL><p>
+    <DT><H3>Other bookmarks</H3>
+    <DL><p>
+        <DT><A HREF="https://d.com">D</A>
+    </DL><p>`)
+
+    expect(flatten(parseNetscapeBookmarks(html)[0].children ?? [])).toEqual([
+      "[Bookmarks bar]",
+      "A -> https://a.com",
+      "[Sub]",
+      "B -> https://b.com",
+      "C -> https://c.com",
+      "[Other bookmarks]",
+      "D -> https://d.com",
+    ])
+  })
+
+  it("gives an untitled bookmark a title derived from its host", () => {
+    const html = wrap(`    <DT><A HREF="https://news.example.com/path"></A>`)
+
+    const [bookmark] = parseNetscapeBookmarks(html)[0].children ?? []
+    expect(bookmark.title).toBe("news.example.com")
+  })
+
+  it("gives an untitled folder a placeholder title", () => {
+    const html = wrap(`    <DT><H3></H3>
+    <DL><p>
+        <DT><A HREF="https://a.com">A</A>
+    </DL><p>`)
+
+    const [folder] = parseNetscapeBookmarks(html)[0].children ?? []
+    expect(folder.title).toBe("Untitled Folder")
+  })
+
+  it("drops anchors with no usable HREF instead of emitting an empty url", () => {
+    const html = wrap(`    <DT><A>Broken</A>
+    <DT><A HREF="">Also broken</A>
+    <DT><A HREF="https://ok.com">Fine</A>`)
+
+    expect(flatten(parseNetscapeBookmarks(html)[0].children ?? [])).toEqual([
+      "Fine -> https://ok.com",
+    ])
+  })
+
+  it("ignores separators", () => {
+    const html = wrap(`    <DT><A HREF="https://a.com">A</A>
+    <HR>
+    <DT><A HREF="https://b.com">B</A>`)
+
+    expect(parseNetscapeBookmarks(html)[0].children).toHaveLength(2)
+  })
+
+  it("returns an empty tree for a file with no list at all", () => {
+    expect(parseNetscapeBookmarks("<html><body>nope</body></html>")).toEqual([])
+  })
+})
+
+describe("deriveBookmarkTitle", () => {
+  it("keeps a real title", () => {
+    expect(deriveBookmarkTitle("  Hello  ", "https://a.com")).toBe("Hello")
+  })
+
+  it("falls back to the host", () => {
+    expect(deriveBookmarkTitle("", "https://a.com/x")).toBe("a.com")
+  })
+
+  it("falls back to the raw value for a hostless URL", () => {
+    expect(deriveBookmarkTitle("", "javascript:alert(1)")).toBe(
+      "javascript:alert(1)"
+    )
+  })
+
+  it("falls back to a placeholder when there is nothing to work with", () => {
+    expect(deriveBookmarkTitle("", "  ")).toBe("Untitled")
+  })
+})

--- a/src/browser/import-export/netscape-parser.ts
+++ b/src/browser/import-export/netscape-parser.ts
@@ -1,8 +1,39 @@
 import type { BookmarkNode } from "../types"
 
+const UNTITLED_BOOKMARK = "Untitled"
+const UNTITLED_FOLDER = "Untitled Folder"
+
+/**
+ * Derives a non-empty title for a bookmark.
+ *
+ * Browsers happily export an untitled bookmark as `<A HREF="..."></A>`, and
+ * some back-ends refuse to store one — the daemon answers `422 a title cannot
+ * be empty`. Rather than dropping the entry (or letting one bad row abort the
+ * whole import), fall back to something the user can recognise: the host, then
+ * the raw URL, then a generic label for URLs with no host at all
+ * (`javascript:`, `data:`, `place:`).
+ */
+export function deriveBookmarkTitle(title: string, url: string): string {
+  const trimmed = title.trim()
+  if (trimmed) return trimmed
+
+  try {
+    const host = new URL(url).hostname
+    if (host) return host
+  } catch {
+    // Not parseable as an absolute URL — fall through to the raw value.
+  }
+
+  return url.trim() || UNTITLED_BOOKMARK
+}
+
 /**
  * Parses the standard Netscape Bookmark HTML format exported by browsers.
  * Structure: nested <DL> lists with <DT> entries for folders and links.
+ *
+ * Entries that cannot become a valid bookmark are dropped here rather than
+ * passed on: an `<A>` with no `HREF` (or an empty one) is not a bookmark any
+ * adapter can store, and `<HR>` separators carry nothing at all.
  */
 export function parseNetscapeBookmarks(html: string): BookmarkNode[] {
   const parser = new DOMParser()
@@ -33,11 +64,14 @@ export function parseNetscapeBookmarks(html: string): BookmarkNode[] {
 
       if (anchor) {
         // It's a bookmark link
+        const url = anchor.getAttribute("HREF")?.trim()
+        if (!url) continue
+
         const id = generateId()
         nodes.push({
           id,
-          title: anchor.textContent?.trim() ?? "",
-          url: anchor.getAttribute("HREF") ?? "",
+          title: deriveBookmarkTitle(anchor.textContent ?? "", url),
+          url,
           parentId,
           dateAdded: parseAddDate(anchor.getAttribute("ADD_DATE")),
           children: undefined,
@@ -55,7 +89,7 @@ export function parseNetscapeBookmarks(html: string): BookmarkNode[] {
 
         nodes.push({
           id,
-          title: heading.textContent?.trim() ?? "",
+          title: heading.textContent?.trim() || UNTITLED_FOLDER,
           parentId,
           dateAdded: parseAddDate(heading.getAttribute("ADD_DATE")),
           children: folderChildren,

--- a/src/browser/standalone/__tests__/bookmarks.test.ts
+++ b/src/browser/standalone/__tests__/bookmarks.test.ts
@@ -108,4 +108,18 @@ describe("StandaloneBookmarkAdapter.getTree seeding in dev", () => {
     const secondTree = await adapter.getTree()
     expect(secondTree).toEqual(tree)
   })
+
+  it("does not stack the seed's own invisible root under the synthetic one", async () => {
+    const adapter = new StandaloneBookmarkAdapter()
+
+    const [root] = await adapter.getTree()
+
+    expect(root.id).toBe(STANDALONE_ROOT_ID)
+    // The seed is a browser export whose first node is a titleless root. If it
+    // were stored as a row, everything would sit one nameless folder deep.
+    const children = root.children ?? []
+    expect(children.length).toBeGreaterThan(0)
+    expect(children.every((child) => child.title !== "")).toBe(true)
+    expect(children.map((child) => child.title)).toContain("Bookmarks Bar")
+  })
 })

--- a/src/browser/standalone/__tests__/bookmarks.test.ts
+++ b/src/browser/standalone/__tests__/bookmarks.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { installFakeIndexedDB } from "@/browser/__tests__/fake-indexeddb"
-import { StandaloneBookmarkAdapter } from "../bookmarks"
+import { StandaloneBookmarkAdapter, STANDALONE_ROOT_ID } from "../bookmarks"
 
 // Throws if the dev seed is ever imported outside of DEV; returns the real
 // seed data when DEV is on, so the same mock also backs the write-path test
@@ -35,7 +35,65 @@ describe("StandaloneBookmarkAdapter.getTree in production", () => {
     const adapter = new StandaloneBookmarkAdapter()
     const tree = await adapter.getTree()
 
-    expect(tree).toEqual([])
+    expect(tree).toEqual([{ id: STANDALONE_ROOT_ID, title: "", children: [] }])
+  })
+})
+
+describe("StandaloneBookmarkAdapter synthetic root", () => {
+  it("creates at the synthetic root as a top-level row, not underneath one", async () => {
+    import.meta.env.DEV = false
+    const adapter = new StandaloneBookmarkAdapter()
+
+    const created = await adapter.create({
+      parentId: STANDALONE_ROOT_ID,
+      title: "Top level",
+    })
+
+    // The synthetic root is never persisted, so the row must come back with
+    // no parent at all — otherwise it would nest under a phantom id.
+    expect(created.parentId).toBeUndefined()
+
+    const [root] = await adapter.getTree()
+    expect(root.id).toBe(STANDALONE_ROOT_ID)
+    expect(root.children?.map((c) => c.title)).toEqual(["Top level"])
+  })
+
+  it("keeps `tree[0]` a folder even when the first stored row is a bookmark", async () => {
+    import.meta.env.DEV = false
+    const adapter = new StandaloneBookmarkAdapter()
+
+    await adapter.create({
+      parentId: STANDALONE_ROOT_ID,
+      title: "A bookmark",
+      url: "https://example.com",
+    })
+
+    const [root] = await adapter.getTree()
+    expect(root.url).toBeUndefined()
+    expect(root.children).toHaveLength(1)
+  })
+
+  it("moves a nested row back out to the top level through the synthetic root", async () => {
+    import.meta.env.DEV = false
+    const adapter = new StandaloneBookmarkAdapter()
+
+    const folder = await adapter.create({
+      parentId: STANDALONE_ROOT_ID,
+      title: "Folder",
+    })
+    const child = await adapter.create({
+      parentId: folder.id,
+      title: "Child",
+      url: "https://example.com",
+    })
+
+    await adapter.move(child.id, { parentId: STANDALONE_ROOT_ID, index: 0 })
+
+    const [root] = await adapter.getTree()
+    expect(root.children?.map((c) => c.title).sort()).toEqual([
+      "Child",
+      "Folder",
+    ])
   })
 })
 

--- a/src/browser/standalone/bookmarks.ts
+++ b/src/browser/standalone/bookmarks.ts
@@ -204,7 +204,27 @@ export class StandaloneBookmarkAdapter implements BookmarkAdapter {
     }
 
     const { default: seedData } = await import("@/dev/seed-bookmarks.json")
-    const flat = flattenNodes(seedData as BookmarkNode[])
+
+    // The seed file is a browser export, so it carries its own invisible root
+    // (`"0"`, titleless). Storing that as a row would put it *below* this
+    // adapter's synthetic root and leave the dashboard showing one nameless
+    // folder containing everything. Promote its children to the top level and
+    // cut the parent link that would otherwise orphan them.
+    const seedRoots = seedData as BookmarkNode[]
+    const wrapper =
+      seedRoots.length === 1 &&
+      seedRoots[0].url === undefined &&
+      seedRoots[0].title === ""
+        ? seedRoots[0]
+        : null
+    const topLevel = wrapper
+      ? (wrapper.children ?? []).map((node) => ({
+          ...node,
+          parentId: undefined,
+        }))
+      : seedRoots
+
+    const flat = flattenNodes(topLevel)
     const tx = db.transaction(STORE_NAME, "readwrite")
     const store = tx.objectStore(STORE_NAME)
     for (const bookmark of flat) {

--- a/src/browser/standalone/bookmarks.ts
+++ b/src/browser/standalone/bookmarks.ts
@@ -28,6 +28,28 @@ interface StoredBookmark {
   index?: number
 }
 
+/**
+ * Id of the synthetic root this adapter wraps its top-level rows in.
+ *
+ * Stored rows have no root: a top-level bookmark is simply one with no
+ * `parentId`. Every other adapter hands the app a single root node, and the
+ * shared helpers assume it — `tree[0]` is "the root". Returning a bare forest
+ * here meant `tree[0]` was whichever row happened to sort first, so creating
+ * "at the root" wrote into that row: inside an arbitrary folder, or worse,
+ * underneath a *bookmark*, where it rendered nowhere at all.
+ *
+ * The root is synthetic, never persisted — `toStoredParentId` maps it back to
+ * "no parent" on the way in — so this needs no migration. The id is a fixed
+ * sentinel rather than `""` because the UI treats a falsy id as "nowhere to
+ * create", and a UUID could in principle collide with a real row.
+ */
+export const STANDALONE_ROOT_ID = "standalone-root"
+
+/** Translates the synthetic root back into how a top-level row is stored. */
+function toStoredParentId(parentId: string | undefined): string | undefined {
+  return parentId === STANDALONE_ROOT_ID ? undefined : parentId
+}
+
 function generateId(): string {
   return crypto.randomUUID()
 }
@@ -76,7 +98,9 @@ function buildTree(bookmarks: StoredBookmark[]): BookmarkNode[] {
   }
   roots.sort((a, b) => (indexMap.get(a.id) ?? 0) - (indexMap.get(b.id) ?? 0))
 
-  return roots
+  // Titleless, like Chrome's `"0"`, so the root-folder picker skips it and
+  // offers only real folders.
+  return [{ id: STANDALONE_ROOT_ID, title: "", children: roots }]
 }
 
 async function putBookmark(
@@ -217,14 +241,13 @@ export class StandaloneBookmarkAdapter implements BookmarkAdapter {
   }): Promise<BookmarkNode> {
     const db = await this.getDB()
     const all = await getAllBookmarks(db)
-    const siblingCount = all.filter(
-      (b) => b.parentId === bookmark.parentId
-    ).length
+    const parentId = toStoredParentId(bookmark.parentId)
+    const siblingCount = all.filter((b) => b.parentId === parentId).length
     const stored: StoredBookmark = {
       id: generateId(),
       title: bookmark.title,
       url: bookmark.url,
-      parentId: bookmark.parentId,
+      parentId,
       dateAdded: Date.now(),
       index: siblingCount,
     }
@@ -289,7 +312,10 @@ export class StandaloneBookmarkAdapter implements BookmarkAdapter {
     if (!bookmark) throw new Error(`Bookmark not found: ${id}`)
 
     const oldParentId = bookmark.parentId
-    const newParentId = destination.parentId ?? oldParentId
+    const newParentId =
+      destination.parentId === undefined
+        ? oldParentId
+        : toStoredParentId(destination.parentId)
     const newIndex = destination.index
 
     // Remove from old parent and re-index siblings

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -149,6 +149,21 @@ export interface AdapterCapabilities {
    * `BookmarkAdapter.setChildOrder()`. True only in daemon mode.
    */
   setChildOrder: boolean
+  /**
+   * Whether `tree[0].id` — the root the tree returns when no folder has been
+   * pinned as the dashboard root — is itself a real, creatable folder.
+   *
+   * True for daemon and standalone: their `tree[0]` is an addressable vault
+   * root that `create()` accepts as a parent. False for Chrome and Firefox,
+   * whose `tree[0]` is each browser's synthetic invisible root (id `"0"`,
+   * see `src/features/settings/import-target.ts`) — both browsers reject it
+   * as a create parent, so a real child folder must be picked first.
+   *
+   * Optional, not required like the other capabilities: adapters (and test
+   * mocks) that predate this field are treated as `false`, the conservative
+   * default that matches their actual (browser) behavior.
+   */
+  rootIsCreatable?: boolean
 }
 
 export interface BrowserAdapter {

--- a/src/components/theme-bootstrap.test.ts
+++ b/src/components/theme-bootstrap.test.ts
@@ -1,0 +1,80 @@
+/// <reference types="node" />
+
+import { readFileSync } from "node:fs"
+import { runInNewContext } from "node:vm"
+import { describe, expect, it } from "vitest"
+
+const bootstrapSource = readFileSync(
+  new URL("../../public/theme-bootstrap.js", import.meta.url),
+  "utf8"
+)
+
+function runBootstrap(options?: {
+  storedTheme?: string | null
+  systemDark?: boolean
+  storageThrows?: boolean
+}) {
+  const classes = new Set<string>()
+  const style: { colorScheme?: string } = {}
+
+  runInNewContext(bootstrapSource, {
+    document: {
+      documentElement: {
+        classList: {
+          add: (className: string) => classes.add(className),
+        },
+        style,
+      },
+    },
+    localStorage: {
+      getItem: () => {
+        if (options?.storageThrows) {
+          throw new Error("Storage unavailable")
+        }
+
+        return options?.storedTheme ?? null
+      },
+    },
+    window: {
+      matchMedia: () => ({ matches: options?.systemDark ?? false }),
+    },
+  })
+
+  return { classes, colorScheme: style.colorScheme }
+}
+
+describe("theme bootstrap", () => {
+  it("defaults to dark before the app loads", () => {
+    const result = runBootstrap()
+
+    expect(result.classes).toEqual(new Set(["dark"]))
+    expect(result.colorScheme).toBe("dark")
+  })
+
+  it("applies a saved light theme", () => {
+    const result = runBootstrap({ storedTheme: "light" })
+
+    expect(result.classes).toEqual(new Set(["light"]))
+    expect(result.colorScheme).toBe("light")
+  })
+
+  it.each([
+    [true, "dark"],
+    [false, "light"],
+  ] as const)(
+    "resolves a system theme when dark is %s",
+    (systemDark, theme) => {
+      const result = runBootstrap({ storedTheme: "system", systemDark })
+
+      expect(result.classes).toEqual(new Set([theme]))
+      expect(result.colorScheme).toBe(theme)
+    }
+  )
+
+  it("falls back to dark when storage is unavailable", () => {
+    const result = runBootstrap({ storageThrows: true })
+
+    expect(result.classes).toEqual(new Set(["dark"]))
+    expect(result.colorScheme).toBe("dark")
+  })
+})

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -112,6 +112,7 @@ export function ThemeProvider({
 
       root.classList.remove("light", "dark")
       root.classList.add(resolvedTheme)
+      root.style.colorScheme = resolvedTheme
 
       if (restoreTransitions) {
         restoreTransitions()

--- a/src/features/bookmark-editor/bookmark-editor-dialog.tsx
+++ b/src/features/bookmark-editor/bookmark-editor-dialog.tsx
@@ -46,6 +46,11 @@ export function BookmarkEditorDialog() {
     closeEditor()
   }
 
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    void handleSave()
+  }
+
   return (
     <Dialog
       open={editingBookmark !== null}
@@ -54,48 +59,57 @@ export function BookmarkEditorDialog() {
       }}
     >
       <DialogContent>
-        <DialogHeader>
-          <DialogTitle>
-            {isFolder ? "Edit Folder" : "Edit Bookmark"}
-          </DialogTitle>
-        </DialogHeader>
+        {/* A real form with a submit button, so Enter saves. Browsers only
+            submit implicitly when a form has one field, which left the
+            two-field bookmark case ignoring the key entirely. */}
+        <form
+          className="flex flex-col gap-4"
+          noValidate
+          onSubmit={handleSubmit}
+        >
+          <DialogHeader>
+            <DialogTitle>
+              {isFolder ? "Edit Folder" : "Edit Bookmark"}
+            </DialogTitle>
+          </DialogHeader>
 
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="bookmark-title">Title</Label>
-            <Input
-              id="bookmark-title"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="Bookmark title"
-            />
-          </div>
-
-          {!isFolder && (
+          <div className="flex flex-col gap-4">
             <div className="flex flex-col gap-2">
-              <Label htmlFor="bookmark-url">URL</Label>
+              <Label htmlFor="bookmark-title">Title</Label>
               <Input
-                id="bookmark-url"
-                value={url}
-                onChange={(e) => setUrl(e.target.value)}
-                placeholder="https://..."
+                id="bookmark-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Bookmark title"
               />
             </div>
-          )}
 
-          {mutationError && (
-            <p role="alert" className="text-sm text-destructive">
-              {mutationError}
-            </p>
-          )}
-        </div>
+            {!isFolder && (
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="bookmark-url">URL</Label>
+                <Input
+                  id="bookmark-url"
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                  placeholder="https://..."
+                />
+              </div>
+            )}
 
-        <DialogFooter>
-          <Button variant="outline" onClick={closeEditor}>
-            Cancel
-          </Button>
-          <Button onClick={handleSave}>Save</Button>
-        </DialogFooter>
+            {mutationError && (
+              <p role="alert" className="text-sm text-destructive">
+                {mutationError}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={closeEditor}>
+              Cancel
+            </Button>
+            <Button type="submit">Save</Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   )

--- a/src/features/bookmark-grid/__tests__/bookmark-grid-empty.test.tsx
+++ b/src/features/bookmark-grid/__tests__/bookmark-grid-empty.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+import { usePreferencesStore } from "@/stores/preferences-store"
+import { useUIStore } from "@/stores/ui-store"
+import { BookmarkGrid } from "../bookmark-grid"
+
+function mount(
+  rootFolderId: string | null,
+  tree = [{ id: "0", title: "", children: [] }],
+  rootIsCreatable = false
+) {
+  useBookmarkStore.setState({
+    adapter: {
+      bookmarks: {} as never,
+      storage: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+      favicon: { getUrl: () => "", isAvailable: () => false },
+      capabilities: {
+        openInManager: false,
+        move: true,
+        reorder: true,
+        setChildOrder: false,
+        rootIsCreatable,
+      },
+    },
+    tree,
+    rootFolder: rootFolderId ? tree[0] : null,
+    rootFolderId,
+    isLoading: false,
+  })
+  usePreferencesStore.setState({
+    experimentalCardDrag: false,
+    nestedFolders: false,
+    folderOrder: [],
+    cardLayouts: {},
+    maxColumns: 4,
+    containerMode: "fluid",
+  })
+  return render(<BookmarkGrid />)
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe("BookmarkGrid empty state", () => {
+  it("offers create actions when a root folder is selected", () => {
+    mount("0")
+
+    expect(screen.getByRole("button", { name: /New Folder/ })).toBeTruthy()
+    expect(screen.getByRole("button", { name: /New Bookmark/ })).toBeTruthy()
+  })
+
+  it("offers only an explanation and Open Settings when no root folder is selected", () => {
+    mount(null)
+
+    expect(screen.queryByRole("button", { name: /New Folder/ })).toBeNull()
+    expect(screen.queryByRole("button", { name: /New Bookmark/ })).toBeNull()
+    expect(screen.getByRole("button", { name: "Open Settings" })).toBeTruthy()
+  })
+
+  it("opens Settings from the no-root explanation", () => {
+    const openSettings = vi.fn()
+    useUIStore.setState({ openSettings })
+    mount(null)
+
+    screen.getByRole("button", { name: "Open Settings" }).click()
+
+    expect(openSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it("offers create actions against the vault root when no root folder is chosen but the adapter allows it (daemon, standalone)", () => {
+    mount(null, [{ id: "vault-root", title: "Vault", children: [] }], true)
+
+    expect(screen.getByRole("button", { name: /New Folder/ })).toBeTruthy()
+    expect(screen.getByRole("button", { name: /New Bookmark/ })).toBeTruthy()
+    expect(screen.queryByRole("button", { name: "Open Settings" })).toBeNull()
+  })
+})

--- a/src/features/bookmark-grid/bookmark-grid-empty.tsx
+++ b/src/features/bookmark-grid/bookmark-grid-empty.tsx
@@ -1,0 +1,80 @@
+import * as React from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Bookmark02Icon, Folder01Icon } from "@hugeicons/core-free-icons"
+import { Button } from "@/components/ui/button"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+import { useUIStore } from "@/stores/ui-store"
+import { resolveEffectiveCreateParentId } from "@/features/root-folder-select"
+
+export function BookmarkGridEmpty() {
+  const rootFolderId = useBookmarkStore((s) => s.rootFolderId)
+  const tree = useBookmarkStore((s) => s.tree)
+  const adapter = useBookmarkStore((s) => s.adapter)
+  const openCreateItem = useUIStore((s) => s.openCreateItem)
+  const openBookmarkOrganizer = useUIStore((s) => s.openBookmarkOrganizer)
+  const openSettings = useUIStore((s) => s.openSettings)
+
+  const createParentId = React.useMemo(
+    () =>
+      rootFolderId ??
+      resolveEffectiveCreateParentId(
+        tree,
+        adapter?.capabilities.rootIsCreatable ?? false
+      ),
+    [rootFolderId, tree, adapter]
+  )
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center gap-3 rounded-lg border border-dashed border-border/70 p-12 text-center">
+      <h2 className="font-medium text-foreground">No bookmarks yet</h2>
+
+      {createParentId ? (
+        <>
+          <p className="text-sm text-muted-foreground">
+            Create a folder or bookmark to get started.
+          </p>
+          <div className="mt-2 flex flex-wrap items-center justify-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                openCreateItem({ type: "folder", parentId: createParentId })
+              }
+            >
+              <HugeiconsIcon icon={Folder01Icon} size={14} />
+              New Folder
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                openCreateItem({ type: "bookmark", parentId: createParentId })
+              }
+            >
+              <HugeiconsIcon icon={Bookmark02Icon} size={14} />
+              New Bookmark
+            </Button>
+            <Button variant="ghost" size="sm" onClick={openBookmarkOrganizer}>
+              Open Bookmark Organizer
+            </Button>
+          </div>
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-muted-foreground">
+            No folder is selected as the dashboard's root yet. Choose a root
+            folder in Settings to see it here.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-2"
+            onClick={openSettings}
+          >
+            Open Settings
+          </Button>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/features/bookmark-grid/bookmark-grid-empty.tsx
+++ b/src/features/bookmark-grid/bookmark-grid-empty.tsx
@@ -4,7 +4,7 @@ import { Bookmark02Icon, Folder01Icon } from "@hugeicons/core-free-icons"
 import { Button } from "@/components/ui/button"
 import { useBookmarkStore } from "@/stores/bookmark-store"
 import { useUIStore } from "@/stores/ui-store"
-import { resolveEffectiveCreateParentId } from "@/features/root-folder-select"
+import { resolveCreateParentId } from "@/features/root-folder-select"
 
 export function BookmarkGridEmpty() {
   const rootFolderId = useBookmarkStore((s) => s.rootFolderId)
@@ -16,9 +16,9 @@ export function BookmarkGridEmpty() {
 
   const createParentId = React.useMemo(
     () =>
-      rootFolderId ??
-      resolveEffectiveCreateParentId(
+      resolveCreateParentId(
         tree,
+        rootFolderId,
         adapter?.capabilities.rootIsCreatable ?? false
       ),
     [rootFolderId, tree, adapter]

--- a/src/features/bookmark-grid/bookmark-grid.tsx
+++ b/src/features/bookmark-grid/bookmark-grid.tsx
@@ -6,6 +6,7 @@ import { useSortableFolder, DropIndicator } from "@/features/dnd"
 import type { BookmarkNode } from "@/browser"
 import { cn } from "@/lib/utils"
 import { getVisibleFolders } from "./folder-collection"
+import { BookmarkGridEmpty } from "./bookmark-grid-empty"
 
 function getColumnCountForWidth(): number {
   const w = window.innerWidth
@@ -171,11 +172,7 @@ export function BookmarkGrid() {
   }
 
   if (folders.length === 0) {
-    return (
-      <div className="flex items-center justify-center p-12 text-muted-foreground">
-        No bookmark folders found.
-      </div>
-    )
+    return <BookmarkGridEmpty />
   }
 
   return (

--- a/src/features/bookmark-organizer/__tests__/bookmark-organizer-create-dialog.test.tsx
+++ b/src/features/bookmark-organizer/__tests__/bookmark-organizer-create-dialog.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, it, vi } from "vitest"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { BookmarkOrganizerCreateDialog } from "../bookmark-organizer-create-dialog"
 import { useBookmarkStore } from "@/stores/bookmark-store"
@@ -17,6 +23,10 @@ describe("BookmarkOrganizerCreateDialog", () => {
       createBookmark: vi.fn().mockResolvedValue(undefined),
     })
   })
+
+  // This project has no global auto-cleanup, so a rendered dialog otherwise
+  // survives into the next test and duplicates every query.
+  afterEach(cleanup)
 
   it("creates a folder from the organizer create dialog", async () => {
     const user = userEvent.setup()
@@ -83,5 +93,80 @@ describe("BookmarkOrganizerCreateDialog", () => {
       expect(closeCreateItem).toHaveBeenCalledTimes(1)
     })
     expect(screen.queryByRole("dialog")).toBeNull()
+  })
+
+  it("disables Create until the folder has a title", async () => {
+    const user = userEvent.setup()
+    useUIStore.setState({
+      creatingItem: { type: "folder", parentId: "parent-1" },
+    })
+
+    render(<BookmarkOrganizerCreateDialog />)
+
+    const create = await screen.findByRole("button", { name: "Create" })
+    expect((create as HTMLButtonElement).disabled).toBe(true)
+
+    await user.type(screen.getByLabelText("Title"), "Something")
+    expect((create as HTMLButtonElement).disabled).toBe(false)
+
+    await user.clear(screen.getByLabelText("Title"))
+    expect((create as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it("keeps Create disabled for a bookmark until both fields are filled", async () => {
+    const user = userEvent.setup()
+    useUIStore.setState({
+      creatingItem: { type: "bookmark", parentId: "parent-2" },
+    })
+
+    render(<BookmarkOrganizerCreateDialog />)
+
+    const create = await screen.findByRole("button", { name: "Create" })
+
+    await user.type(screen.getByLabelText("Title"), "Title only")
+    expect((create as HTMLButtonElement).disabled).toBe(true)
+
+    await user.type(screen.getByLabelText("URL"), "https://example.com")
+    expect((create as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it("explains an empty field once the user has left it", async () => {
+    const user = userEvent.setup()
+    useUIStore.setState({
+      creatingItem: { type: "folder", parentId: "parent-1" },
+    })
+
+    render(<BookmarkOrganizerCreateDialog />)
+    await screen.findByLabelText("Title")
+
+    expect(screen.queryByText("A title is required.")).toBeNull()
+
+    await user.click(screen.getByLabelText("Title"))
+    await user.tab()
+
+    expect(screen.getByText("A title is required.")).toBeTruthy()
+  })
+
+  it("submits a bookmark on Enter, which the two-field form used to ignore", async () => {
+    const user = userEvent.setup()
+    const createBookmark = vi.fn().mockResolvedValue(undefined)
+    useBookmarkStore.setState({ createBookmark })
+    useUIStore.setState({
+      creatingItem: { type: "bookmark", parentId: "parent-2" },
+      closeCreateItem: vi.fn(),
+    })
+
+    render(<BookmarkOrganizerCreateDialog />)
+
+    await user.type(await screen.findByLabelText("Title"), "Typed")
+    await user.type(screen.getByLabelText("URL"), "https://example.com{Enter}")
+
+    await waitFor(() => {
+      expect(createBookmark).toHaveBeenCalledWith(
+        "parent-2",
+        "Typed",
+        "https://example.com"
+      )
+    })
   })
 })

--- a/src/features/bookmark-organizer/__tests__/bookmark-organizer-sheet.test.tsx
+++ b/src/features/bookmark-organizer/__tests__/bookmark-organizer-sheet.test.tsx
@@ -100,6 +100,35 @@ describe("BookmarkOrganizerSheet", () => {
     expect(screen.queryByRole("alert")).toBeNull()
   })
 
+  it("disables the header New menu when no root folder is selected", () => {
+    render(<BookmarkOrganizerSheet />)
+
+    const newButton = screen.getByRole("button", { name: "New" })
+    expect(newButton.hasAttribute("disabled")).toBe(true)
+  })
+
+  it("enables the header New menu once a root folder is selected", () => {
+    useBookmarkStore.setState({ rootFolderId: "root-1" })
+    render(<BookmarkOrganizerSheet />)
+
+    const newButton = screen.getByRole("button", { name: "New" })
+    expect(newButton.hasAttribute("disabled")).toBe(false)
+  })
+
+  it("enables the header New menu with no root folder selected when the adapter allows creating at the vault root (daemon, standalone)", () => {
+    useBookmarkStore.setState((state) => ({
+      tree: [{ id: "vault-root", title: "Vault", children: [] }],
+      adapter: state.adapter && {
+        ...state.adapter,
+        capabilities: { ...state.adapter.capabilities, rootIsCreatable: true },
+      },
+    }))
+    render(<BookmarkOrganizerSheet />)
+
+    const newButton = screen.getByRole("button", { name: "New" })
+    expect(newButton.hasAttribute("disabled")).toBe(false)
+  })
+
   it("clears a stale message when the sheet is closed and reopened", () => {
     render(<BookmarkOrganizerSheet />)
 

--- a/src/features/bookmark-organizer/__tests__/bookmark-organizer-sheet.test.tsx
+++ b/src/features/bookmark-organizer/__tests__/bookmark-organizer-sheet.test.tsx
@@ -108,11 +108,31 @@ describe("BookmarkOrganizerSheet", () => {
   })
 
   it("enables the header New menu once a root folder is selected", () => {
-    useBookmarkStore.setState({ rootFolderId: "root-1" })
+    useBookmarkStore.setState({
+      // The folder has to actually be in the tree: a saved id that no longer
+      // resolves is treated as absent, so that writes never target a folder
+      // that was deleted elsewhere.
+      tree: [
+        {
+          id: "0",
+          title: "",
+          children: [{ id: "root-1", title: "Root", children: [] }],
+        },
+      ],
+      rootFolderId: "root-1",
+    })
     render(<BookmarkOrganizerSheet />)
 
     const newButton = screen.getByRole("button", { name: "New" })
     expect(newButton.hasAttribute("disabled")).toBe(false)
+  })
+
+  it("disables the header New menu when the saved root folder no longer exists", () => {
+    useBookmarkStore.setState({ tree: [], rootFolderId: "deleted-folder" })
+    render(<BookmarkOrganizerSheet />)
+
+    const newButton = screen.getByRole("button", { name: "New" })
+    expect(newButton.hasAttribute("disabled")).toBe(true)
   })
 
   it("enables the header New menu with no root folder selected when the adapter allows creating at the vault root (daemon, standalone)", () => {

--- a/src/features/bookmark-organizer/__tests__/bookmark-organizer-tree-empty.test.tsx
+++ b/src/features/bookmark-organizer/__tests__/bookmark-organizer-tree-empty.test.tsx
@@ -172,4 +172,42 @@ describe("BookmarkOrganizerTree empty state", () => {
     expect(screen.getByRole("button", { name: /New Folder/ })).toBeTruthy()
     expect(screen.getByRole("button", { name: /New Bookmark/ })).toBeTruthy()
   })
+
+  it("falls back to the tree root when the saved root folder has been deleted", async () => {
+    const getSubTree = vi
+      .fn()
+      .mockResolvedValue([{ id: "0", title: "", children: [] }])
+    useBookmarkStore.setState({
+      tree: [{ id: "0", title: "", children: [] }],
+      // The store resolves a saved id that no longer exists to `null`, which
+      // is what tells the organizer to stop asking for that subtree.
+      rootFolderId: "deleted-folder",
+      rootFolder: null,
+      isLoading: false,
+      adapter: adapterWithChildren(getSubTree),
+      init: vi.fn(),
+      setRootFolderId: vi.fn(),
+      refresh: vi.fn(),
+      createBookmark: vi.fn(),
+      updateBookmark: vi.fn(),
+      deleteBookmark: vi.fn(),
+      deleteFolder: vi.fn(),
+      createFolder: vi.fn(),
+      moveBookmark: vi.fn(),
+    })
+
+    render(
+      <BookmarkOrganizerTree
+        rootFolderId="deleted-folder"
+        showBookmarks
+        treeRef={{ current: null }}
+      />
+    )
+
+    // Asking for the deleted folder would render a permanently empty tree.
+    await waitFor(() => {
+      expect(getSubTree).toHaveBeenCalled()
+    })
+    expect(getSubTree).not.toHaveBeenCalledWith("deleted-folder")
+  })
 })

--- a/src/features/bookmark-organizer/__tests__/bookmark-organizer-tree-empty.test.tsx
+++ b/src/features/bookmark-organizer/__tests__/bookmark-organizer-tree-empty.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import { BookmarkOrganizerTree } from "../bookmark-organizer-tree"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+import { useUIStore } from "@/stores/ui-store"
+import type { BookmarkNode } from "@/browser"
+
+function adapterWithChildren(
+  getSubTree: (id: string) => Promise<BookmarkNode[]>,
+  rootIsCreatable = false
+) {
+  return {
+    bookmarks: {
+      getTree: vi.fn().mockResolvedValue([]),
+      getSubTree,
+      create: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      removeTree: vi.fn(),
+      move: vi.fn(),
+      onChanged: vi.fn(() => () => {}),
+      onCreated: vi.fn(() => () => {}),
+      onRemoved: vi.fn(() => () => {}),
+      onMoved: vi.fn(() => () => {}),
+      openInManager: vi.fn(),
+    },
+    storage: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+    favicon: { getUrl: vi.fn(() => ""), isAvailable: vi.fn(() => false) },
+    capabilities: {
+      openInManager: true,
+      move: true,
+      reorder: true,
+      setChildOrder: false,
+      rootIsCreatable,
+    },
+  }
+}
+
+describe("BookmarkOrganizerTree empty state", () => {
+  beforeEach(() => {
+    useUIStore.setState({
+      settingsOpen: false,
+      bookmarkOrganizerOpen: true,
+      editingBookmark: null,
+      deletingItem: null,
+      creatingItem: null,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("offers create actions when the selected root folder has no children", async () => {
+    const getSubTree = vi
+      .fn()
+      .mockResolvedValue([
+        { id: "root-1", title: "Bookmarks Bar", children: [] },
+      ])
+    useBookmarkStore.setState({
+      tree: [{ id: "root-1", title: "Bookmarks Bar", children: [] }],
+      rootFolderId: "root-1",
+      isLoading: false,
+      adapter: adapterWithChildren(getSubTree),
+      rootFolder: { id: "root-1", title: "Bookmarks Bar", children: [] },
+      init: vi.fn(),
+      setRootFolderId: vi.fn(),
+      refresh: vi.fn(),
+      createBookmark: vi.fn(),
+      updateBookmark: vi.fn(),
+      deleteBookmark: vi.fn(),
+      deleteFolder: vi.fn(),
+      createFolder: vi.fn(),
+      moveBookmark: vi.fn(),
+    })
+
+    render(
+      <BookmarkOrganizerTree
+        rootFolderId="root-1"
+        showBookmarks
+        treeRef={{ current: null }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "This folder is empty. Create a folder or bookmark to get started."
+        )
+      ).toBeTruthy()
+    })
+    expect(screen.getByRole("button", { name: /New Folder/ })).toBeTruthy()
+    expect(screen.getByRole("button", { name: /New Bookmark/ })).toBeTruthy()
+  })
+
+  it("shows explanatory copy with no create actions when no root folder is selected", async () => {
+    const getSubTree = vi.fn().mockResolvedValue([])
+    useBookmarkStore.setState({
+      tree: [],
+      rootFolderId: null,
+      isLoading: false,
+      adapter: adapterWithChildren(getSubTree),
+      rootFolder: null,
+      init: vi.fn(),
+      setRootFolderId: vi.fn(),
+      refresh: vi.fn(),
+      createBookmark: vi.fn(),
+      updateBookmark: vi.fn(),
+      deleteBookmark: vi.fn(),
+      deleteFolder: vi.fn(),
+      createFolder: vi.fn(),
+      moveBookmark: vi.fn(),
+    })
+
+    render(
+      <BookmarkOrganizerTree
+        rootFolderId={null}
+        showBookmarks
+        treeRef={{ current: null }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Choose a root folder above before creating items here."
+        )
+      ).toBeTruthy()
+    })
+    expect(screen.queryByRole("button", { name: /New Folder/ })).toBeNull()
+    expect(screen.queryByRole("button", { name: /New Bookmark/ })).toBeNull()
+  })
+
+  it("offers create actions against the vault root when no root folder is selected but the adapter allows it (daemon, standalone)", async () => {
+    const getSubTree = vi
+      .fn()
+      .mockResolvedValue([{ id: "vault-root", title: "Vault", children: [] }])
+    useBookmarkStore.setState({
+      tree: [{ id: "vault-root", title: "Vault", children: [] }],
+      rootFolderId: null,
+      isLoading: false,
+      adapter: adapterWithChildren(getSubTree, true),
+      rootFolder: null,
+      init: vi.fn(),
+      setRootFolderId: vi.fn(),
+      refresh: vi.fn(),
+      createBookmark: vi.fn(),
+      updateBookmark: vi.fn(),
+      deleteBookmark: vi.fn(),
+      deleteFolder: vi.fn(),
+      createFolder: vi.fn(),
+      moveBookmark: vi.fn(),
+    })
+
+    render(
+      <BookmarkOrganizerTree
+        rootFolderId={null}
+        showBookmarks
+        treeRef={{ current: null }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "This folder is empty. Create a folder or bookmark to get started."
+        )
+      ).toBeTruthy()
+    })
+    expect(screen.getByRole("button", { name: /New Folder/ })).toBeTruthy()
+    expect(screen.getByRole("button", { name: /New Bookmark/ })).toBeTruthy()
+  })
+})

--- a/src/features/bookmark-organizer/bookmark-organizer-create-dialog.tsx
+++ b/src/features/bookmark-organizer/bookmark-organizer-create-dialog.tsx
@@ -22,10 +22,15 @@ export function BookmarkOrganizerCreateDialog() {
 
   const [title, setTitle] = React.useState("")
   const [url, setUrl] = React.useState("")
+  // Empty fields only complain once the user has actually been there and left
+  // them blank — a dialog that opens already shouting is worse than one that
+  // waits to be asked.
+  const [touched, setTouched] = React.useState({ title: false, url: false })
 
   React.useEffect(() => {
     setTitle("")
     setUrl("")
+    setTouched({ title: false, url: false })
     clearMutationError()
   }, [creatingItem, clearMutationError])
 
@@ -36,29 +41,15 @@ export function BookmarkOrganizerCreateDialog() {
   const isBookmark = creatingItem.type === "bookmark"
   const dialogTitle = isBookmark ? "New Bookmark" : "New Folder"
 
+  const normalizedTitle = title.trim()
+  const normalizedUrl = url.trim()
+  const canCreate =
+    normalizedTitle !== "" && (!isBookmark || normalizedUrl !== "")
+
   const handleCreate = async () => {
-    if (!creatingItem) {
-      return
-    }
-
-    const titleInput = document.getElementById(
-      "bookmark-organizer-create-title"
-    ) as HTMLInputElement | null
-    const urlInput = document.getElementById(
-      "bookmark-organizer-create-url"
-    ) as HTMLInputElement | null
-
-    const normalizedTitle = titleInput?.value.trim() ?? ""
-    const normalizedUrl = urlInput?.value.trim() ?? ""
-
-    if (!normalizedTitle) {
-      return
-    }
+    if (!canCreate) return
 
     if (isBookmark) {
-      if (!normalizedUrl) {
-        return
-      }
       await createBookmark(
         creatingItem.parentId,
         normalizedTitle,
@@ -76,6 +67,9 @@ export function BookmarkOrganizerCreateDialog() {
     event.preventDefault()
     void handleCreate()
   }
+
+  const titleError = touched.title && normalizedTitle === ""
+  const urlError = isBookmark && touched.url && normalizedUrl === ""
 
   return (
     <Dialog
@@ -103,8 +97,23 @@ export function BookmarkOrganizerCreateDialog() {
                 id="bookmark-organizer-create-title"
                 autoFocus
                 value={title}
+                aria-invalid={titleError || undefined}
+                aria-describedby={
+                  titleError
+                    ? "bookmark-organizer-create-title-error"
+                    : undefined
+                }
                 onChange={(event) => setTitle(event.target.value)}
+                onBlur={() => setTouched((t) => ({ ...t, title: true }))}
               />
+              {titleError && (
+                <p
+                  id="bookmark-organizer-create-title-error"
+                  className="text-xs text-destructive"
+                >
+                  A title is required.
+                </p>
+              )}
             </div>
 
             {isBookmark && (
@@ -114,8 +123,21 @@ export function BookmarkOrganizerCreateDialog() {
                   id="bookmark-organizer-create-url"
                   type="text"
                   value={url}
+                  aria-invalid={urlError || undefined}
+                  aria-describedby={
+                    urlError ? "bookmark-organizer-create-url-error" : undefined
+                  }
                   onChange={(event) => setUrl(event.target.value)}
+                  onBlur={() => setTouched((t) => ({ ...t, url: true }))}
                 />
+                {urlError && (
+                  <p
+                    id="bookmark-organizer-create-url-error"
+                    className="text-xs text-destructive"
+                  >
+                    A URL is required.
+                  </p>
+                )}
               </div>
             )}
 
@@ -130,7 +152,21 @@ export function BookmarkOrganizerCreateDialog() {
             <Button type="button" variant="outline" onClick={closeCreateItem}>
               Cancel
             </Button>
-            <Button type="button" onClick={() => void handleCreate()}>
+            {/* `type="submit"` is what makes Enter work in the two-field
+                bookmark form; browsers only submit implicitly when a form has
+                a single field, so folders used to accept Enter and bookmarks
+                silently did not. */}
+            <Button
+              type="submit"
+              disabled={!canCreate}
+              title={
+                canCreate
+                  ? undefined
+                  : isBookmark
+                    ? "Enter a title and a URL first."
+                    : "Enter a title first."
+              }
+            >
               Create
             </Button>
           </DialogFooter>

--- a/src/features/bookmark-organizer/bookmark-organizer-sheet.tsx
+++ b/src/features/bookmark-organizer/bookmark-organizer-sheet.tsx
@@ -30,7 +30,7 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area"
 import {
   RootFolderSelect,
-  resolveEffectiveCreateParentId,
+  resolveCreateParentId,
 } from "@/features/root-folder-select"
 import { BookmarkOrganizerCreateDialog } from "./bookmark-organizer-create-dialog"
 import {
@@ -51,12 +51,11 @@ export function BookmarkOrganizerSheet() {
   const mutationError = useBookmarkStore((s) => s.mutationError)
   const clearMutationError = useBookmarkStore((s) => s.clearMutationError)
 
-  const createParentId =
-    rootFolderId ??
-    resolveEffectiveCreateParentId(
-      tree,
-      adapter?.capabilities.rootIsCreatable ?? false
-    )
+  const createParentId = resolveCreateParentId(
+    tree,
+    rootFolderId,
+    adapter?.capabilities.rootIsCreatable ?? false
+  )
 
   const creatingItem = useUIStore((s) => s.creatingItem)
   const openCreateItem = useUIStore((s) => s.openCreateItem)

--- a/src/features/bookmark-organizer/bookmark-organizer-sheet.tsx
+++ b/src/features/bookmark-organizer/bookmark-organizer-sheet.tsx
@@ -1,7 +1,24 @@
 import * as React from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Add01Icon,
+  Bookmark02Icon,
+  Folder01Icon,
+} from "@hugeicons/core-free-icons"
 import { Button } from "@/components/ui/button"
 import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip"
 
 import {
   Sheet,
@@ -11,7 +28,10 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { RootFolderSelect } from "@/features/root-folder-select"
+import {
+  RootFolderSelect,
+  resolveEffectiveCreateParentId,
+} from "@/features/root-folder-select"
 import { BookmarkOrganizerCreateDialog } from "./bookmark-organizer-create-dialog"
 import {
   BookmarkOrganizerTree,
@@ -26,10 +46,20 @@ export function BookmarkOrganizerSheet() {
   const closeBookmarkOrganizer = useUIStore((s) => s.closeBookmarkOrganizer)
   const rootFolderId = useBookmarkStore((s) => s.rootFolderId)
   const setRootFolderId = useBookmarkStore((s) => s.setRootFolderId)
+  const tree = useBookmarkStore((s) => s.tree)
+  const adapter = useBookmarkStore((s) => s.adapter)
   const mutationError = useBookmarkStore((s) => s.mutationError)
   const clearMutationError = useBookmarkStore((s) => s.clearMutationError)
 
+  const createParentId =
+    rootFolderId ??
+    resolveEffectiveCreateParentId(
+      tree,
+      adapter?.capabilities.rootIsCreatable ?? false
+    )
+
   const creatingItem = useUIStore((s) => s.creatingItem)
+  const openCreateItem = useUIStore((s) => s.openCreateItem)
 
   const foldersOnly = usePreferencesStore(
     (s) => s.isFoldersOnlyEnabledInTreeEditor
@@ -104,6 +134,70 @@ export function BookmarkOrganizerSheet() {
                   </Label>
                 </div>
                 <div className="ml-auto flex items-center gap-2">
+                  {createParentId ? (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger
+                        render={
+                          <Button type="button" variant="outline" size="xs">
+                            <HugeiconsIcon icon={Add01Icon} size={14} />
+                            New
+                          </Button>
+                        }
+                      />
+                      <DropdownMenuContent side="bottom" align="end">
+                        <DropdownMenuItem
+                          onClick={() =>
+                            openCreateItem({
+                              type: "folder",
+                              parentId: createParentId,
+                            })
+                          }
+                        >
+                          <HugeiconsIcon
+                            icon={Folder01Icon}
+                            size={14}
+                            className="text-primary"
+                          />
+                          New Folder
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() =>
+                            openCreateItem({
+                              type: "bookmark",
+                              parentId: createParentId,
+                            })
+                          }
+                        >
+                          <HugeiconsIcon
+                            icon={Bookmark02Icon}
+                            size={14}
+                            className="text-muted-foreground"
+                          />
+                          New Bookmark
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  ) : (
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="xs"
+                            disabled
+                            aria-disabled="true"
+                          >
+                            <HugeiconsIcon icon={Add01Icon} size={14} />
+                            New
+                          </Button>
+                        }
+                      />
+                      <TooltipContent side="bottom">
+                        Choose a root folder above before creating items here.
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
                   <Button
                     type="button"
                     variant="outline"

--- a/src/features/bookmark-organizer/bookmark-organizer-tree.tsx
+++ b/src/features/bookmark-organizer/bookmark-organizer-tree.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/ui/button"
 import type { BookmarkAdapter, BookmarkNode } from "@/browser"
 import { useBookmarkStore } from "@/stores/bookmark-store"
 import { useUIStore } from "@/stores/ui-store"
-import { resolveEffectiveCreateParentId } from "@/features/root-folder-select"
+import { resolveCreateParentId } from "@/features/root-folder-select"
 import {
   loadOrganizerChildren,
   loadOrganizerItem,
@@ -415,12 +415,11 @@ export function BookmarkOrganizerTree({
     adapter.capabilities.setChildOrder &&
     adapter.bookmarks.setChildOrder !== undefined
 
-  const createParentId =
-    rootFolderId ??
-    resolveEffectiveCreateParentId(
-      tree,
-      adapter.capabilities.rootIsCreatable ?? false
-    )
+  const createParentId = resolveCreateParentId(
+    tree,
+    rootFolderId,
+    adapter.capabilities.rootIsCreatable ?? false
+  )
 
   return (
     <BookmarkOrganizerTreeImpl

--- a/src/features/bookmark-organizer/bookmark-organizer-tree.tsx
+++ b/src/features/bookmark-organizer/bookmark-organizer-tree.tsx
@@ -7,9 +7,13 @@ import {
   isOrderedDragTarget,
   propMemoizationFeature,
 } from "@headless-tree/core"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Bookmark02Icon, Folder01Icon } from "@hugeicons/core-free-icons"
+import { Button } from "@/components/ui/button"
 import type { BookmarkAdapter, BookmarkNode } from "@/browser"
 import { useBookmarkStore } from "@/stores/bookmark-store"
 import { useUIStore } from "@/stores/ui-store"
+import { resolveEffectiveCreateParentId } from "@/features/root-folder-select"
 import {
   loadOrganizerChildren,
   loadOrganizerItem,
@@ -75,6 +79,54 @@ function BookmarkOrganizerUnavailable() {
   )
 }
 
+function BookmarkOrganizerEmpty({
+  createParentId,
+}: {
+  createParentId: string | null
+}) {
+  const openCreateItem = useUIStore((s) => s.openCreateItem)
+
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-border/70 px-3 py-8 text-center">
+      <p className="text-sm text-muted-foreground">
+        {createParentId
+          ? "This folder is empty. Create a folder or bookmark to get started."
+          : "Choose a root folder above before creating items here."}
+      </p>
+      {createParentId && (
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              openCreateItem({ type: "folder", parentId: createParentId })
+            }
+          >
+            <HugeiconsIcon
+              icon={Folder01Icon}
+              size={14}
+              className="text-primary"
+            />
+            New Folder
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              openCreateItem({ type: "bookmark", parentId: createParentId })
+            }
+          >
+            <HugeiconsIcon icon={Bookmark02Icon} size={14} />
+            New Bookmark
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
 export type BookmarkOrganizerTreeHandle = {
   expandAll: () => void
   collapseAll: () => void
@@ -85,6 +137,8 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
   BookmarkOrganizerTreeHandle,
   {
     effectiveRootId: string | null
+    /** Where a "New Folder"/"New Bookmark" action should create, or `null` when nothing valid is selected — drives the empty state's copy and actions. */
+    createParentId: string | null
     /** Whether the effective root folder's own child order is frozen. */
     rootOrderReadOnly?: boolean
     bookmarks: Pick<BookmarkAdapter, "getSubTree">
@@ -96,6 +150,7 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
 >(function BookmarkOrganizerTreeImpl(
   {
     effectiveRootId,
+    createParentId,
     rootOrderReadOnly,
     bookmarks,
     showBookmarks,
@@ -259,6 +314,16 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
     tree.getState().dnd?.draggedItems?.map((i) => i.getId()) ?? []
   )
 
+  const visibleItems = items.filter((item) => {
+    if (item.getId() === BOOKMARK_ORGANIZER_ROOT_ID) return false
+    if (!showBookmarks && !item.isFolder()) return false
+    return true
+  })
+
+  if (visibleItems.length === 0) {
+    return <BookmarkOrganizerEmpty createParentId={createParentId} />
+  }
+
   return (
     <div
       {...tree.getContainerProps("Bookmark Organizer")}
@@ -268,61 +333,54 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
         className="h-0.5 rounded-full bg-primary"
         style={tree.getDragLineStyle()}
       />
-      {tree
-        .getItems()
-        .filter((item) => {
-          if (item.getId() === BOOKMARK_ORGANIZER_ROOT_ID) return false
-          if (!showBookmarks && !item.isFolder()) return false
-          return true
-        })
-        .map((item) => (
-          <BookmarkOrganizerRow
-            key={item.getId()}
-            item={item}
-            isDragging={draggedItemIds.has(item.getId())}
-            dragEnabled={dragEnabled}
-            onCreateItem={(type) => {
-              openCreateItem({ type, parentId: item.getId() })
-            }}
-            onRename={async (treeItem) => {
-              const itemData = treeItem.getItemData()
-              if (!itemData) {
-                return
-              }
+      {visibleItems.map((item) => (
+        <BookmarkOrganizerRow
+          key={item.getId()}
+          item={item}
+          isDragging={draggedItemIds.has(item.getId())}
+          dragEnabled={dragEnabled}
+          onCreateItem={(type) => {
+            openCreateItem({ type, parentId: item.getId() })
+          }}
+          onRename={async (treeItem) => {
+            const itemData = treeItem.getItemData()
+            if (!itemData) {
+              return
+            }
 
-              if (itemData.kind === "folder") {
-                openEditor({
-                  id: itemData.id,
-                  title: itemData.title,
-                  parentId: itemData.parentId ?? undefined,
-                  children: [],
-                })
-                return
-              }
-
-              const [bookmark] = await bookmarks.getSubTree(treeItem.getId())
-              if (!bookmark) {
-                return
-              }
-
-              openEditor(toBookmarkNode(bookmark))
-            }}
-            onDelete={(treeItem) => {
-              const itemData = treeItem.getItemData()
-              if (!itemData) {
-                return
-              }
-
-              openDeleteConfirm({
+            if (itemData.kind === "folder") {
+              openEditor({
                 id: itemData.id,
                 title: itemData.title,
-                type: itemData.kind,
-                childCount:
-                  itemData.kind === "folder" ? itemData.childCount : undefined,
+                parentId: itemData.parentId ?? undefined,
+                children: [],
               })
-            }}
-          />
-        ))}
+              return
+            }
+
+            const [bookmark] = await bookmarks.getSubTree(treeItem.getId())
+            if (!bookmark) {
+              return
+            }
+
+            openEditor(toBookmarkNode(bookmark))
+          }}
+          onDelete={(treeItem) => {
+            const itemData = treeItem.getItemData()
+            if (!itemData) {
+              return
+            }
+
+            openDeleteConfirm({
+              id: itemData.id,
+              title: itemData.title,
+              type: itemData.kind,
+              childCount:
+                itemData.kind === "folder" ? itemData.childCount : undefined,
+            })
+          }}
+        />
+      ))}
     </div>
   )
 })
@@ -357,10 +415,18 @@ export function BookmarkOrganizerTree({
     adapter.capabilities.setChildOrder &&
     adapter.bookmarks.setChildOrder !== undefined
 
+  const createParentId =
+    rootFolderId ??
+    resolveEffectiveCreateParentId(
+      tree,
+      adapter.capabilities.rootIsCreatable ?? false
+    )
+
   return (
     <BookmarkOrganizerTreeImpl
       ref={treeRef}
       effectiveRootId={effectiveRootId}
+      createParentId={createParentId}
       // Gated, not just unused: an extension build's synthetic root keeps the
       // exact static item data it always had, rather than relying on
       // `canDropOnTarget` to ignore a flag it should never have been handed.

--- a/src/features/bookmark-organizer/bookmark-organizer-tree.tsx
+++ b/src/features/bookmark-organizer/bookmark-organizer-tree.tsx
@@ -397,15 +397,13 @@ export function BookmarkOrganizerTree({
   const adapter = useBookmarkStore((s) => s.adapter)
   const tree = useBookmarkStore((s) => s.tree)
   const rootFolder = useBookmarkStore((s) => s.rootFolder)
-  const effectiveRootId = rootFolderId ?? tree[0]?.id ?? null
-  // The store already holds this node — `rootFolder` is its own resolution of
-  // `rootFolderId`, and an unpinned root is `tree[0]`. Reading the flag from
-  // here rather than re-fetching matters because the daemon answers
-  // `GET /bookmarks/:id` for a root with the *entire* recursive subtree, so a
-  // refetch would move the whole vault across the wire to learn one boolean.
-  const effectiveRootNode = [rootFolder, tree[0]].find(
-    (node) => node?.id === effectiveRootId
-  )
+  // `rootFolder` is the store's own resolution of `rootFolderId` against the
+  // tree, so going through it means a saved id whose folder has since been
+  // deleted falls back to the tree root instead of asking for a subtree that
+  // no longer exists and rendering an empty organizer — which is what the
+  // create actions and import already do.
+  const effectiveRootNode = rootFolder ?? tree[0]
+  const effectiveRootId = effectiveRootNode?.id ?? null
 
   if (!adapter) {
     return <BookmarkOrganizerUnavailable />

--- a/src/features/onboarding/__tests__/onboarding-wizard.test.tsx
+++ b/src/features/onboarding/__tests__/onboarding-wizard.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { installFakeIndexedDB } from "@/browser/__tests__/fake-indexeddb"
+import { ThemeProvider } from "@/components/theme-provider"
+import { usePreferencesStore } from "@/stores/preferences-store"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+import { OnboardingWizard } from "../onboarding-wizard"
+
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+installFakeIndexedDB()
+
+function renderWizard(onComplete = vi.fn()) {
+  return {
+    onComplete,
+    ...render(
+      <ThemeProvider>
+        <OnboardingWizard onComplete={onComplete} />
+      </ThemeProvider>
+    ),
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+  )
+  vi.stubGlobal("ResizeObserver", StubResizeObserver)
+
+  usePreferencesStore.setState({
+    adapterMode: "browser",
+    setAdapterMode: vi.fn(),
+    adapter: {
+      bookmarks: {
+        getTree: vi.fn().mockResolvedValue([]),
+        getSubTree: vi.fn().mockResolvedValue([]),
+        create: vi.fn(),
+        update: vi.fn(),
+        remove: vi.fn(),
+        removeTree: vi.fn(),
+        move: vi.fn(),
+        onChanged: vi.fn(() => () => {}),
+        onCreated: vi.fn(() => () => {}),
+        onRemoved: vi.fn(() => () => {}),
+        onMoved: vi.fn(() => () => {}),
+        openInManager: vi.fn(),
+      },
+      storage: {
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn().mockResolvedValue(undefined),
+        remove: vi.fn().mockResolvedValue(undefined),
+      },
+      favicon: { getUrl: vi.fn(), isAvailable: vi.fn(() => false) },
+      capabilities: {
+        openInManager: false,
+        move: true,
+        reorder: true,
+        setChildOrder: false,
+      },
+    },
+  })
+
+  useBookmarkStore.setState({
+    tree: [],
+    rootFolderId: null,
+    mutationError: null,
+    setRootFolderId: vi.fn(),
+    createFolder: vi.fn(),
+    refresh: vi.fn().mockResolvedValue(undefined),
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  installFakeIndexedDB()
+})
+
+describe("OnboardingWizard mode step", () => {
+  it("adds a daemon setup step only when Daemon is selected", async () => {
+    const user = userEvent.setup()
+    renderWizard()
+
+    await user.click(screen.getByRole("button", { name: "Get Started" }))
+    expect(screen.getByText("Where do your bookmarks live?")).toBeTruthy()
+
+    await user.click(screen.getByRole("button", { name: /Daemon/ }))
+    await user.click(screen.getByRole("button", { name: "Next" }))
+
+    expect(screen.getByText("Set up the daemon")).toBeTruthy()
+  })
+
+  it("skips straight to the root folder step for Browser", async () => {
+    const user = userEvent.setup()
+    renderWizard()
+
+    await user.click(screen.getByRole("button", { name: "Get Started" }))
+    await user.click(screen.getByRole("button", { name: /Browser/ }))
+    await user.click(screen.getByRole("button", { name: "Next" }))
+
+    expect(screen.getByText("Choose your bookmark folder")).toBeTruthy()
+  })
+
+  it("skips straight to the root folder step for Standalone", async () => {
+    const user = userEvent.setup()
+    renderWizard()
+
+    await user.click(screen.getByRole("button", { name: "Get Started" }))
+    await user.click(
+      screen.getByRole("button", {
+        name: "Advanced: use a standalone collection stored in this browser only",
+      })
+    )
+    await user.click(screen.getByRole("button", { name: "Next" }))
+
+    expect(screen.getByText("Choose your bookmark folder")).toBeTruthy()
+  })
+
+  it("does not persist adapterMode when the wizard completes with Daemon selected but not connected", async () => {
+    const user = userEvent.setup()
+    renderWizard()
+
+    await user.click(screen.getByRole("button", { name: "Get Started" }))
+    await user.click(screen.getByRole("button", { name: /Daemon/ }))
+    await user.click(screen.getByRole("button", { name: "Skip, use defaults" }))
+
+    await waitFor(() => {
+      expect(
+        usePreferencesStore.getState().setAdapterMode
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  it("persists adapterMode for Browser on completion", async () => {
+    const user = userEvent.setup()
+    renderWizard()
+
+    await user.click(screen.getByRole("button", { name: "Get Started" }))
+    await user.click(screen.getByRole("button", { name: /Browser/ }))
+    await user.click(screen.getByRole("button", { name: "Skip, use defaults" }))
+
+    await waitFor(() => {
+      expect(
+        usePreferencesStore.getState().setAdapterMode
+      ).toHaveBeenCalledWith("browser")
+    })
+  })
+})
+
+describe("OnboardingWizard root folder step", () => {
+  it("creates a folder and selects it as the root", async () => {
+    const user = userEvent.setup()
+    const createFolder = vi.fn().mockResolvedValue({ id: "new-folder" })
+    useBookmarkStore.setState({
+      tree: [
+        {
+          id: "0",
+          title: "",
+          children: [{ id: "1", title: "Bookmarks Bar", children: [] }],
+        },
+      ],
+      createFolder,
+    })
+
+    renderWizard()
+
+    await user.click(screen.getByRole("button", { name: "Get Started" }))
+    await user.click(screen.getByRole("button", { name: /Browser/ }))
+    await user.click(screen.getByRole("button", { name: "Next" }))
+
+    expect(screen.getByText("Choose your bookmark folder")).toBeTruthy()
+
+    await user.type(
+      screen.getByLabelText("New folder name"),
+      "Personal Bookmarks"
+    )
+    await user.click(screen.getByRole("button", { name: "Create folder" }))
+
+    await waitFor(() => {
+      expect(createFolder).toHaveBeenCalledWith("1", "Personal Bookmarks")
+    })
+  })
+
+  it("hides the create-folder control when there is no valid parent", async () => {
+    const user = userEvent.setup()
+    useBookmarkStore.setState({ tree: [] })
+
+    renderWizard()
+
+    await user.click(screen.getByRole("button", { name: "Get Started" }))
+    await user.click(screen.getByRole("button", { name: /Browser/ }))
+    await user.click(screen.getByRole("button", { name: "Next" }))
+
+    expect(screen.queryByLabelText("New folder name")).toBeNull()
+  })
+})

--- a/src/features/onboarding/__tests__/onboarding-wizard.test.tsx
+++ b/src/features/onboarding/__tests__/onboarding-wizard.test.tsx
@@ -207,4 +207,54 @@ describe("OnboardingWizard root folder step", () => {
 
     expect(screen.queryByLabelText("New folder name")).toBeNull()
   })
+
+  it("starts on the Bookmarks Bar rather than Browser Root", async () => {
+    const user = userEvent.setup()
+    useBookmarkStore.setState({
+      tree: [
+        {
+          id: "0",
+          title: "",
+          children: [
+            { id: "1", title: "Bookmarks Bar", children: [] },
+            { id: "2", title: "Other Bookmarks", children: [] },
+          ],
+        },
+      ],
+      rootFolderId: null,
+    })
+
+    renderWizard()
+
+    await user.click(screen.getByRole("button", { name: "Get Started" }))
+    await user.click(screen.getByRole("button", { name: /Browser/ }))
+    await user.click(screen.getByRole("button", { name: "Next" }))
+
+    expect(screen.getByRole("combobox").textContent).toBe("Bookmarks Bar")
+  })
+
+  it("keeps an already-saved root folder when the wizard is re-opened", async () => {
+    const user = userEvent.setup()
+    useBookmarkStore.setState({
+      tree: [
+        {
+          id: "0",
+          title: "",
+          children: [
+            { id: "1", title: "Bookmarks Bar", children: [] },
+            { id: "2", title: "Other Bookmarks", children: [] },
+          ],
+        },
+      ],
+      rootFolderId: "2",
+    })
+
+    renderWizard()
+
+    await user.click(screen.getByRole("button", { name: "Get Started" }))
+    await user.click(screen.getByRole("button", { name: /Browser/ }))
+    await user.click(screen.getByRole("button", { name: "Next" }))
+
+    expect(screen.getByRole("combobox").textContent).toBe("Other Bookmarks")
+  })
 })

--- a/src/features/onboarding/onboarding-wizard.tsx
+++ b/src/features/onboarding/onboarding-wizard.tsx
@@ -13,6 +13,7 @@ import { AppearanceStep } from "./steps/appearance-step"
 import { DoneStep } from "./steps/done-step"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
+import { resolveEffectiveCreateParentId } from "@/features/root-folder-select"
 import type { AdapterMode } from "@/browser/types"
 
 type ThemeMode = "light" | "dark" | "system"
@@ -63,6 +64,28 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   React.useEffect(() => {
     setTheme("dark")
   }, [setTheme])
+
+  // Start the root-folder step on something meaningful rather than "Browser
+  // Root (all bookmarks)", which shows every bookmark the user owns. Seeded
+  // once, and only until the user touches the select — `null` is a legitimate
+  // choice there, so this cannot re-run and quietly undo it. An already-saved
+  // root wins, since re-opening the wizard from Settings shouldn't silently
+  // repoint an existing dashboard.
+  const hasSeededRootFolder = React.useRef(false)
+  const bookmarkTree = useBookmarkStore((s) => s.tree)
+  const bookmarkAdapter = useBookmarkStore((s) => s.adapter)
+  React.useEffect(() => {
+    if (hasSeededRootFolder.current || bookmarkTree.length === 0) return
+    hasSeededRootFolder.current = true
+
+    setRootFolderId(
+      useBookmarkStore.getState().rootFolderId ??
+        resolveEffectiveCreateParentId(
+          bookmarkTree,
+          bookmarkAdapter?.capabilities.rootIsCreatable ?? false
+        )
+    )
+  }, [bookmarkTree, bookmarkAdapter])
 
   const showDaemonSetupStep = SHOW_MODE_STEP && adapterMode === "daemon"
 

--- a/src/features/onboarding/onboarding-wizard.tsx
+++ b/src/features/onboarding/onboarding-wizard.tsx
@@ -6,24 +6,33 @@ import {
 } from "@/stores/preferences-store"
 import { useTheme } from "@/components/theme-provider"
 import { WelcomeStep } from "./steps/welcome-step"
+import { ModeStep } from "./steps/mode-step"
+import { DaemonSetupStep } from "./steps/daemon-setup-step"
 import { RootFolderStep } from "./steps/root-folder-step"
 import { AppearanceStep } from "./steps/appearance-step"
 import { DoneStep } from "./steps/done-step"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
+import type { AdapterMode } from "@/browser/types"
 
 type ThemeMode = "light" | "dark" | "system"
-
-const TOTAL_STEPS = 4
 
 interface OnboardingWizardProps {
   onComplete: () => void
 }
 
+// The mode step (and its conditional daemon-setup follow-up) is skipped in
+// the daemon-served build, since that build always serves its own
+// same-origin daemon adapter — there is no choice to make there.
+const SHOW_MODE_STEP = import.meta.env.VITE_BUILD_TARGET !== "daemon"
+
 export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   const [currentStep, setCurrentStep] = React.useState(0)
 
   // Local wizard state
+  const [adapterMode, setAdapterModeLocal] = React.useState<AdapterMode>(
+    usePreferencesStore.getState().adapterMode
+  )
   const [rootFolderId, setRootFolderId] = React.useState<string | null>(null)
   const [colorTheme, setColorTheme] = React.useState<ColorTheme>("default")
   const [themeMode, setThemeMode] = React.useState<ThemeMode>("dark")
@@ -31,6 +40,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   // Store actions for persisting on completion
   const setStoreRootFolderId = useBookmarkStore((s) => s.setRootFolderId)
   const setStoreColorTheme = usePreferencesStore((s) => s.setColorTheme)
+  const setStoreAdapterMode = usePreferencesStore((s) => s.setAdapterMode)
   const adapter = usePreferencesStore((s) => s.adapter)
   const { setTheme } = useTheme()
 
@@ -54,6 +64,57 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
     setTheme("dark")
   }, [setTheme])
 
+  const showDaemonSetupStep = SHOW_MODE_STEP && adapterMode === "daemon"
+
+  const steps = React.useMemo(() => {
+    const list: React.ReactNode[] = [<WelcomeStep key="welcome" />]
+    if (SHOW_MODE_STEP) {
+      list.push(
+        <ModeStep
+          key="mode"
+          value={adapterMode}
+          onChange={setAdapterModeLocal}
+        />
+      )
+    }
+    if (showDaemonSetupStep) {
+      list.push(<DaemonSetupStep key="daemon-setup" />)
+    }
+    list.push(
+      <RootFolderStep
+        key="root-folder"
+        value={rootFolderId}
+        onChange={setRootFolderId}
+      />,
+      <AppearanceStep
+        key="appearance"
+        colorTheme={colorTheme}
+        onColorThemeChange={handleColorThemeChange}
+        themeMode={themeMode}
+        onThemeModeChange={handleThemeModeChange}
+      />,
+      <DoneStep key="done" />
+    )
+    return list
+  }, [
+    adapterMode,
+    showDaemonSetupStep,
+    rootFolderId,
+    colorTheme,
+    themeMode,
+    handleColorThemeChange,
+    handleThemeModeChange,
+  ])
+
+  const TOTAL_STEPS = steps.length
+
+  // Toggling the daemon step in or out of the list can leave `currentStep`
+  // pointing past the end (or, if the user is still ahead of it, at the
+  // wrong step) — clamp it back onto the track rather than rendering blank.
+  React.useEffect(() => {
+    setCurrentStep((s) => Math.min(s, TOTAL_STEPS - 1))
+  }, [TOTAL_STEPS])
+
   const goNext = () => {
     if (currentStep < TOTAL_STEPS - 1) {
       setCurrentStep((s) => s + 1)
@@ -66,8 +127,18 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
     }
   }
 
+  const persistAdapterMode = () => {
+    // Daemon mode is only ever persisted through `connectToDaemon`'s own
+    // validate/permission/health-check flow (triggered from the daemon-setup
+    // step's connection panel), never set directly here.
+    if (adapterMode !== "daemon") {
+      setStoreAdapterMode(adapterMode)
+    }
+  }
+
   const handleComplete = async () => {
     // Persist all selections
+    persistAdapterMode()
     setStoreRootFolderId(rootFolderId)
     setStoreColorTheme(colorTheme)
     setTheme(themeMode)
@@ -79,7 +150,9 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   }
 
   const handleSkip = async () => {
-    // Preserve any root folder selection already made, use defaults for the rest
+    // Preserve any root folder and mode selection already made, use defaults
+    // for the rest
+    persistAdapterMode()
     setStoreRootFolderId(rootFolderId)
     setStoreColorTheme("default")
     setTheme("dark")
@@ -129,22 +202,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
             className="flex transition-transform duration-300 ease-in-out"
             style={{ transform: `translateX(-${currentStep * 100}%)` }}
           >
-            {[
-              <WelcomeStep key="welcome" />,
-              <RootFolderStep
-                key="root-folder"
-                value={rootFolderId}
-                onChange={setRootFolderId}
-              />,
-              <AppearanceStep
-                key="appearance"
-                colorTheme={colorTheme}
-                onColorThemeChange={handleColorThemeChange}
-                themeMode={themeMode}
-                onThemeModeChange={handleThemeModeChange}
-              />,
-              <DoneStep key="done" />,
-            ].map((step, i) => (
+            {steps.map((step, i) => (
               <div key={i} className="w-full flex-shrink-0 px-1">
                 {step}
               </div>

--- a/src/features/onboarding/steps/daemon-setup-step.tsx
+++ b/src/features/onboarding/steps/daemon-setup-step.tsx
@@ -1,0 +1,27 @@
+import { DaemonConnectionPanel } from "@/features/settings/daemon-connection-panel"
+
+export function DaemonSetupStep() {
+  return (
+    <div className="flex flex-col gap-6 py-4">
+      <div className="flex flex-col gap-2 text-center">
+        <h2 className="text-2xl font-bold tracking-tight">Set up the daemon</h2>
+        <p className="text-muted-foreground">
+          The daemon is a separate program that runs on this machine and keeps
+          your bookmark vault. If you haven't installed it yet, see the{" "}
+          <a
+            href="https://github.com/farhadeidi/bookmarks-but-better"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            project repository
+          </a>{" "}
+          for install instructions, then come back and connect below. You can
+          also skip this and connect later from Settings.
+        </p>
+      </div>
+
+      <DaemonConnectionPanel />
+    </div>
+  )
+}

--- a/src/features/onboarding/steps/mode-step.tsx
+++ b/src/features/onboarding/steps/mode-step.tsx
@@ -1,0 +1,87 @@
+import { HugeiconsIcon } from "@hugeicons/react"
+import { BrowserIcon, ComputerTerminal01Icon } from "@hugeicons/core-free-icons"
+import { cn } from "@/lib/utils"
+import { isDaemonModeSupported } from "@/browser/daemon"
+import type { AdapterMode } from "@/browser/types"
+
+interface ModeStepProps {
+  value: AdapterMode
+  onChange: (mode: AdapterMode) => void
+}
+
+export function ModeStep({ value, onChange }: ModeStepProps) {
+  const daemonSupported = isDaemonModeSupported()
+
+  return (
+    <div className="flex flex-col gap-6 py-4">
+      <div className="flex flex-col gap-2 text-center">
+        <h2 className="text-2xl font-bold tracking-tight">
+          Where do your bookmarks live?
+        </h2>
+        <p className="text-muted-foreground">
+          You can always change this later in settings.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <button
+          type="button"
+          onClick={() => onChange("browser")}
+          className={cn(
+            "flex flex-col items-start gap-2 rounded-lg border p-4 text-left transition-colors",
+            value === "browser"
+              ? "border-primary bg-accent ring-2 ring-primary"
+              : "border-border hover:bg-accent/50"
+          )}
+        >
+          <HugeiconsIcon
+            icon={BrowserIcon}
+            size={22}
+            className="text-primary"
+          />
+          <span className="font-medium">Browser</span>
+          <span className="text-xs text-muted-foreground">
+            Uses the bookmarks already in this browser and stays in sync with
+            it. No extra install.
+          </span>
+        </button>
+
+        {daemonSupported && (
+          <button
+            type="button"
+            onClick={() => onChange("daemon")}
+            className={cn(
+              "flex flex-col items-start gap-2 rounded-lg border p-4 text-left transition-colors",
+              value === "daemon"
+                ? "border-primary bg-accent ring-2 ring-primary"
+                : "border-border hover:bg-accent/50"
+            )}
+          >
+            <HugeiconsIcon
+              icon={ComputerTerminal01Icon}
+              size={22}
+              className="text-primary"
+            />
+            <span className="font-medium">Daemon</span>
+            <span className="text-xs text-muted-foreground">
+              Bookmarks live in a local <code>bbb</code> daemon vault, shared
+              across browsers and profiles on this machine. Requires installing
+              the daemon.
+            </span>
+          </button>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onChange("standalone")}
+        className={cn(
+          "text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline",
+          value === "standalone" && "font-medium text-foreground underline"
+        )}
+      >
+        Advanced: use a standalone collection stored in this browser only
+      </button>
+    </div>
+  )
+}

--- a/src/features/onboarding/steps/root-folder-step.tsx
+++ b/src/features/onboarding/steps/root-folder-step.tsx
@@ -1,4 +1,11 @@
-import { RootFolderSelect } from "@/features/root-folder-select"
+import * as React from "react"
+import {
+  RootFolderSelect,
+  resolveEffectiveCreateParentId,
+} from "@/features/root-folder-select"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useBookmarkStore } from "@/stores/bookmark-store"
 
 interface RootFolderStepProps {
   value: string | null
@@ -6,6 +13,39 @@ interface RootFolderStepProps {
 }
 
 export function RootFolderStep({ value, onChange }: RootFolderStepProps) {
+  const tree = useBookmarkStore((s) => s.tree)
+  const adapter = useBookmarkStore((s) => s.adapter)
+  const createFolder = useBookmarkStore((s) => s.createFolder)
+  const refresh = useBookmarkStore((s) => s.refresh)
+  const mutationError = useBookmarkStore((s) => s.mutationError)
+
+  const [newFolderName, setNewFolderName] = React.useState("")
+  const [isCreating, setIsCreating] = React.useState(false)
+
+  const defaultParentId = React.useMemo(
+    () =>
+      resolveEffectiveCreateParentId(
+        tree,
+        adapter?.capabilities.rootIsCreatable ?? false
+      ),
+    [tree, adapter]
+  )
+
+  const handleCreate = async () => {
+    const title = newFolderName.trim()
+    if (!title || !defaultParentId) return
+
+    setIsCreating(true)
+    const created = await createFolder(defaultParentId, title)
+    await refresh()
+    setIsCreating(false)
+
+    if (!created) return
+
+    setNewFolderName("")
+    onChange(created.id)
+  }
+
   return (
     <div className="flex flex-col gap-6 py-4">
       <div className="flex flex-col gap-2 text-center">
@@ -13,11 +53,49 @@ export function RootFolderStep({ value, onChange }: RootFolderStepProps) {
           Choose your bookmark folder
         </h2>
         <p className="text-muted-foreground">
-          Pick a folder to display on your new tab page. You can change this
-          later in settings.
+          The dashboard only shows the folders inside this one, so picking a
+          dedicated folder gives you a curated page instead of every bookmark
+          you own. You can change this later in settings.
         </p>
       </div>
+
       <RootFolderSelect value={value} onChange={onChange} />
+
+      {defaultParentId && (
+        <div className="flex flex-col gap-2 rounded-lg border border-dashed border-border/70 p-3">
+          <p className="text-xs text-muted-foreground">
+            New here? We recommend creating a dedicated folder — like{" "}
+            <span className="font-medium text-foreground">
+              Personal Bookmarks
+            </span>{" "}
+            or <span className="font-medium text-foreground">Work</span> — for
+            the bookmarks you want to always see on this page.
+          </p>
+          <div className="flex gap-2">
+            <Input
+              value={newFolderName}
+              onChange={(e) => setNewFolderName(e.target.value)}
+              placeholder="Personal Bookmarks"
+              aria-label="New folder name"
+              disabled={isCreating}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={isCreating || newFolderName.trim() === ""}
+              onClick={() => void handleCreate()}
+            >
+              {isCreating ? "Creating…" : "Create folder"}
+            </Button>
+          </div>
+          {mutationError && (
+            <p role="alert" className="text-xs text-destructive">
+              {mutationError}
+            </p>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/features/onboarding/steps/root-folder-step.tsx
+++ b/src/features/onboarding/steps/root-folder-step.tsx
@@ -84,6 +84,11 @@ export function RootFolderStep({ value, onChange }: RootFolderStepProps) {
               variant="outline"
               size="sm"
               disabled={isCreating || newFolderName.trim() === ""}
+              title={
+                newFolderName.trim() === ""
+                  ? "Name the folder first."
+                  : undefined
+              }
               onClick={() => void handleCreate()}
             >
               {isCreating ? "Creating…" : "Create folder"}

--- a/src/features/root-folder-select/default-parent.test.ts
+++ b/src/features/root-folder-select/default-parent.test.ts
@@ -117,6 +117,17 @@ describe("resolveEffectiveCreateParentId", () => {
     expect(resolveEffectiveCreateParentId([], true)).toBeNull()
     expect(resolveEffectiveCreateParentId([], false)).toBeNull()
   })
+
+  it("refuses to create under tree[0] when it is a bookmark, whatever the flag claims", () => {
+    const tree: BookmarkNode[] = [
+      { id: "b1", title: "A bookmark", url: "https://example.com" },
+      { id: "f1", title: "A folder", children: [] },
+    ]
+
+    // Creating under a bookmark is accepted by some stores and then renders
+    // nowhere, so this must never be the answer.
+    expect(resolveEffectiveCreateParentId(tree, true)).not.toBe("b1")
+  })
 })
 
 describe("resolveCreateParentId", () => {

--- a/src/features/root-folder-select/default-parent.test.ts
+++ b/src/features/root-folder-select/default-parent.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./default-parent"
 
 describe("resolveDefaultCreateParentId", () => {
-  it("returns the first child folder of the Chrome-shaped root", () => {
+  it("picks the Bookmarks Bar out of a Chrome-shaped root", () => {
     const tree: BookmarkNode[] = [
       {
         id: "0",
@@ -19,6 +19,53 @@ describe("resolveDefaultCreateParentId", () => {
     ]
 
     expect(resolveDefaultCreateParentId(tree)).toBe("1")
+  })
+
+  it("picks the Bookmarks Toolbar out of a Firefox-shaped root, not the Bookmarks Menu that comes first", () => {
+    const tree: BookmarkNode[] = [
+      {
+        id: "root________",
+        title: "",
+        children: [
+          { id: "menu________", title: "Bookmarks Menu", children: [] },
+          { id: "toolbar_____", title: "Bookmarks Toolbar", children: [] },
+          { id: "unfiled_____", title: "Other Bookmarks", children: [] },
+          { id: "mobile______", title: "Mobile Bookmarks", children: [] },
+        ],
+      },
+    ]
+
+    expect(resolveDefaultCreateParentId(tree)).toBe("toolbar_____")
+  })
+
+  it("falls back to the first child folder when no known bookmarks bar id is present", () => {
+    const tree: BookmarkNode[] = [
+      {
+        id: "root",
+        title: "",
+        children: [
+          { id: "custom-a", title: "Some Folder", children: [] },
+          { id: "custom-b", title: "Another Folder", children: [] },
+        ],
+      },
+    ]
+
+    expect(resolveDefaultCreateParentId(tree)).toBe("custom-a")
+  })
+
+  it("skips bookmarks sitting directly under the root when falling back", () => {
+    const tree: BookmarkNode[] = [
+      {
+        id: "root",
+        title: "",
+        children: [
+          { id: "b1", title: "A bookmark", url: "https://example.com" },
+          { id: "f1", title: "A folder", children: [] },
+        ],
+      },
+    ]
+
+    expect(resolveDefaultCreateParentId(tree)).toBe("f1")
   })
 
   it("returns null for an empty tree", () => {

--- a/src/features/root-folder-select/default-parent.test.ts
+++ b/src/features/root-folder-select/default-parent.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+import type { BookmarkNode } from "@/browser"
+import {
+  resolveDefaultCreateParentId,
+  resolveEffectiveCreateParentId,
+} from "./default-parent"
+
+describe("resolveDefaultCreateParentId", () => {
+  it("returns the first child folder of the Chrome-shaped root", () => {
+    const tree: BookmarkNode[] = [
+      {
+        id: "0",
+        title: "",
+        children: [
+          { id: "1", title: "Bookmarks Bar", children: [] },
+          { id: "2", title: "Other Bookmarks", children: [] },
+        ],
+      },
+    ]
+
+    expect(resolveDefaultCreateParentId(tree)).toBe("1")
+  })
+
+  it("returns null for an empty tree", () => {
+    expect(resolveDefaultCreateParentId([])).toBeNull()
+  })
+
+  it("returns null when the root has no child folders", () => {
+    const tree: BookmarkNode[] = [
+      {
+        id: "0",
+        title: "",
+        children: [
+          { id: "1", title: "A bookmark", url: "https://example.com" },
+        ],
+      },
+    ]
+
+    expect(resolveDefaultCreateParentId(tree)).toBeNull()
+  })
+
+  it("returns null when the root has no children at all", () => {
+    const tree: BookmarkNode[] = [{ id: "0", title: "", children: [] }]
+
+    expect(resolveDefaultCreateParentId(tree)).toBeNull()
+  })
+})
+
+describe("resolveEffectiveCreateParentId", () => {
+  it("uses the vault root directly when the adapter allows it (daemon, standalone)", () => {
+    const tree: BookmarkNode[] = [{ id: "root", title: "Vault", children: [] }]
+
+    expect(resolveEffectiveCreateParentId(tree, true)).toBe("root")
+  })
+
+  it("falls back to the child-folder walk when the adapter does not allow it (chrome, firefox)", () => {
+    const tree: BookmarkNode[] = [
+      {
+        id: "0",
+        title: "",
+        children: [{ id: "1", title: "Bookmarks Bar", children: [] }],
+      },
+    ]
+
+    expect(resolveEffectiveCreateParentId(tree, false)).toBe("1")
+  })
+
+  it("returns null for an empty tree regardless of the capability", () => {
+    expect(resolveEffectiveCreateParentId([], true)).toBeNull()
+    expect(resolveEffectiveCreateParentId([], false)).toBeNull()
+  })
+})

--- a/src/features/root-folder-select/default-parent.test.ts
+++ b/src/features/root-folder-select/default-parent.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import type { BookmarkNode } from "@/browser"
 import {
+  resolveCreateParentId,
   resolveDefaultCreateParentId,
   resolveEffectiveCreateParentId,
 } from "./default-parent"
@@ -115,5 +116,45 @@ describe("resolveEffectiveCreateParentId", () => {
   it("returns null for an empty tree regardless of the capability", () => {
     expect(resolveEffectiveCreateParentId([], true)).toBeNull()
     expect(resolveEffectiveCreateParentId([], false)).toBeNull()
+  })
+})
+
+describe("resolveCreateParentId", () => {
+  const tree: BookmarkNode[] = [
+    {
+      id: "0",
+      title: "",
+      children: [
+        {
+          id: "1",
+          title: "Bookmarks Bar",
+          children: [{ id: "10", title: "Work", children: [] }],
+        },
+      ],
+    },
+  ]
+
+  it("honours a root folder that still exists, at any depth", () => {
+    expect(resolveCreateParentId(tree, "10", false)).toBe("10")
+  })
+
+  it("falls back rather than writing into a root folder that is gone", () => {
+    expect(resolveCreateParentId(tree, "deleted", false)).toBe("1")
+  })
+
+  it("falls back to the vault root for daemon and standalone", () => {
+    const vault: BookmarkNode[] = [
+      { id: "vault", title: "Vault", children: [] },
+    ]
+
+    expect(resolveCreateParentId(vault, "deleted", true)).toBe("vault")
+  })
+
+  it("falls back when no root folder is set at all", () => {
+    expect(resolveCreateParentId(tree, null, false)).toBe("1")
+  })
+
+  it("returns null when there is nowhere to write", () => {
+    expect(resolveCreateParentId([], "anything", false)).toBeNull()
   })
 })

--- a/src/features/root-folder-select/default-parent.ts
+++ b/src/features/root-folder-select/default-parent.ts
@@ -62,7 +62,12 @@ export function resolveEffectiveCreateParentId(
   tree: BookmarkNode[],
   rootIsCreatable: boolean
 ): string | null {
-  if (rootIsCreatable) return tree[0]?.id ?? null
+  // The `url === undefined` guard holds the capability to its word. An adapter
+  // whose `tree[0]` is a bookmark would otherwise have everything created
+  // underneath it, where no folder-shaped view ever renders it again — silent
+  // data loss from a wrong flag rather than a loud failure.
+  const root = tree[0]
+  if (rootIsCreatable && root?.url === undefined) return root?.id ?? null
   return resolveDefaultCreateParentId(tree)
 }
 

--- a/src/features/root-folder-select/default-parent.ts
+++ b/src/features/root-folder-select/default-parent.ts
@@ -1,14 +1,32 @@
 import type { BookmarkNode } from "@/browser"
 
 /**
+ * Ids of the browser's permanent "bookmarks bar" folder, most preferred first.
+ *
+ * Both engines guarantee this folder exists in every profile and refuse to let
+ * it be renamed, moved or removed — Chrome documents "You also cannot rename,
+ * move, or remove the special 'Bookmarks Bar' and 'Other Bookmarks' folders",
+ * and Firefox raises "The bookmark root cannot be modified" for the same — so
+ * matching on the id is safe in a way that matching on a (localized) title
+ * would not be.
+ *
+ * `"1"` is Chrome's Bookmarks Bar; `"toolbar_____"` is the Firefox Places GUID
+ * for the Bookmarks Toolbar. Firefox needs naming explicitly because its root
+ * children start with the Bookmarks *Menu* (`menu________`), so "the first
+ * child folder" would silently mean a different folder there than in Chrome.
+ */
+const BOOKMARKS_BAR_IDS = ["1", "toolbar_____"]
+
+/**
  * Picks a parent folder id to create a new folder under when no root folder
  * is selected yet.
  *
- * `tree[0].id` (Chrome's invisible tree root, `"0"`) is rejected as a parent
- * by `chrome.bookmarks.create` — the same constraint documented in
- * `src/features/settings/import-target.ts` — so this returns the first real
- * child folder instead (Chrome's "Bookmarks bar", or the standalone/daemon
- * equivalent). Returns `null` when there is no such folder to create under.
+ * `tree[0].id` (Chrome's invisible tree root, `"0"`, and Firefox's
+ * `root________`) is rejected as a parent by both engines — the same
+ * constraint documented in `src/features/settings/import-target.ts` — so this
+ * returns a real child folder instead: the bookmarks bar when it can be
+ * identified, otherwise the first child folder there is. Returns `null` when
+ * there is no such folder to create under.
  */
 export function resolveDefaultCreateParentId(
   tree: BookmarkNode[]
@@ -16,10 +34,17 @@ export function resolveDefaultCreateParentId(
   const root = tree[0]
   if (!root) return null
 
-  const firstChildFolder = (root.children ?? []).find(
+  const childFolders = (root.children ?? []).filter(
     (child) => child.url === undefined
   )
-  return firstChildFolder?.id ?? null
+
+  const bookmarksBar = childFolders.find((child) =>
+    BOOKMARKS_BAR_IDS.includes(child.id)
+  )
+
+  // The fallback matters for anything that is neither Chrome nor Firefox
+  // shaped — a Chromium fork that renumbers its roots, or a test fixture.
+  return (bookmarksBar ?? childFolders[0])?.id ?? null
 }
 
 /**

--- a/src/features/root-folder-select/default-parent.ts
+++ b/src/features/root-folder-select/default-parent.ts
@@ -1,0 +1,42 @@
+import type { BookmarkNode } from "@/browser"
+
+/**
+ * Picks a parent folder id to create a new folder under when no root folder
+ * is selected yet.
+ *
+ * `tree[0].id` (Chrome's invisible tree root, `"0"`) is rejected as a parent
+ * by `chrome.bookmarks.create` — the same constraint documented in
+ * `src/features/settings/import-target.ts` — so this returns the first real
+ * child folder instead (Chrome's "Bookmarks bar", or the standalone/daemon
+ * equivalent). Returns `null` when there is no such folder to create under.
+ */
+export function resolveDefaultCreateParentId(
+  tree: BookmarkNode[]
+): string | null {
+  const root = tree[0]
+  if (!root) return null
+
+  const firstChildFolder = (root.children ?? []).find(
+    (child) => child.url === undefined
+  )
+  return firstChildFolder?.id ?? null
+}
+
+/**
+ * Resolves where to create a folder or bookmark when no root folder has been
+ * explicitly selected — the id a "New Folder" / "New Bookmark" action should
+ * target by default.
+ *
+ * When the active adapter's `tree[0]` is itself a real, creatable folder
+ * (daemon, standalone — see `AdapterCapabilities.rootIsCreatable`), that's
+ * the answer: there is nothing synthetic to walk past. Otherwise falls back
+ * to `resolveDefaultCreateParentId`'s child-folder walk, which Chrome and
+ * Firefox need.
+ */
+export function resolveEffectiveCreateParentId(
+  tree: BookmarkNode[],
+  rootIsCreatable: boolean
+): string | null {
+  if (rootIsCreatable) return tree[0]?.id ?? null
+  return resolveDefaultCreateParentId(tree)
+}

--- a/src/features/root-folder-select/default-parent.ts
+++ b/src/features/root-folder-select/default-parent.ts
@@ -65,3 +65,28 @@ export function resolveEffectiveCreateParentId(
   if (rootIsCreatable) return tree[0]?.id ?? null
   return resolveDefaultCreateParentId(tree)
 }
+
+function containsNode(nodes: BookmarkNode[], id: string): boolean {
+  return nodes.some(
+    (node) => node.id === id || containsNode(node.children ?? [], id)
+  )
+}
+
+/**
+ * Resolves where a create — or an import — should write, honouring the
+ * dashboard root when there is one.
+ *
+ * The saved root id is verified against the tree rather than trusted. It is
+ * persisted separately from the bookmarks themselves, so a folder deleted in
+ * the browser (or in the vault, by another client) leaves the id behind
+ * pointing at nothing; using it would send every write to a parent that does
+ * not exist and fail the lot. Falling back is strictly better than failing.
+ */
+export function resolveCreateParentId(
+  tree: BookmarkNode[],
+  rootFolderId: string | null,
+  rootIsCreatable: boolean
+): string | null {
+  if (rootFolderId && containsNode(tree, rootFolderId)) return rootFolderId
+  return resolveEffectiveCreateParentId(tree, rootIsCreatable)
+}

--- a/src/features/root-folder-select/index.ts
+++ b/src/features/root-folder-select/index.ts
@@ -4,4 +4,5 @@ export type { RootFolderOption } from "./root-folder-options"
 export {
   resolveDefaultCreateParentId,
   resolveEffectiveCreateParentId,
+  resolveCreateParentId,
 } from "./default-parent"

--- a/src/features/root-folder-select/index.ts
+++ b/src/features/root-folder-select/index.ts
@@ -1,3 +1,7 @@
 export { RootFolderSelect } from "./root-folder-select"
 export { buildRootFolderOptions } from "./root-folder-options"
 export type { RootFolderOption } from "./root-folder-options"
+export {
+  resolveDefaultCreateParentId,
+  resolveEffectiveCreateParentId,
+} from "./default-parent"

--- a/src/features/root-folder-select/root-folder-select.test.tsx
+++ b/src/features/root-folder-select/root-folder-select.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+import type { BookmarkNode } from "@/browser"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+import { RootFolderSelect } from "./root-folder-select"
+
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const VAULT: BookmarkNode[] = [
+  {
+    id: "vault-root",
+    title: "Bookmarks",
+    children: [{ id: "work", title: "Work", children: [] }],
+  },
+]
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+  )
+  vi.stubGlobal("ResizeObserver", StubResizeObserver)
+  useBookmarkStore.setState({ tree: VAULT })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+function label(): string {
+  return screen.getByRole("combobox").textContent ?? ""
+}
+
+describe("RootFolderSelect display label", () => {
+  it("names a real folder by its path", () => {
+    render(<RootFolderSelect value="work" onChange={vi.fn()} />)
+
+    expect(label()).toBe("Bookmarks > Work")
+  })
+
+  it("shows the root label when nothing is selected", () => {
+    render(<RootFolderSelect value={null} onChange={vi.fn()} />)
+
+    expect(label()).toBe("Browser Root (all bookmarks)")
+  })
+
+  it("shows the root label for an adapter whose tree root is selectable, not its raw id", () => {
+    // Daemon and standalone hand back a real root node, which the options list
+    // deliberately omits — selecting it means the same as selecting nothing.
+    render(<RootFolderSelect value="vault-root" onChange={vi.fn()} />)
+
+    expect(label()).toBe("Browser Root (all bookmarks)")
+  })
+
+  it("says a folder is gone rather than printing its id", () => {
+    render(<RootFolderSelect value="deleted-folder" onChange={vi.fn()} />)
+
+    expect(label()).toBe("Unavailable folder — using the default")
+  })
+})

--- a/src/features/root-folder-select/root-folder-select.tsx
+++ b/src/features/root-folder-select/root-folder-select.tsx
@@ -9,6 +9,7 @@ import {
 import { buildRootFolderOptions } from "./root-folder-options"
 
 const ROOT_VALUE = "__root__"
+const ROOT_LABEL = "Browser Root (all bookmarks)"
 
 interface RootFolderSelectProps {
   value: string | null
@@ -27,9 +28,18 @@ export function RootFolderSelect({
 
   const folders = React.useMemo(() => buildRootFolderOptions(tree), [tree])
 
-  const displayLabel = value
-    ? (folders.find((folder) => folder.id === value)?.label ?? value)
-    : "Browser Root (all bookmarks)"
+  // A raw id is never a label. Two ways `value` can miss the options list:
+  // it is the tree root itself — the daemon and standalone adapters have a
+  // real, selectable root, which is deliberately left out of the list because
+  // it is the same thing as selecting nothing — or it names a folder that has
+  // since been deleted, in which case the app is already falling back and the
+  // picker should say so rather than print a UUID.
+  const displayLabel = !value
+    ? ROOT_LABEL
+    : value === tree[0]?.id
+      ? ROOT_LABEL
+      : (folders.find((folder) => folder.id === value)?.label ??
+        "Unavailable folder — using the default")
 
   return (
     <div className="flex flex-col gap-2">

--- a/src/features/settings/__tests__/import-conflict-dialog.test.tsx
+++ b/src/features/settings/__tests__/import-conflict-dialog.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { ImportConflict } from "../import-plan"
+import { ImportConflictDialog } from "../import-conflict-dialog"
+
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function conflict(n: number): ImportConflict {
+  return {
+    key: `c${n}`,
+    path: "Dev Tools",
+    incomingTitle: `Incoming ${n}`,
+    existingTitle: `Existing ${n}`,
+    url: `https://example.com/${n}`,
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+  )
+  vi.stubGlobal("ResizeObserver", StubResizeObserver)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function mount(conflicts: ImportConflict[]) {
+  const onResolve = vi.fn()
+  const onCancel = vi.fn()
+  render(
+    <ImportConflictDialog
+      conflicts={conflicts}
+      onResolve={onResolve}
+      onCancel={onCancel}
+    />
+  )
+  return { onResolve, onCancel }
+}
+
+describe("ImportConflictDialog", () => {
+  it("shows both sides of the conflict and where it is", () => {
+    mount([conflict(1)])
+
+    expect(screen.getByText("Incoming 1")).toBeTruthy()
+    expect(screen.getByText("Existing 1")).toBeTruthy()
+    expect(screen.getByText("https://example.com/1")).toBeTruthy()
+    expect(screen.getByText(/in Dev Tools/)).toBeTruthy()
+  })
+
+  it("resolves immediately when there is only one conflict", async () => {
+    const user = userEvent.setup()
+    const { onResolve } = mount([conflict(1)])
+
+    await user.click(screen.getByRole("button", { name: "Replace" }))
+
+    expect(onResolve).toHaveBeenCalledWith({ c1: "replace" })
+  })
+
+  it("walks through conflicts one at a time, keeping each answer", async () => {
+    const user = userEvent.setup()
+    const { onResolve } = mount([conflict(1), conflict(2)])
+
+    expect(screen.getByText(/Conflict 1 of 2/)).toBeTruthy()
+    await user.click(screen.getByRole("button", { name: "Skip" }))
+
+    expect(screen.getByText(/Conflict 2 of 2/)).toBeTruthy()
+    expect(onResolve).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole("button", { name: "Keep both" }))
+
+    expect(onResolve).toHaveBeenCalledWith({ c1: "skip", c2: "keep-both" })
+  })
+
+  it("applies one answer to every remaining conflict when asked to", async () => {
+    const user = userEvent.setup()
+    const { onResolve } = mount([conflict(1), conflict(2), conflict(3)])
+
+    await user.click(screen.getByRole("button", { name: "Replace" }))
+    await user.click(screen.getByRole("checkbox"))
+    await user.click(screen.getByRole("button", { name: "Skip" }))
+
+    expect(onResolve).toHaveBeenCalledWith({
+      c1: "replace",
+      c2: "skip",
+      c3: "skip",
+    })
+  })
+
+  it("cancels without resolving anything", async () => {
+    const user = userEvent.setup()
+    const { onResolve, onCancel } = mount([conflict(1), conflict(2)])
+
+    await user.click(screen.getByRole("button", { name: "Cancel import" }))
+
+    expect(onCancel).toHaveBeenCalled()
+    expect(onResolve).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/settings/__tests__/import-conflict-dialog.test.tsx
+++ b/src/features/settings/__tests__/import-conflict-dialog.test.tsx
@@ -54,9 +54,57 @@ function mount(conflicts: ImportConflict[]) {
   return { onResolve, onCancel }
 }
 
-describe("ImportConflictDialog", () => {
-  it("shows both sides of the conflict and where it is", () => {
+/** Moves from the opening summary into the one-at-a-time view. */
+async function startReview(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "Review one by one" }))
+}
+
+describe("ImportConflictDialog summary", () => {
+  it("opens on a summary listing every conflict", () => {
+    mount([conflict(1), conflict(2)])
+
+    expect(screen.getByText("2 bookmarks already exist")).toBeTruthy()
+    expect(screen.getByText("Incoming 1")).toBeTruthy()
+    expect(screen.getByText("Incoming 2")).toBeTruthy()
+  })
+
+  it("applies one bulk answer to everything without asking again", async () => {
+    const user = userEvent.setup()
+    const { onResolve } = mount([conflict(1), conflict(2), conflict(3)])
+
+    await user.click(screen.getByRole("button", { name: "Replace all" }))
+
+    expect(onResolve).toHaveBeenCalledWith({
+      c1: "replace",
+      c2: "replace",
+      c3: "replace",
+    })
+  })
+
+  it("offers skip, replace and keep both in bulk", () => {
     mount([conflict(1)])
+
+    for (const label of ["Skip all", "Replace all", "Keep both for all"]) {
+      expect(screen.getByRole("button", { name: label })).toBeTruthy()
+    }
+  })
+
+  it("cancels without resolving anything", async () => {
+    const user = userEvent.setup()
+    const { onResolve, onCancel } = mount([conflict(1)])
+
+    await user.click(screen.getByRole("button", { name: "Cancel import" }))
+
+    expect(onCancel).toHaveBeenCalled()
+    expect(onResolve).not.toHaveBeenCalled()
+  })
+})
+
+describe("ImportConflictDialog review", () => {
+  it("shows both sides of the conflict and where it is", async () => {
+    const user = userEvent.setup()
+    mount([conflict(1)])
+    await startReview(user)
 
     expect(screen.getByText("Incoming 1")).toBeTruthy()
     expect(screen.getByText("Existing 1")).toBeTruthy()
@@ -67,6 +115,7 @@ describe("ImportConflictDialog", () => {
   it("resolves immediately when there is only one conflict", async () => {
     const user = userEvent.setup()
     const { onResolve } = mount([conflict(1)])
+    await startReview(user)
 
     await user.click(screen.getByRole("button", { name: "Replace" }))
 
@@ -76,6 +125,7 @@ describe("ImportConflictDialog", () => {
   it("walks through conflicts one at a time, keeping each answer", async () => {
     const user = userEvent.setup()
     const { onResolve } = mount([conflict(1), conflict(2)])
+    await startReview(user)
 
     expect(screen.getByText(/Conflict 1 of 2/)).toBeTruthy()
     await user.click(screen.getByRole("button", { name: "Skip" }))
@@ -91,6 +141,7 @@ describe("ImportConflictDialog", () => {
   it("applies one answer to every remaining conflict when asked to", async () => {
     const user = userEvent.setup()
     const { onResolve } = mount([conflict(1), conflict(2), conflict(3)])
+    await startReview(user)
 
     await user.click(screen.getByRole("button", { name: "Replace" }))
     await user.click(screen.getByRole("checkbox"))
@@ -103,13 +154,40 @@ describe("ImportConflictDialog", () => {
     })
   })
 
-  it("cancels without resolving anything", async () => {
+  it("hides the apply-to-the-rest option on the last conflict", async () => {
     const user = userEvent.setup()
-    const { onResolve, onCancel } = mount([conflict(1), conflict(2)])
+    mount([conflict(1), conflict(2)])
+    await startReview(user)
 
-    await user.click(screen.getByRole("button", { name: "Cancel import" }))
+    expect(screen.getByRole("checkbox")).toBeTruthy()
+    await user.click(screen.getByRole("button", { name: "Skip" }))
 
-    expect(onCancel).toHaveBeenCalled()
-    expect(onResolve).not.toHaveBeenCalled()
+    expect(screen.queryByRole("checkbox")).toBeNull()
+  })
+
+  it("goes back to change an earlier answer", async () => {
+    const user = userEvent.setup()
+    const { onResolve } = mount([conflict(1), conflict(2)])
+    await startReview(user)
+
+    await user.click(screen.getByRole("button", { name: "Skip" }))
+    await user.click(screen.getByRole("button", { name: "Back" }))
+
+    expect(screen.getByText(/Conflict 1 of 2/)).toBeTruthy()
+
+    await user.click(screen.getByRole("button", { name: "Replace" }))
+    await user.click(screen.getByRole("button", { name: "Skip" }))
+
+    expect(onResolve).toHaveBeenCalledWith({ c1: "replace", c2: "skip" })
+  })
+
+  it("goes back to the summary from the first conflict", async () => {
+    const user = userEvent.setup()
+    mount([conflict(1), conflict(2)])
+    await startReview(user)
+
+    await user.click(screen.getByRole("button", { name: "Back" }))
+
+    expect(screen.getByText("2 bookmarks already exist")).toBeTruthy()
   })
 })

--- a/src/features/settings/__tests__/settings-dialog-onboarding.test.tsx
+++ b/src/features/settings/__tests__/settings-dialog-onboarding.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { installFakeIndexedDB } from "@/browser/__tests__/fake-indexeddb"
+import { useUIStore } from "@/stores/ui-store"
+import { usePreferencesStore } from "@/stores/preferences-store"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+import { SettingsDialog } from "../settings-dialog"
+
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+installFakeIndexedDB()
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", StubResizeObserver)
+  useUIStore.setState({
+    settingsOpen: true,
+    onboardingOpen: false,
+  })
+  usePreferencesStore.setState({ adapterMode: "browser" })
+  useBookmarkStore.setState({ tree: [], rootFolderId: null })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  installFakeIndexedDB()
+})
+
+describe("SettingsDialog setup wizard", () => {
+  it("clears onboardingCompleted, closes settings, and opens the wizard", async () => {
+    const storageSet = vi.fn().mockResolvedValue(undefined)
+    useBookmarkStore.setState({
+      adapter: {
+        bookmarks: {} as never,
+        storage: {
+          get: vi.fn().mockResolvedValue(null),
+          set: storageSet,
+          remove: vi.fn(),
+        },
+        favicon: { getUrl: vi.fn(), isAvailable: vi.fn(() => false) },
+        capabilities: {
+          openInManager: false,
+          move: true,
+          reorder: true,
+          setChildOrder: false,
+        },
+      },
+    })
+
+    render(<SettingsDialog />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Show setup wizard" }))
+
+    expect(storageSet).toHaveBeenCalledWith("onboardingCompleted", false)
+    await vi.waitFor(() => {
+      expect(useUIStore.getState().settingsOpen).toBe(false)
+      expect(useUIStore.getState().onboardingOpen).toBe(true)
+    })
+  })
+})

--- a/src/features/settings/daemon-connection-panel.tsx
+++ b/src/features/settings/daemon-connection-panel.tsx
@@ -221,6 +221,11 @@ export function DaemonConnectionPanel() {
               type="button"
               size="sm"
               disabled={phase === "connecting" || origin.trim() === ""}
+              title={
+                origin.trim() === ""
+                  ? "Enter the daemon address first."
+                  : undefined
+              }
               onClick={handleConnect}
             >
               {phase === "connecting"

--- a/src/features/settings/export-scope.test.ts
+++ b/src/features/settings/export-scope.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+import type { BookmarkNode } from "@/browser"
+import { exportFileName, resolveExportTree } from "./export-scope"
+
+const TREE: BookmarkNode[] = [
+  {
+    id: "0",
+    title: "",
+    children: [
+      {
+        id: "1",
+        title: "Bookmarks Bar",
+        children: [{ id: "10", title: "Work", children: [] }],
+      },
+      { id: "2", title: "Other Bookmarks", children: [] },
+    ],
+  },
+]
+
+describe("resolveExportTree", () => {
+  it("returns only the dashboard root subtree", () => {
+    expect(resolveExportTree(TREE, "10", "dashboard")).toEqual([
+      { id: "10", title: "Work", children: [] },
+    ])
+  })
+
+  it("returns the whole tree for the everything scope", () => {
+    expect(resolveExportTree(TREE, "10", "everything")).toBe(TREE)
+  })
+
+  it("returns the whole tree when no root folder is selected", () => {
+    expect(resolveExportTree(TREE, null, "dashboard")).toBe(TREE)
+  })
+
+  it("falls back to the whole tree rather than exporting nothing for a stale root id", () => {
+    expect(resolveExportTree(TREE, "gone", "dashboard")).toBe(TREE)
+  })
+})
+
+describe("exportFileName", () => {
+  it("uses a plain name for a full export", () => {
+    expect(exportFileName("everything", "Work")).toBe("bookmarks.html")
+  })
+
+  it("slugs the root folder title", () => {
+    expect(exportFileName("dashboard", "Personal Bookmarks")).toBe(
+      "bookmarks-personal-bookmarks.html"
+    )
+  })
+
+  it("never produces a name containing a path separator", () => {
+    expect(exportFileName("dashboard", "a/b: c")).toBe("bookmarks-a-b-c.html")
+  })
+
+  it("falls back when the title slugs to nothing", () => {
+    expect(exportFileName("dashboard", "///")).toBe("bookmarks.html")
+    expect(exportFileName("dashboard", null)).toBe("bookmarks.html")
+  })
+})

--- a/src/features/settings/export-scope.ts
+++ b/src/features/settings/export-scope.ts
@@ -1,0 +1,48 @@
+import type { BookmarkNode } from "@/browser"
+
+export type ExportScope = "dashboard" | "everything"
+
+function findNode(nodes: BookmarkNode[], id: string): BookmarkNode | null {
+  for (const node of nodes) {
+    if (node.id === id) return node
+    const found = findNode(node.children ?? [], id)
+    if (found) return found
+  }
+  return null
+}
+
+/**
+ * Picks the subtree an export should serialize.
+ *
+ * `"dashboard"` exports only what the dashboard actually shows, so that an
+ * export round-trips back through import as the same set of bookmarks. It
+ * degrades to the whole tree when no root folder is selected (nothing is being
+ * scoped away) or when the saved root no longer exists — an export that
+ * silently produces an empty file would be worse than an over-broad one.
+ */
+export function resolveExportTree(
+  tree: BookmarkNode[],
+  rootFolderId: string | null,
+  scope: ExportScope
+): BookmarkNode[] {
+  if (scope === "everything" || !rootFolderId) return tree
+
+  const root = findNode(tree, rootFolderId)
+  return root ? [root] : tree
+}
+
+/** Filename for the downloaded file, kept free of path separators. */
+export function exportFileName(
+  scope: ExportScope,
+  rootTitle: string | null
+): string {
+  if (scope === "everything" || !rootTitle) return "bookmarks.html"
+
+  const slug = rootTitle
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+
+  return slug ? `bookmarks-${slug}.html` : "bookmarks.html"
+}

--- a/src/features/settings/import-bookmarks.test.ts
+++ b/src/features/settings/import-bookmarks.test.ts
@@ -219,6 +219,41 @@ describe("executeImportPlan", () => {
     )
   })
 
+  it("never exceeds the concurrency limit, across folders as well as within one", async () => {
+    let inFlight = 0
+    let peak = 0
+    let n = 0
+    const adapter = makeAdapter({
+      create: async (input) => {
+        inFlight += 1
+        peak = Math.max(peak, inFlight)
+        await new Promise((resolve) => setTimeout(resolve, 1))
+        inFlight -= 1
+        return { id: `created-${++n}`, title: input.title } as BookmarkNode
+      },
+    })
+
+    // 10 sibling folders of 5 bookmarks each. Batching per level would create
+    // all 10 folders at once and then run 10 subtrees in parallel, each with
+    // its own allowance.
+    const plan: ImportPlanNode[] = Array.from({ length: 10 }, (_, f) => ({
+      kind: "folder" as const,
+      title: `f${f}`,
+      existingId: null,
+      children: Array.from({ length: 5 }, (_, b) => ({
+        kind: "bookmark" as const,
+        title: `b${f}-${b}`,
+        url: `https://example.com/${f}/${b}`,
+        conflict: null,
+      })),
+    }))
+
+    const result = await executeImportPlan(adapter, plan, "target", {}, 3)
+
+    expect(result).toMatchObject({ folders: 10, bookmarks: 50, failed: 0 })
+    expect(peak).toBeLessThanOrEqual(3)
+  })
+
   it("never rejects, so a caller cannot end up with an unhandled error", async () => {
     const adapter = makeAdapter({
       create: async () => {

--- a/src/features/settings/import-bookmarks.test.ts
+++ b/src/features/settings/import-bookmarks.test.ts
@@ -1,55 +1,62 @@
 import { describe, expect, it, vi } from "vitest"
 import type { BookmarkAdapter, BookmarkNode } from "@/browser"
-import { formatImportResult, importBookmarkNodes } from "./import-bookmarks"
+import { executeImportPlan, formatImportResult } from "./import-bookmarks"
+import type { ImportPlanNode } from "./import-plan"
+import type { ImportResult } from "./import-bookmarks"
 
-function makeAdapter(
-  create: (input: {
-    parentId: string
-    title: string
-    url?: string
-  }) => Promise<BookmarkNode>
-): BookmarkAdapter {
-  return { create } as unknown as BookmarkAdapter
+function makeAdapter(overrides: Partial<BookmarkAdapter>): BookmarkAdapter {
+  return overrides as unknown as BookmarkAdapter
 }
 
 /** Accepts everything, handing back a unique id per call. */
 function acceptingAdapter() {
   let n = 0
   const create = vi.fn(
-    async (input: { parentId: string; title: string; url?: string }) => ({
-      id: `created-${++n}`,
-      title: input.title,
-      url: input.url,
-      parentId: input.parentId,
-    })
+    async (input: { parentId: string; title: string; url?: string }) =>
+      ({
+        id: `created-${++n}`,
+        title: input.title,
+        url: input.url,
+        parentId: input.parentId,
+      }) as BookmarkNode
   )
-  return { adapter: makeAdapter(create), create }
+  const update = vi.fn(async (id: string, changes: { title?: string }) => ({
+    id,
+    title: changes.title ?? "",
+  }))
+  return { adapter: makeAdapter({ create, update }), create, update }
 }
 
-const TREE: BookmarkNode[] = [
-  { id: "b1", title: "A", url: "https://a.com" },
+const PLAN: ImportPlanNode[] = [
+  { kind: "bookmark", title: "A", url: "https://a.com", conflict: null },
   {
-    id: "f1",
+    kind: "folder",
     title: "Folder",
+    existingId: null,
     children: [
-      { id: "b2", title: "B", url: "https://b.com" },
-      { id: "f2", title: "Nested", children: [] },
+      { kind: "bookmark", title: "B", url: "https://b.com", conflict: null },
+      { kind: "folder", title: "Nested", existingId: null, children: [] },
     ],
   },
 ]
 
-describe("importBookmarkNodes", () => {
-  it("writes the whole tree under the target parent", async () => {
+const EMPTY: ImportResult = {
+  folders: 0,
+  merged: 0,
+  bookmarks: 0,
+  replaced: 0,
+  skipped: 0,
+  failed: 0,
+  firstError: null,
+}
+
+describe("executeImportPlan", () => {
+  it("writes the whole plan under the target parent", async () => {
     const { adapter, create } = acceptingAdapter()
 
-    const result = await importBookmarkNodes(adapter, TREE, "target")
+    const result = await executeImportPlan(adapter, PLAN, "target")
 
-    expect(result).toEqual({
-      folders: 2,
-      bookmarks: 2,
-      failed: 0,
-      firstError: null,
-    })
+    expect(result).toEqual({ ...EMPTY, folders: 2, bookmarks: 2 })
     expect(create).toHaveBeenCalledWith({
       parentId: "target",
       title: "A",
@@ -57,36 +64,154 @@ describe("importBookmarkNodes", () => {
     })
   })
 
-  it("keeps going when a single bookmark is rejected", async () => {
-    let n = 0
-    const adapter = makeAdapter(async (input) => {
-      if (input.url === "https://b.com")
-        throw new Error("a url cannot be empty")
-      return { id: `created-${++n}`, title: input.title, url: input.url }
+  it("writes into an existing folder instead of creating it again", async () => {
+    const { adapter, create } = acceptingAdapter()
+    const plan: ImportPlanNode[] = [
+      {
+        kind: "folder",
+        title: "Dev Tools",
+        existingId: "existing-folder",
+        children: [
+          {
+            kind: "bookmark",
+            title: "B",
+            url: "https://b.com",
+            conflict: null,
+          },
+        ],
+      },
+    ]
+
+    const result = await executeImportPlan(adapter, plan, "target")
+
+    expect(result).toMatchObject({ folders: 0, merged: 1, bookmarks: 1 })
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(create).toHaveBeenCalledWith({
+      parentId: "existing-folder",
+      title: "B",
+      url: "https://b.com",
+    })
+  })
+
+  it("skips a conflicting bookmark without touching the adapter", async () => {
+    const { adapter, create, update } = acceptingAdapter()
+    const plan: ImportPlanNode[] = [
+      {
+        kind: "bookmark",
+        title: "New title",
+        url: "https://a.com",
+        conflict: { key: "c0", existingId: "old" },
+      },
+    ]
+
+    const result = await executeImportPlan(adapter, plan, "target", {
+      c0: "skip",
     })
 
-    const result = await importBookmarkNodes(adapter, TREE, "target")
+    expect(result).toMatchObject({ skipped: 1, bookmarks: 0, replaced: 0 })
+    expect(create).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+  })
 
-    expect(result.bookmarks).toBe(1)
-    expect(result.folders).toBe(2)
-    expect(result.failed).toBe(1)
-    expect(result.firstError).toBe("a url cannot be empty")
+  it("retitles the existing bookmark in place for replace", async () => {
+    const { adapter, create, update } = acceptingAdapter()
+    const plan: ImportPlanNode[] = [
+      {
+        kind: "bookmark",
+        title: "New title",
+        url: "https://a.com",
+        conflict: { key: "c0", existingId: "old" },
+      },
+    ]
+
+    const result = await executeImportPlan(adapter, plan, "target", {
+      c0: "replace",
+    })
+
+    expect(result).toMatchObject({ replaced: 1, bookmarks: 0 })
+    expect(update).toHaveBeenCalledWith("old", { title: "New title" })
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it("creates a second copy for keep-both", async () => {
+    const { adapter, create } = acceptingAdapter()
+    const plan: ImportPlanNode[] = [
+      {
+        kind: "bookmark",
+        title: "New title",
+        url: "https://a.com",
+        conflict: { key: "c0", existingId: "old" },
+      },
+    ]
+
+    const result = await executeImportPlan(adapter, plan, "target", {
+      c0: "keep-both",
+    })
+
+    expect(result).toMatchObject({ bookmarks: 1, skipped: 0, replaced: 0 })
+    expect(create).toHaveBeenCalledWith({
+      parentId: "target",
+      title: "New title",
+      url: "https://a.com",
+    })
+  })
+
+  it("defaults an unanswered conflict to skip, so nothing existing is disturbed", async () => {
+    const { adapter, create, update } = acceptingAdapter()
+    const plan: ImportPlanNode[] = [
+      {
+        kind: "bookmark",
+        title: "New title",
+        url: "https://a.com",
+        conflict: { key: "c0", existingId: "old" },
+      },
+    ]
+
+    const result = await executeImportPlan(adapter, plan, "target")
+
+    expect(result).toMatchObject({ skipped: 1 })
+    expect(create).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it("keeps going when a single bookmark is rejected", async () => {
+    let n = 0
+    const adapter = makeAdapter({
+      create: async (input) => {
+        if (input.url === "https://b.com") {
+          throw new Error("a url cannot be empty")
+        }
+        return {
+          id: `created-${++n}`,
+          title: input.title,
+          url: input.url,
+        } as BookmarkNode
+      },
+    })
+
+    const result = await executeImportPlan(adapter, PLAN, "target")
+
+    expect(result).toMatchObject({
+      bookmarks: 1,
+      folders: 2,
+      failed: 1,
+      firstError: "a url cannot be empty",
+    })
   })
 
   it("counts a rejected folder's whole subtree as lost, and skips writing it", async () => {
     const create = vi.fn(async (input: { title: string }) => {
       if (input.title === "Folder") throw new Error("nope")
-      return { id: "created", title: input.title }
+      return { id: "created", title: input.title } as BookmarkNode
     })
 
-    const result = await importBookmarkNodes(
-      makeAdapter(create as never),
-      TREE,
+    const result = await executeImportPlan(
+      makeAdapter({ create: create as never }),
+      PLAN,
       "target"
     )
 
-    expect(result.bookmarks).toBe(1)
-    expect(result.folders).toBe(0)
+    expect(result).toMatchObject({ bookmarks: 1, folders: 0 })
     // "Folder" itself, its bookmark "B", and its "Nested" child.
     expect(result.failed).toBe(3)
     expect(create.mock.calls.some(([input]) => input.title === "Nested")).toBe(
@@ -95,32 +220,44 @@ describe("importBookmarkNodes", () => {
   })
 
   it("never rejects, so a caller cannot end up with an unhandled error", async () => {
-    const adapter = makeAdapter(async () => {
-      throw new Error("everything is broken")
+    const adapter = makeAdapter({
+      create: async () => {
+        throw new Error("everything is broken")
+      },
     })
 
     await expect(
-      importBookmarkNodes(adapter, TREE, "target")
+      executeImportPlan(adapter, PLAN, "target")
     ).resolves.toMatchObject({ folders: 0, bookmarks: 0, failed: 4 })
   })
 })
 
 describe("formatImportResult", () => {
   it("summarizes a clean import", () => {
+    expect(formatImportResult({ ...EMPTY, folders: 2, bookmarks: 1 })).toBe(
+      "Imported 1 bookmark and 2 folders."
+    )
+  })
+
+  it("reports merges and conflict outcomes", () => {
     expect(
       formatImportResult({
-        folders: 2,
-        bookmarks: 1,
-        failed: 0,
-        firstError: null,
+        ...EMPTY,
+        folders: 1,
+        merged: 3,
+        bookmarks: 10,
+        replaced: 2,
+        skipped: 4,
       })
-    ).toBe("Imported 1 bookmark and 2 folders.")
+    ).toBe(
+      "Imported 10 bookmarks and 1 folder. 3 folders merged, 2 duplicates replaced, 4 duplicates skipped."
+    )
   })
 
   it("reports failures with the underlying reason", () => {
     expect(
       formatImportResult({
-        folders: 0,
+        ...EMPTY,
         bookmarks: 5,
         failed: 2,
         firstError: "a title cannot be empty",

--- a/src/features/settings/import-bookmarks.test.ts
+++ b/src/features/settings/import-bookmarks.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest"
+import type { BookmarkAdapter, BookmarkNode } from "@/browser"
+import { formatImportResult, importBookmarkNodes } from "./import-bookmarks"
+
+function makeAdapter(
+  create: (input: {
+    parentId: string
+    title: string
+    url?: string
+  }) => Promise<BookmarkNode>
+): BookmarkAdapter {
+  return { create } as unknown as BookmarkAdapter
+}
+
+/** Accepts everything, handing back a unique id per call. */
+function acceptingAdapter() {
+  let n = 0
+  const create = vi.fn(
+    async (input: { parentId: string; title: string; url?: string }) => ({
+      id: `created-${++n}`,
+      title: input.title,
+      url: input.url,
+      parentId: input.parentId,
+    })
+  )
+  return { adapter: makeAdapter(create), create }
+}
+
+const TREE: BookmarkNode[] = [
+  { id: "b1", title: "A", url: "https://a.com" },
+  {
+    id: "f1",
+    title: "Folder",
+    children: [
+      { id: "b2", title: "B", url: "https://b.com" },
+      { id: "f2", title: "Nested", children: [] },
+    ],
+  },
+]
+
+describe("importBookmarkNodes", () => {
+  it("writes the whole tree under the target parent", async () => {
+    const { adapter, create } = acceptingAdapter()
+
+    const result = await importBookmarkNodes(adapter, TREE, "target")
+
+    expect(result).toEqual({
+      folders: 2,
+      bookmarks: 2,
+      failed: 0,
+      firstError: null,
+    })
+    expect(create).toHaveBeenCalledWith({
+      parentId: "target",
+      title: "A",
+      url: "https://a.com",
+    })
+  })
+
+  it("keeps going when a single bookmark is rejected", async () => {
+    let n = 0
+    const adapter = makeAdapter(async (input) => {
+      if (input.url === "https://b.com")
+        throw new Error("a url cannot be empty")
+      return { id: `created-${++n}`, title: input.title, url: input.url }
+    })
+
+    const result = await importBookmarkNodes(adapter, TREE, "target")
+
+    expect(result.bookmarks).toBe(1)
+    expect(result.folders).toBe(2)
+    expect(result.failed).toBe(1)
+    expect(result.firstError).toBe("a url cannot be empty")
+  })
+
+  it("counts a rejected folder's whole subtree as lost, and skips writing it", async () => {
+    const create = vi.fn(async (input: { title: string }) => {
+      if (input.title === "Folder") throw new Error("nope")
+      return { id: "created", title: input.title }
+    })
+
+    const result = await importBookmarkNodes(
+      makeAdapter(create as never),
+      TREE,
+      "target"
+    )
+
+    expect(result.bookmarks).toBe(1)
+    expect(result.folders).toBe(0)
+    // "Folder" itself, its bookmark "B", and its "Nested" child.
+    expect(result.failed).toBe(3)
+    expect(create.mock.calls.some(([input]) => input.title === "Nested")).toBe(
+      false
+    )
+  })
+
+  it("never rejects, so a caller cannot end up with an unhandled error", async () => {
+    const adapter = makeAdapter(async () => {
+      throw new Error("everything is broken")
+    })
+
+    await expect(
+      importBookmarkNodes(adapter, TREE, "target")
+    ).resolves.toMatchObject({ folders: 0, bookmarks: 0, failed: 4 })
+  })
+})
+
+describe("formatImportResult", () => {
+  it("summarizes a clean import", () => {
+    expect(
+      formatImportResult({
+        folders: 2,
+        bookmarks: 1,
+        failed: 0,
+        firstError: null,
+      })
+    ).toBe("Imported 1 bookmark and 2 folders.")
+  })
+
+  it("reports failures with the underlying reason", () => {
+    expect(
+      formatImportResult({
+        folders: 0,
+        bookmarks: 5,
+        failed: 2,
+        firstError: "a title cannot be empty",
+      })
+    ).toBe(
+      "Imported 5 bookmarks and 0 folders. 2 items could not be imported (a title cannot be empty)."
+    )
+  })
+})

--- a/src/features/settings/import-bookmarks.ts
+++ b/src/features/settings/import-bookmarks.ts
@@ -1,10 +1,17 @@
-import type { BookmarkAdapter, BookmarkNode } from "@/browser"
+import type { BookmarkAdapter } from "@/browser"
+import type { ConflictResolution, ImportPlanNode } from "./import-plan"
 
 export interface ImportResult {
-  /** Folders successfully created. */
+  /** Folders created. Folders merged into an existing one are not counted. */
   folders: number
-  /** Bookmarks successfully created. */
+  /** Folders that landed inside an existing folder of the same name. */
+  merged: number
+  /** Bookmarks created, including "keep both" duplicates. */
   bookmarks: number
+  /** Existing bookmarks retitled in place because the user chose "replace". */
+  replaced: number
+  /** Conflicting bookmarks the user chose not to import. */
+  skipped: number
   /**
    * Nodes that could not be written, including every descendant of a folder
    * whose own creation failed — those descendants have nowhere to go, so they
@@ -16,10 +23,10 @@ export interface ImportResult {
 }
 
 /** Total nodes in a subtree, counting the nodes themselves. */
-function countNodes(nodes: BookmarkNode[]): number {
+function countNodes(nodes: ImportPlanNode[]): number {
   let total = 0
   for (const node of nodes) {
-    total += 1 + countNodes(node.children ?? [])
+    total += 1 + (node.kind === "folder" ? countNodes(node.children) : 0)
   }
   return total
 }
@@ -29,24 +36,29 @@ function messageOf(error: unknown): string {
 }
 
 /**
- * Writes a parsed bookmark tree under `parentId`.
+ * Carries out a plan from `planImport` under the user's conflict choices.
  *
- * Every create is isolated: a single rejected node (a URL the back-end refuses,
+ * Every write is isolated: a single rejected node (a URL the back-end refuses,
  * a transient daemon conflict) costs that node and — for a folder — its
- * subtree, never the rest of the import. The previous implementation batched
- * creates through `Promise.all` with no error handling, so one rejection threw
- * out of the file-input handler and the user was left with a half-written tree
- * and no message at all.
+ * subtree, never the rest of the import. This function never rejects, so a
+ * caller cannot end up with a half-written tree and no message.
+ *
+ * A conflict with no recorded choice defaults to `"skip"`, so an import that
+ * is confirmed without answering leaves what is already there alone.
  */
-export async function importBookmarkNodes(
+export async function executeImportPlan(
   bookmarks: BookmarkAdapter,
-  nodes: BookmarkNode[],
+  nodes: ImportPlanNode[],
   parentId: string,
+  resolutions: Record<string, ConflictResolution> = {},
   concurrency = 8
 ): Promise<ImportResult> {
   const result: ImportResult = {
     folders: 0,
+    merged: 0,
     bookmarks: 0,
+    replaced: 0,
+    skipped: 0,
     failed: 0,
     firstError: null,
   }
@@ -56,36 +68,59 @@ export async function importBookmarkNodes(
     result.firstError ??= messageOf(error)
   }
 
-  async function write(level: BookmarkNode[], target: string): Promise<void> {
-    const folders: BookmarkNode[] = []
-    const leaves: BookmarkNode[] = []
-    for (const node of level) {
-      if (node.url) leaves.push(node)
-      else if (node.children) folders.push(node)
+  async function writeBookmark(
+    node: Extract<ImportPlanNode, { kind: "bookmark" }>,
+    target: string
+  ): Promise<void> {
+    const choice = node.conflict
+      ? (resolutions[node.conflict.key] ?? "skip")
+      : "keep-both"
+
+    try {
+      if (node.conflict && choice === "skip") {
+        result.skipped += 1
+        return
+      }
+
+      if (node.conflict && choice === "replace") {
+        // The URLs are identical by definition of the conflict, so the only
+        // thing left to carry over is the incoming title.
+        await bookmarks.update(node.conflict.existingId, { title: node.title })
+        result.replaced += 1
+        return
+      }
+
+      await bookmarks.create({
+        parentId: target,
+        title: node.title,
+        url: node.url,
+      })
+      result.bookmarks += 1
+    } catch (error) {
+      record(error, 1)
     }
+  }
+
+  async function write(level: ImportPlanNode[], target: string): Promise<void> {
+    const folders = level.filter((n) => n.kind === "folder")
+    const leaves = level.filter((n) => n.kind === "bookmark")
 
     for (let i = 0; i < leaves.length; i += concurrency) {
-      const batch = leaves.slice(i, i + concurrency)
       await Promise.all(
-        batch.map(async (node) => {
-          try {
-            await bookmarks.create({
-              parentId: target,
-              title: node.title,
-              url: node.url,
-            })
-            result.bookmarks += 1
-          } catch (error) {
-            record(error, 1)
-          }
-        })
+        leaves
+          .slice(i, i + concurrency)
+          .map((node) => writeBookmark(node, target))
       )
     }
 
-    // Folders are created level by level so their children have a real parent
+    // Folders are resolved level by level so their children have a real parent
     // id to attach to; `null` marks the ones whose subtree has to be abandoned.
-    const createdIds = await Promise.all(
+    const targets = await Promise.all(
       folders.map(async (node) => {
+        if (node.existingId) {
+          result.merged += 1
+          return node.existingId
+        }
         try {
           const created = await bookmarks.create({
             parentId: target,
@@ -94,7 +129,7 @@ export async function importBookmarkNodes(
           result.folders += 1
           return created.id
         } catch (error) {
-          record(error, 1 + countNodes(node.children ?? []))
+          record(error, 1 + countNodes(node.children))
           return null
         }
       })
@@ -102,8 +137,8 @@ export async function importBookmarkNodes(
 
     await Promise.all(
       folders.map((node, i) => {
-        const id = createdIds[i]
-        return id === null ? undefined : write(node.children ?? [], id)
+        const id = targets[i]
+        return id === null ? undefined : write(node.children, id)
       })
     )
   }
@@ -113,16 +148,33 @@ export async function importBookmarkNodes(
   return result
 }
 
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`
+}
+
 /** A short, human-readable summary of an import, for showing in the UI. */
 export function formatImportResult(result: ImportResult): string {
-  const parts = [
-    `${result.bookmarks} bookmark${result.bookmarks === 1 ? "" : "s"}`,
-    `${result.folders} folder${result.folders === 1 ? "" : "s"}`,
-  ]
-  let summary = `Imported ${parts.join(" and ")}.`
+  let summary = `Imported ${plural(result.bookmarks, "bookmark")} and ${plural(
+    result.folders,
+    "folder"
+  )}.`
+
+  const extras: string[] = []
+  if (result.merged > 0) {
+    extras.push(`${plural(result.merged, "folder")} merged`)
+  }
+  if (result.replaced > 0) {
+    extras.push(`${plural(result.replaced, "duplicate")} replaced`)
+  }
+  if (result.skipped > 0) {
+    extras.push(`${plural(result.skipped, "duplicate")} skipped`)
+  }
+  if (extras.length > 0) {
+    summary += ` ${extras.join(", ")}.`
+  }
 
   if (result.failed > 0) {
-    summary += ` ${result.failed} item${result.failed === 1 ? "" : "s"} could not be imported`
+    summary += ` ${plural(result.failed, "item")} could not be imported`
     summary += result.firstError ? ` (${result.firstError}).` : "."
   }
 

--- a/src/features/settings/import-bookmarks.ts
+++ b/src/features/settings/import-bookmarks.ts
@@ -1,0 +1,130 @@
+import type { BookmarkAdapter, BookmarkNode } from "@/browser"
+
+export interface ImportResult {
+  /** Folders successfully created. */
+  folders: number
+  /** Bookmarks successfully created. */
+  bookmarks: number
+  /**
+   * Nodes that could not be written, including every descendant of a folder
+   * whose own creation failed — those descendants have nowhere to go, so they
+   * are reported as lost rather than silently forgotten.
+   */
+  failed: number
+  /** The first error message seen, for showing the user *why* it went wrong. */
+  firstError: string | null
+}
+
+/** Total nodes in a subtree, counting the nodes themselves. */
+function countNodes(nodes: BookmarkNode[]): number {
+  let total = 0
+  for (const node of nodes) {
+    total += 1 + countNodes(node.children ?? [])
+  }
+  return total
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Writes a parsed bookmark tree under `parentId`.
+ *
+ * Every create is isolated: a single rejected node (a URL the back-end refuses,
+ * a transient daemon conflict) costs that node and — for a folder — its
+ * subtree, never the rest of the import. The previous implementation batched
+ * creates through `Promise.all` with no error handling, so one rejection threw
+ * out of the file-input handler and the user was left with a half-written tree
+ * and no message at all.
+ */
+export async function importBookmarkNodes(
+  bookmarks: BookmarkAdapter,
+  nodes: BookmarkNode[],
+  parentId: string,
+  concurrency = 8
+): Promise<ImportResult> {
+  const result: ImportResult = {
+    folders: 0,
+    bookmarks: 0,
+    failed: 0,
+    firstError: null,
+  }
+
+  const record = (error: unknown, lost: number) => {
+    result.failed += lost
+    result.firstError ??= messageOf(error)
+  }
+
+  async function write(level: BookmarkNode[], target: string): Promise<void> {
+    const folders: BookmarkNode[] = []
+    const leaves: BookmarkNode[] = []
+    for (const node of level) {
+      if (node.url) leaves.push(node)
+      else if (node.children) folders.push(node)
+    }
+
+    for (let i = 0; i < leaves.length; i += concurrency) {
+      const batch = leaves.slice(i, i + concurrency)
+      await Promise.all(
+        batch.map(async (node) => {
+          try {
+            await bookmarks.create({
+              parentId: target,
+              title: node.title,
+              url: node.url,
+            })
+            result.bookmarks += 1
+          } catch (error) {
+            record(error, 1)
+          }
+        })
+      )
+    }
+
+    // Folders are created level by level so their children have a real parent
+    // id to attach to; `null` marks the ones whose subtree has to be abandoned.
+    const createdIds = await Promise.all(
+      folders.map(async (node) => {
+        try {
+          const created = await bookmarks.create({
+            parentId: target,
+            title: node.title,
+          })
+          result.folders += 1
+          return created.id
+        } catch (error) {
+          record(error, 1 + countNodes(node.children ?? []))
+          return null
+        }
+      })
+    )
+
+    await Promise.all(
+      folders.map((node, i) => {
+        const id = createdIds[i]
+        return id === null ? undefined : write(node.children ?? [], id)
+      })
+    )
+  }
+
+  await write(nodes, parentId)
+
+  return result
+}
+
+/** A short, human-readable summary of an import, for showing in the UI. */
+export function formatImportResult(result: ImportResult): string {
+  const parts = [
+    `${result.bookmarks} bookmark${result.bookmarks === 1 ? "" : "s"}`,
+    `${result.folders} folder${result.folders === 1 ? "" : "s"}`,
+  ]
+  let summary = `Imported ${parts.join(" and ")}.`
+
+  if (result.failed > 0) {
+    summary += ` ${result.failed} item${result.failed === 1 ? "" : "s"} could not be imported`
+    summary += result.firstError ? ` (${result.firstError}).` : "."
+  }
+
+  return summary
+}

--- a/src/features/settings/import-bookmarks.ts
+++ b/src/features/settings/import-bookmarks.ts
@@ -36,6 +36,41 @@ function messageOf(error: unknown): string {
 }
 
 /**
+ * Caps how many adapter requests are in flight across the *whole* import.
+ *
+ * Batching per folder is not enough: a file with 100 sibling folders would
+ * create all 100 at once and then run 100 subtrees in parallel, each with its
+ * own allowance — hundreds of simultaneous requests from a limit that reads
+ * like eight. A single shared pool makes the number mean what it says.
+ *
+ * A slot is held only for the duration of one request, never across the
+ * recursion into a folder's children, so nothing can deadlock waiting on work
+ * that is itself queued behind it.
+ */
+function createLimiter(limit: number) {
+  let active = 0
+  const waiting: (() => void)[] = []
+
+  return async function run<T>(task: () => Promise<T>): Promise<T> {
+    if (active >= limit) {
+      await new Promise<void>((resolve) => waiting.push(resolve))
+    } else {
+      active += 1
+    }
+
+    try {
+      return await task()
+    } finally {
+      // Hand the slot straight to the next waiter rather than freeing and
+      // reacquiring it, so the count cannot drift.
+      const next = waiting.shift()
+      if (next) next()
+      else active -= 1
+    }
+  }
+}
+
+/**
  * Carries out a plan from `planImport` under the user's conflict choices.
  *
  * Every write is isolated: a single rejected node (a URL the back-end refuses,
@@ -68,6 +103,8 @@ export async function executeImportPlan(
     result.firstError ??= messageOf(error)
   }
 
+  const limit = createLimiter(concurrency)
+
   async function writeBookmark(
     node: Extract<ImportPlanNode, { kind: "bookmark" }>,
     target: string
@@ -85,16 +122,19 @@ export async function executeImportPlan(
       if (node.conflict && choice === "replace") {
         // The URLs are identical by definition of the conflict, so the only
         // thing left to carry over is the incoming title.
-        await bookmarks.update(node.conflict.existingId, { title: node.title })
+        const existingId = node.conflict.existingId
+        await limit(() => bookmarks.update(existingId, { title: node.title }))
         result.replaced += 1
         return
       }
 
-      await bookmarks.create({
-        parentId: target,
-        title: node.title,
-        url: node.url,
-      })
+      await limit(() =>
+        bookmarks.create({
+          parentId: target,
+          title: node.title,
+          url: node.url,
+        })
+      )
       result.bookmarks += 1
     } catch (error) {
       record(error, 1)
@@ -105,13 +145,7 @@ export async function executeImportPlan(
     const folders = level.filter((n) => n.kind === "folder")
     const leaves = level.filter((n) => n.kind === "bookmark")
 
-    for (let i = 0; i < leaves.length; i += concurrency) {
-      await Promise.all(
-        leaves
-          .slice(i, i + concurrency)
-          .map((node) => writeBookmark(node, target))
-      )
-    }
+    await Promise.all(leaves.map((node) => writeBookmark(node, target)))
 
     // Folders are resolved level by level so their children have a real parent
     // id to attach to; `null` marks the ones whose subtree has to be abandoned.
@@ -122,10 +156,9 @@ export async function executeImportPlan(
           return node.existingId
         }
         try {
-          const created = await bookmarks.create({
-            parentId: target,
-            title: node.title,
-          })
+          const created = await limit(() =>
+            bookmarks.create({ parentId: target, title: node.title })
+          )
           result.folders += 1
           return created.id
         } catch (error) {

--- a/src/features/settings/import-conflict-dialog.tsx
+++ b/src/features/settings/import-conflict-dialog.tsx
@@ -1,0 +1,146 @@
+import * as React from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import type { ConflictResolution, ImportConflict } from "./import-plan"
+
+interface ImportConflictDialogProps {
+  conflicts: ImportConflict[]
+  onResolve: (resolutions: Record<string, ConflictResolution>) => void
+  onCancel: () => void
+}
+
+const ACTIONS: { value: ConflictResolution; label: string; hint: string }[] = [
+  {
+    value: "skip",
+    label: "Skip",
+    hint: "Leave the bookmark that is already there and drop the incoming one.",
+  },
+  {
+    value: "replace",
+    label: "Replace",
+    hint: "Keep one bookmark, using the incoming title.",
+  },
+  {
+    value: "keep-both",
+    label: "Keep both",
+    hint: "Import the incoming bookmark alongside the existing one.",
+  },
+]
+
+/**
+ * Asks what to do about bookmarks that already exist at their destination,
+ * one at a time, in the shape a file manager uses.
+ *
+ * Answers are collected and returned in one go rather than applied as they are
+ * given: nothing has been written when this is on screen, so cancelling has to
+ * leave the tree exactly as it was.
+ */
+export function ImportConflictDialog({
+  conflicts,
+  onResolve,
+  onCancel,
+}: ImportConflictDialogProps) {
+  const [index, setIndex] = React.useState(0)
+  const [resolutions, setResolutions] = React.useState<
+    Record<string, ConflictResolution>
+  >({})
+  const [applyToAll, setApplyToAll] = React.useState(false)
+
+  const conflict = conflicts[index]
+  if (!conflict) return null
+
+  const choose = (resolution: ConflictResolution) => {
+    const next = { ...resolutions }
+
+    if (applyToAll) {
+      for (const remaining of conflicts.slice(index)) {
+        next[remaining.key] = resolution
+      }
+      onResolve(next)
+      return
+    }
+
+    next[conflict.key] = resolution
+    setResolutions(next)
+
+    if (index + 1 >= conflicts.length) {
+      onResolve(next)
+      return
+    }
+    setIndex(index + 1)
+  }
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onCancel()
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>This bookmark already exists</DialogTitle>
+          <DialogDescription>
+            {conflicts.length === 1
+              ? "One incoming bookmark points at a URL that is already saved."
+              : `Conflict ${index + 1} of ${conflicts.length}. Some incoming bookmarks point at URLs that are already saved.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1 rounded-lg border border-border/70 p-3">
+            <p className="truncate text-sm font-medium">
+              {conflict.incomingTitle}
+            </p>
+            <p className="truncate text-xs text-muted-foreground">
+              {conflict.url}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Already saved as{" "}
+              <span className="font-medium text-foreground">
+                {conflict.existingTitle}
+              </span>
+              {conflict.path ? ` in ${conflict.path}` : " in the destination"}.
+            </p>
+          </div>
+
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={applyToAll}
+              onChange={(e) => setApplyToAll(e.target.checked)}
+              className="size-3.5 accent-primary"
+            />
+            Apply my choice to the remaining{" "}
+            {conflicts.length - index - 1 === 0
+              ? "conflicts"
+              : `${conflicts.length - index - 1} conflicts`}
+          </label>
+
+          <div className="flex flex-wrap gap-2">
+            {ACTIONS.map((action) => (
+              <Button
+                key={action.value}
+                variant={action.value === "skip" ? "default" : "outline"}
+                size="sm"
+                title={action.hint}
+                onClick={() => choose(action.value)}
+              >
+                {action.label}
+              </Button>
+            ))}
+            <Button variant="ghost" size="sm" onClick={onCancel}>
+              Cancel import
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/settings/import-conflict-dialog.tsx
+++ b/src/features/settings/import-conflict-dialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import type { ConflictResolution, ImportConflict } from "./import-plan"
 
 interface ImportConflictDialogProps {
@@ -15,30 +16,43 @@ interface ImportConflictDialogProps {
   onCancel: () => void
 }
 
-const ACTIONS: { value: ConflictResolution; label: string; hint: string }[] = [
-  {
-    value: "skip",
-    label: "Skip",
-    hint: "Leave the bookmark that is already there and drop the incoming one.",
-  },
-  {
-    value: "replace",
-    label: "Replace",
-    hint: "Keep one bookmark, using the incoming title.",
-  },
-  {
-    value: "keep-both",
-    label: "Keep both",
-    hint: "Import the incoming bookmark alongside the existing one.",
-  },
-]
+const ACTION_LABELS: Record<ConflictResolution, string> = {
+  skip: "Skip",
+  replace: "Replace",
+  "keep-both": "Keep both",
+}
+
+const BULK_LABELS: Record<ConflictResolution, string> = {
+  skip: "Skip all",
+  replace: "Replace all",
+  "keep-both": "Keep both for all",
+}
+
+const ACTION_HINTS: Record<ConflictResolution, string> = {
+  skip: "Leave the bookmark that is already there and drop the incoming one.",
+  replace: "Keep one bookmark, using the incoming title.",
+  "keep-both": "Import the incoming bookmark alongside the existing one.",
+}
+
+const ACTIONS: ConflictResolution[] = ["skip", "replace", "keep-both"]
+
+function everything(
+  conflicts: ImportConflict[],
+  resolution: ConflictResolution
+): Record<string, ConflictResolution> {
+  return Object.fromEntries(conflicts.map((c) => [c.key, resolution]))
+}
 
 /**
- * Asks what to do about bookmarks that already exist at their destination,
- * one at a time, in the shape a file manager uses.
+ * Asks what to do about bookmarks that already exist at their destination.
+ *
+ * Opens on a summary, because one decision usually covers a whole file and
+ * making someone answer the same question 200 times is not a choice, it is a
+ * chore. Review-one-by-one is there for when the answer genuinely differs, and
+ * that view keeps the same actions plus an "apply to the rest" escape hatch.
  *
  * Answers are collected and returned in one go rather than applied as they are
- * given: nothing has been written when this is on screen, so cancelling has to
+ * given: nothing has been written while this is on screen, so cancelling has to
  * leave the tree exactly as it was.
  */
 export function ImportConflictDialog({
@@ -46,27 +60,26 @@ export function ImportConflictDialog({
   onResolve,
   onCancel,
 }: ImportConflictDialogProps) {
+  const [reviewing, setReviewing] = React.useState(false)
   const [index, setIndex] = React.useState(0)
   const [resolutions, setResolutions] = React.useState<
     Record<string, ConflictResolution>
   >({})
-  const [applyToAll, setApplyToAll] = React.useState(false)
+  const [applyToRest, setApplyToRest] = React.useState(false)
 
   const conflict = conflicts[index]
-  if (!conflict) return null
+  const remaining = conflicts.length - index - 1
 
   const choose = (resolution: ConflictResolution) => {
-    const next = { ...resolutions }
+    if (!conflict) return
 
-    if (applyToAll) {
-      for (const remaining of conflicts.slice(index)) {
-        next[remaining.key] = resolution
-      }
-      onResolve(next)
+    const next = { ...resolutions, [conflict.key]: resolution }
+
+    if (applyToRest) {
+      onResolve({ ...next, ...everything(conflicts.slice(index), resolution) })
       return
     }
 
-    next[conflict.key] = resolution
     setResolutions(next)
 
     if (index + 1 >= conflicts.length) {
@@ -84,62 +97,131 @@ export function ImportConflictDialog({
       }}
     >
       <DialogContent>
-        <DialogHeader>
-          <DialogTitle>This bookmark already exists</DialogTitle>
-          <DialogDescription>
-            {conflicts.length === 1
-              ? "One incoming bookmark points at a URL that is already saved."
-              : `Conflict ${index + 1} of ${conflicts.length}. Some incoming bookmarks point at URLs that are already saved.`}
-          </DialogDescription>
-        </DialogHeader>
+        {!reviewing || !conflict ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>
+                {conflicts.length === 1
+                  ? "1 bookmark already exists"
+                  : `${conflicts.length} bookmarks already exist`}
+              </DialogTitle>
+              <DialogDescription>
+                These point at URLs that are already saved where they would
+                land. Choose once for all of them, or go through them one at a
+                time.
+              </DialogDescription>
+            </DialogHeader>
 
-        <div className="flex flex-col gap-3">
-          <div className="flex flex-col gap-1 rounded-lg border border-border/70 p-3">
-            <p className="truncate text-sm font-medium">
-              {conflict.incomingTitle}
-            </p>
-            <p className="truncate text-xs text-muted-foreground">
-              {conflict.url}
-            </p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Already saved as{" "}
-              <span className="font-medium text-foreground">
-                {conflict.existingTitle}
-              </span>
-              {conflict.path ? ` in ${conflict.path}` : " in the destination"}.
-            </p>
-          </div>
+            <ScrollArea className="max-h-48 rounded-lg border border-border/70">
+              <ul className="divide-y divide-border/50">
+                {conflicts.map((item) => (
+                  <li key={item.key} className="px-3 py-2">
+                    <p className="truncate text-sm">{item.incomingTitle}</p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {item.path ? `${item.path} · ` : ""}
+                      {item.url}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </ScrollArea>
 
-          <label className="flex items-center gap-2 text-xs text-muted-foreground">
-            <input
-              type="checkbox"
-              checked={applyToAll}
-              onChange={(e) => setApplyToAll(e.target.checked)}
-              className="size-3.5 accent-primary"
-            />
-            Apply my choice to the remaining{" "}
-            {conflicts.length - index - 1 === 0
-              ? "conflicts"
-              : `${conflicts.length - index - 1} conflicts`}
-          </label>
-
-          <div className="flex flex-wrap gap-2">
-            {ACTIONS.map((action) => (
+            <div className="flex flex-wrap gap-2">
+              {ACTIONS.map((action) => (
+                <Button
+                  key={action}
+                  variant={action === "skip" ? "default" : "outline"}
+                  size="sm"
+                  title={ACTION_HINTS[action]}
+                  onClick={() => onResolve(everything(conflicts, action))}
+                >
+                  {BULK_LABELS[action]}
+                </Button>
+              ))}
               <Button
-                key={action.value}
-                variant={action.value === "skip" ? "default" : "outline"}
+                variant="outline"
                 size="sm"
-                title={action.hint}
-                onClick={() => choose(action.value)}
+                onClick={() => setReviewing(true)}
               >
-                {action.label}
+                Review one by one
               </Button>
-            ))}
-            <Button variant="ghost" size="sm" onClick={onCancel}>
-              Cancel import
-            </Button>
-          </div>
-        </div>
+              <Button variant="ghost" size="sm" onClick={onCancel}>
+                Cancel import
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>This bookmark already exists</DialogTitle>
+              <DialogDescription>
+                {conflicts.length === 1
+                  ? "One incoming bookmark points at a URL that is already saved."
+                  : `Conflict ${index + 1} of ${conflicts.length}.`}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-1 rounded-lg border border-border/70 p-3">
+                <p className="truncate text-sm font-medium">
+                  {conflict.incomingTitle}
+                </p>
+                <p className="truncate text-xs text-muted-foreground">
+                  {conflict.url}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Already saved as{" "}
+                  <span className="font-medium text-foreground">
+                    {conflict.existingTitle}
+                  </span>
+                  {conflict.path
+                    ? ` in ${conflict.path}`
+                    : " in the destination"}
+                  .
+                </p>
+              </div>
+
+              {remaining > 0 && (
+                <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <input
+                    type="checkbox"
+                    checked={applyToRest}
+                    onChange={(e) => setApplyToRest(e.target.checked)}
+                    className="size-3.5 accent-primary"
+                  />
+                  Apply my choice to the remaining {remaining} conflict
+                  {remaining === 1 ? "" : "s"}
+                </label>
+              )}
+
+              <div className="flex flex-wrap gap-2">
+                {ACTIONS.map((action) => (
+                  <Button
+                    key={action}
+                    variant={action === "skip" ? "default" : "outline"}
+                    size="sm"
+                    title={ACTION_HINTS[action]}
+                    onClick={() => choose(action)}
+                  >
+                    {ACTION_LABELS[action]}
+                  </Button>
+                ))}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() =>
+                    index === 0 ? setReviewing(false) : setIndex(index - 1)
+                  }
+                >
+                  Back
+                </Button>
+                <Button variant="ghost" size="sm" onClick={onCancel}>
+                  Cancel import
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/src/features/settings/import-plan.test.ts
+++ b/src/features/settings/import-plan.test.ts
@@ -170,6 +170,26 @@ describe("planImport", () => {
     expect(plan.nodes).toHaveLength(2)
   })
 
+  it("lets only the first incoming copy claim an existing bookmark", () => {
+    const plan = planImport(
+      TREE,
+      "dest",
+      imported([
+        { id: "1", title: "Personal", url: "https://a.com" },
+        { id: "2", title: "Work", url: "https://a.com" },
+      ])
+    )
+
+    // One conflict, not two pointed at the same node — resolving both as
+    // "replace" would otherwise race two updates against one bookmark.
+    expect(plan.conflicts).toHaveLength(1)
+    expect(plan.nodes[0]).toMatchObject({
+      title: "Personal",
+      conflict: { existingId: "old-a" },
+    })
+    expect(plan.nodes[1]).toMatchObject({ title: "Work", conflict: null })
+  })
+
   it("plans everything as new when the destination is not in the tree", () => {
     const plan = planImport(
       TREE,

--- a/src/features/settings/import-plan.test.ts
+++ b/src/features/settings/import-plan.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest"
+import type { BookmarkNode } from "@/browser"
+import { normalizeUrl, planImport } from "./import-plan"
+
+const TREE: BookmarkNode[] = [
+  {
+    id: "0",
+    title: "",
+    children: [
+      {
+        id: "dest",
+        title: "Destination",
+        children: [
+          { id: "old-a", title: "Old A", url: "https://a.com" },
+          {
+            id: "old-dev",
+            title: "Dev Tools",
+            children: [{ id: "old-b", title: "Old B", url: "https://b.com/" }],
+          },
+        ],
+      },
+    ],
+  },
+]
+
+function imported(nodes: BookmarkNode[]): BookmarkNode[] {
+  return nodes
+}
+
+describe("normalizeUrl", () => {
+  it("folds scheme and host case", () => {
+    expect(normalizeUrl("HTTPS://Example.COM/Path")).toBe(
+      normalizeUrl("https://example.com/Path")
+    )
+  })
+
+  it("treats a bare host and a trailing slash as the same place", () => {
+    expect(normalizeUrl("https://a.com")).toBe(normalizeUrl("https://a.com/"))
+  })
+
+  it("keeps the path case, which servers may care about", () => {
+    expect(normalizeUrl("https://a.com/A")).not.toBe(
+      normalizeUrl("https://a.com/a")
+    )
+  })
+
+  it("keeps distinct fragments apart", () => {
+    expect(normalizeUrl("https://a.com/#/inbox")).not.toBe(
+      normalizeUrl("https://a.com/#/sent")
+    )
+  })
+
+  it("falls back to the raw value for a schemeless or opaque URL", () => {
+    expect(normalizeUrl(" JavaScript:void(0) ")).toBe("javascript:void(0)")
+  })
+})
+
+describe("planImport", () => {
+  it("reports no conflicts for entirely new content", () => {
+    const plan = planImport(
+      TREE,
+      "dest",
+      imported([{ id: "1", title: "New", url: "https://new.com" }])
+    )
+
+    expect(plan.conflicts).toEqual([])
+    expect(plan.nodes).toEqual([
+      {
+        kind: "bookmark",
+        title: "New",
+        url: "https://new.com",
+        conflict: null,
+      },
+    ])
+  })
+
+  it("flags a bookmark whose URL is already in the destination", () => {
+    const plan = planImport(
+      TREE,
+      "dest",
+      imported([{ id: "1", title: "New A", url: "https://a.com/" }])
+    )
+
+    expect(plan.conflicts).toEqual([
+      {
+        key: "c0",
+        path: "",
+        incomingTitle: "New A",
+        existingTitle: "Old A",
+        url: "https://a.com/",
+      },
+    ])
+    expect(plan.nodes[0]).toMatchObject({
+      conflict: { key: "c0", existingId: "old-a" },
+    })
+  })
+
+  it("merges a folder of the same name instead of creating a second one", () => {
+    const plan = planImport(
+      TREE,
+      "dest",
+      imported([
+        {
+          id: "1",
+          title: "dev tools",
+          children: [{ id: "2", title: "C", url: "https://c.com" }],
+        },
+      ])
+    )
+
+    expect(plan.nodes[0]).toMatchObject({
+      kind: "folder",
+      title: "dev tools",
+      existingId: "old-dev",
+    })
+    expect(plan.conflicts).toEqual([])
+  })
+
+  it("compares one level deeper inside a merged folder", () => {
+    const plan = planImport(
+      TREE,
+      "dest",
+      imported([
+        {
+          id: "1",
+          title: "Dev Tools",
+          children: [{ id: "2", title: "New B", url: "https://b.com" }],
+        },
+      ])
+    )
+
+    expect(plan.conflicts).toEqual([
+      {
+        key: "c0",
+        path: "Dev Tools",
+        incomingTitle: "New B",
+        existingTitle: "Old B",
+        url: "https://b.com",
+      },
+    ])
+  })
+
+  it("does not flag a bookmark that only collides in a different folder", () => {
+    const plan = planImport(
+      TREE,
+      "dest",
+      imported([
+        {
+          id: "1",
+          title: "Elsewhere",
+          children: [{ id: "2", title: "A again", url: "https://a.com" }],
+        },
+      ])
+    )
+
+    expect(plan.conflicts).toEqual([])
+  })
+
+  it("does not treat duplicates inside the imported file as conflicts", () => {
+    const plan = planImport(
+      TREE,
+      "dest",
+      imported([
+        { id: "1", title: "New", url: "https://new.com" },
+        { id: "2", title: "New again", url: "https://new.com" },
+      ])
+    )
+
+    expect(plan.conflicts).toEqual([])
+    expect(plan.nodes).toHaveLength(2)
+  })
+
+  it("plans everything as new when the destination is not in the tree", () => {
+    const plan = planImport(
+      TREE,
+      "missing",
+      imported([{ id: "1", title: "Old A", url: "https://a.com" }])
+    )
+
+    expect(plan.conflicts).toEqual([])
+  })
+})

--- a/src/features/settings/import-plan.ts
+++ b/src/features/settings/import-plan.ts
@@ -119,6 +119,13 @@ export function planImport(
           }
         }
 
+        // One existing bookmark can only be skipped or replaced once. Claiming
+        // it here means a second incoming copy of the same URL is planned as
+        // new rather than pointed at the same node — otherwise "replace all"
+        // would fire two concurrent updates at one bookmark and leave whichever
+        // won as its title (or, on a revision-checking adapter, fail one).
+        existingByUrl.delete(normalizeUrl(node.url))
+
         const key = `c${keyCounter++}`
         conflicts.push({
           key,

--- a/src/features/settings/import-plan.ts
+++ b/src/features/settings/import-plan.ts
@@ -1,0 +1,168 @@
+import type { BookmarkNode } from "@/browser"
+
+export type ConflictResolution = "skip" | "replace" | "keep-both"
+
+/** A single incoming bookmark that already exists in its destination folder. */
+export interface ImportConflict {
+  /** Stable identity for the resolution map; opaque to the UI. */
+  key: string
+  /** " > "-joined folder path below the destination, for showing the user where. */
+  path: string
+  incomingTitle: string
+  existingTitle: string
+  url: string
+}
+
+export type ImportPlanNode =
+  | {
+      kind: "folder"
+      title: string
+      /** Set when an existing folder of the same name is being merged into. */
+      existingId: string | null
+      children: ImportPlanNode[]
+    }
+  | {
+      kind: "bookmark"
+      title: string
+      url: string
+      /** Set when this bookmark collides with one already in the destination. */
+      conflict: { key: string; existingId: string } | null
+    }
+
+export interface ImportPlan {
+  nodes: ImportPlanNode[]
+  conflicts: ImportConflict[]
+}
+
+/**
+ * Canonical form used to decide whether two bookmarks point at the same place.
+ *
+ * Scheme and host are case-insensitive per RFC 3986 and a default port means
+ * the same thing as no port, so those are folded. Path, query and fragment are
+ * left alone — `#/inbox` and `#/sent` are genuinely different bookmarks in a
+ * single-page app, and silently merging them would lose one.
+ */
+export function normalizeUrl(url: string): string {
+  const trimmed = url.trim()
+
+  try {
+    const parsed = new URL(trimmed)
+    // Opaque schemes (`javascript:`, `mailto:`, `place:`) have no authority to
+    // reassemble around; `href` already folds their scheme case for us.
+    if (!parsed.host) return parsed.href
+    const path = parsed.pathname === "/" ? "" : parsed.pathname
+    return `${parsed.protocol}//${parsed.host}${path}${parsed.search}${parsed.hash}`
+  } catch {
+    // `javascript:`, `place:` and friends have no comparable structure.
+    return trimmed.toLowerCase()
+  }
+}
+
+function sameFolderName(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase()
+}
+
+function findNodeById(nodes: BookmarkNode[], id: string): BookmarkNode | null {
+  for (const node of nodes) {
+    if (node.id === id) return node
+    const found = findNodeById(node.children ?? [], id)
+    if (found) return found
+  }
+  return null
+}
+
+/**
+ * Works out what importing `imported` under `destinationId` would actually do,
+ * without writing anything.
+ *
+ * Folders merge by name, the way a file manager merges directories: an
+ * incoming "Dev Tools" lands inside the existing "Dev Tools" instead of
+ * creating a second one, and its contents are then compared one level deeper.
+ * Bookmarks collide on URL within the folder they end up in, and each
+ * collision becomes a conflict for the user to resolve.
+ *
+ * Duplicates *within the imported file itself* are not conflicts — the file is
+ * what the user exported, and there is no existing node to skip or replace.
+ */
+export function planImport(
+  tree: BookmarkNode[],
+  destinationId: string,
+  imported: BookmarkNode[]
+): ImportPlan {
+  const destination = findNodeById(tree, destinationId)
+  const conflicts: ImportConflict[] = []
+  let keyCounter = 0
+
+  function planLevel(
+    nodes: BookmarkNode[],
+    existing: BookmarkNode[],
+    path: string[]
+  ): ImportPlanNode[] {
+    const existingByUrl = new Map<string, BookmarkNode>()
+    for (const node of existing) {
+      if (node.url === undefined) continue
+      const key = normalizeUrl(node.url)
+      // First one wins, so a destination that already holds duplicates
+      // resolves against a single, predictable node.
+      if (!existingByUrl.has(key)) existingByUrl.set(key, node)
+    }
+
+    return nodes.map((node): ImportPlanNode => {
+      if (node.url !== undefined) {
+        const match = existingByUrl.get(normalizeUrl(node.url))
+        if (!match) {
+          return {
+            kind: "bookmark",
+            title: node.title,
+            url: node.url,
+            conflict: null,
+          }
+        }
+
+        const key = `c${keyCounter++}`
+        conflicts.push({
+          key,
+          path: path.join(" > "),
+          incomingTitle: node.title,
+          existingTitle: match.title,
+          url: node.url,
+        })
+        return {
+          kind: "bookmark",
+          title: node.title,
+          url: node.url,
+          conflict: { key, existingId: match.id },
+        }
+      }
+
+      const match = existing.find(
+        (child) =>
+          child.url === undefined && sameFolderName(child.title, node.title)
+      )
+
+      return {
+        kind: "folder",
+        title: node.title,
+        existingId: match?.id ?? null,
+        children: planLevel(node.children ?? [], match?.children ?? [], [
+          ...path,
+          node.title,
+        ]),
+      }
+    })
+  }
+
+  return {
+    nodes: planLevel(imported, destination?.children ?? [], []),
+    conflicts,
+  }
+}
+
+/** Number of bookmarks a plan would leave untouched under the given choices. */
+export function countResolved(
+  conflicts: ImportConflict[],
+  resolutions: Record<string, ConflictResolution>,
+  resolution: ConflictResolution
+): number {
+  return conflicts.filter((c) => resolutions[c.key] === resolution).length
+}

--- a/src/features/settings/import-target.test.ts
+++ b/src/features/settings/import-target.test.ts
@@ -1,12 +1,36 @@
 import { describe, expect, it } from "vitest"
-import { resolveImportRootId } from "./import-target"
+import type { BookmarkNode } from "@/browser"
+import { resolveDefaultImportParentId } from "./import-target"
 
-describe("resolveImportRootId", () => {
-  it("returns the selected root folder id unchanged", () => {
-    expect(resolveImportRootId("42")).toBe("42")
+const BROWSER_TREE: BookmarkNode[] = [
+  {
+    id: "0",
+    title: "",
+    children: [
+      { id: "1", title: "Bookmarks Bar", children: [] },
+      { id: "2", title: "Other Bookmarks", children: [] },
+    ],
+  },
+]
+
+const VAULT_TREE: BookmarkNode[] = [
+  { id: "vault", title: "Bookmarks", children: [] },
+]
+
+describe("resolveDefaultImportParentId", () => {
+  it("prefers the selected dashboard root", () => {
+    expect(resolveDefaultImportParentId(BROWSER_TREE, "2", false)).toBe("2")
   })
 
-  it('throws a clear error instead of assuming root id "0" when no root folder is set', () => {
-    expect(() => resolveImportRootId(null)).toThrow(/root folder/i)
+  it("falls back to the Bookmarks Bar in browser mode, never the synthetic root", () => {
+    expect(resolveDefaultImportParentId(BROWSER_TREE, null, false)).toBe("1")
+  })
+
+  it("falls back to the vault root in daemon and standalone mode", () => {
+    expect(resolveDefaultImportParentId(VAULT_TREE, null, true)).toBe("vault")
+  })
+
+  it("returns null only when there is genuinely nowhere to write", () => {
+    expect(resolveDefaultImportParentId([], null, false)).toBeNull()
   })
 })

--- a/src/features/settings/import-target.ts
+++ b/src/features/settings/import-target.ts
@@ -1,15 +1,19 @@
 import type { BookmarkNode } from "@/browser"
-import { resolveEffectiveCreateParentId } from "@/features/root-folder-select"
+import { resolveCreateParentId } from "@/features/root-folder-select"
 
 /**
  * Resolves the folder an import should default to writing under.
  *
- * The dashboard root is the obvious answer when there is one. When there
- * isn't, importing must still work: a root folder is meaningless in daemon and
- * standalone mode, where the tree root is itself a real, writable folder, so
- * refusing the whole import until the user picks one (as this module used to)
- * locked those modes out of importing entirely. Falling back to the same
- * parent the create buttons use keeps every mode consistent.
+ * The dashboard root is the obvious answer when there is one — and when it
+ * still exists; a saved id that no longer resolves is treated as absent rather
+ * than used, since importing into a deleted folder fails every single write.
+ *
+ * When there is no usable root, importing must still work: a root folder is
+ * meaningless in daemon and standalone mode, where the tree root is itself a
+ * real, writable folder, so refusing the whole import until the user picks one
+ * (as this module used to) locked those modes out of importing entirely.
+ * Falling back to the same parent the create buttons use keeps every mode
+ * consistent.
  *
  * Returns `null` only when there is genuinely nowhere to write — an empty tree
  * with a browser adapter, whose synthetic root is not a valid parent.
@@ -19,5 +23,5 @@ export function resolveDefaultImportParentId(
   rootFolderId: string | null,
   rootIsCreatable: boolean
 ): string | null {
-  return rootFolderId ?? resolveEffectiveCreateParentId(tree, rootIsCreatable)
+  return resolveCreateParentId(tree, rootFolderId, rootIsCreatable)
 }

--- a/src/features/settings/import-target.ts
+++ b/src/features/settings/import-target.ts
@@ -1,18 +1,23 @@
+import type { BookmarkNode } from "@/browser"
+import { resolveEffectiveCreateParentId } from "@/features/root-folder-select"
+
 /**
- * Resolves the folder id that imported bookmarks should be written under.
+ * Resolves the folder an import should default to writing under.
  *
- * There is no universally valid "root" id to fall back to: "0" happens to be
- * Chrome's invisible tree-root id, which chrome.bookmarks.create() rejects
- * as a parent, and it does not correspond to any real folder in Firefox or
- * the standalone adapter. Importing without a selected root folder must fail
- * clearly instead of silently writing bookmarks nowhere (standalone) or
- * throwing an adapter-level error the user can't make sense of (Chrome).
+ * The dashboard root is the obvious answer when there is one. When there
+ * isn't, importing must still work: a root folder is meaningless in daemon and
+ * standalone mode, where the tree root is itself a real, writable folder, so
+ * refusing the whole import until the user picks one (as this module used to)
+ * locked those modes out of importing entirely. Falling back to the same
+ * parent the create buttons use keeps every mode consistent.
+ *
+ * Returns `null` only when there is genuinely nowhere to write — an empty tree
+ * with a browser adapter, whose synthetic root is not a valid parent.
  */
-export function resolveImportRootId(rootFolderId: string | null): string {
-  if (!rootFolderId) {
-    throw new Error(
-      "Choose a root folder in Settings before importing bookmarks."
-    )
-  }
-  return rootFolderId
+export function resolveDefaultImportParentId(
+  tree: BookmarkNode[],
+  rootFolderId: string | null,
+  rootIsCreatable: boolean
+): string | null {
+  return rootFolderId ?? resolveEffectiveCreateParentId(tree, rootIsCreatable)
 }

--- a/src/features/settings/settings-dialog.tsx
+++ b/src/features/settings/settings-dialog.tsx
@@ -15,16 +15,58 @@ import {
   SelectItem,
   SelectTrigger,
 } from "@/components/ui/select"
+import { Input } from "@/components/ui/input"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { useUIStore } from "@/stores/ui-store"
 import { usePreferencesStore } from "@/stores/preferences-store"
 import { useBookmarkStore } from "@/stores/bookmark-store"
-import { RootFolderSelect } from "@/features/root-folder-select"
+import {
+  RootFolderSelect,
+  buildRootFolderOptions,
+} from "@/features/root-folder-select"
 import { serializeNetscapeBookmarks } from "@/browser/import-export/netscape-serializer"
 import { parseNetscapeBookmarks } from "@/browser/import-export/netscape-parser"
 import { isDaemonModeSupported } from "@/browser/daemon"
-import { resolveImportRootId } from "./import-target"
+import { resolveDefaultImportParentId } from "./import-target"
+import { importBookmarkNodes, formatImportResult } from "./import-bookmarks"
+import {
+  resolveExportTree,
+  exportFileName,
+  type ExportScope,
+} from "./export-scope"
 import { DaemonConnectionPanel } from "./daemon-connection-panel"
 import type { BookmarkNode } from "@/browser"
+
+/** A parsed file waiting for the user to confirm where it should land. */
+interface PendingImport {
+  nodes: BookmarkNode[]
+  folders: number
+  bookmarks: number
+}
+
+function summarize(nodes: BookmarkNode[]): {
+  folders: number
+  bookmarks: number
+} {
+  let folders = 0
+  let bookmarks = 0
+  for (const node of nodes) {
+    if (node.url) {
+      bookmarks += 1
+    } else {
+      folders += 1
+      const nested = summarize(node.children ?? [])
+      folders += nested.folders
+      bookmarks += nested.bookmarks
+    }
+  }
+  return { folders, bookmarks }
+}
 
 export function SettingsDialog() {
   const open = useUIStore((s) => s.settingsOpen)
@@ -51,13 +93,38 @@ export function SettingsDialog() {
   const containerMode = usePreferencesStore((s) => s.containerMode)
   const setContainerMode = usePreferencesStore((s) => s.setContainerMode)
 
-  const handleExport = () => {
-    const html = serializeNetscapeBookmarks(tree)
+  const [pendingImport, setPendingImport] =
+    React.useState<PendingImport | null>(null)
+  const [importParentId, setImportParentId] = React.useState<string | null>(
+    null
+  )
+  const [importFolderName, setImportFolderName] = React.useState("")
+  const [importStatus, setImportStatus] = React.useState<string | null>(null)
+  const [isImporting, setIsImporting] = React.useState(false)
+
+  const folderOptions = React.useMemo(
+    () => buildRootFolderOptions(tree),
+    [tree]
+  )
+
+  const defaultImportParentId = React.useMemo(
+    () =>
+      resolveDefaultImportParentId(
+        tree,
+        rootFolderId,
+        adapter?.capabilities.rootIsCreatable ?? false
+      ),
+    [tree, rootFolderId, adapter]
+  )
+
+  const handleExport = (scope: ExportScope) => {
+    const exported = resolveExportTree(tree, rootFolderId, scope)
+    const html = serializeNetscapeBookmarks(exported)
     const blob = new Blob([html], { type: "text/html" })
     const url = URL.createObjectURL(blob)
     const a = document.createElement("a")
     a.href = url
-    a.download = "bookmarks.html"
+    a.download = exportFileName(scope, exported[0]?.title ?? null)
     a.click()
     URL.revokeObjectURL(url)
   }
@@ -68,76 +135,82 @@ export function SettingsDialog() {
     openOnboarding()
   }
 
-  const handleImport = () => {
+  const handlePickImportFile = () => {
     const input = document.createElement("input")
     input.type = "file"
     input.accept = ".html,.htm"
     input.onchange = async (e) => {
       const file = (e.target as HTMLInputElement).files?.[0]
-      if (!file || !adapter) return
+      if (!file) return
 
-      let targetRootId: string
+      setImportStatus(null)
+
+      let nodes: BookmarkNode[]
       try {
-        targetRootId = resolveImportRootId(rootFolderId)
+        nodes = parseNetscapeBookmarks(await file.text()).flatMap(
+          (root) => root.children ?? []
+        )
       } catch (error) {
-        window.alert(error instanceof Error ? error.message : "Import failed.")
+        setImportStatus(
+          `Could not read that file: ${error instanceof Error ? error.message : String(error)}`
+        )
         return
       }
 
-      const text = await file.text()
-      const imported = parseNetscapeBookmarks(text)
-
-      async function writeNodesParallel(
-        nodes: BookmarkNode[],
-        parentId: string,
-        concurrency = 8
-      ): Promise<void> {
-        const folders: BookmarkNode[] = []
-        const leaves: BookmarkNode[] = []
-        for (const node of nodes) {
-          if (node.url) leaves.push(node)
-          else if (node.children) folders.push(node)
-        }
-
-        for (let i = 0; i < leaves.length; i += concurrency) {
-          const batch = leaves.slice(i, i + concurrency)
-          await Promise.all(
-            batch.map((node) =>
-              adapter!.bookmarks.create({
-                parentId,
-                title: node.title,
-                url: node.url,
-              })
-            )
-          )
-        }
-
-        const createdFolders = await Promise.all(
-          folders.map((node) =>
-            adapter!.bookmarks.create({ parentId, title: node.title })
-          )
-        )
-
-        await Promise.all(
-          folders.map((node, i) =>
-            writeNodesParallel(
-              node.children ?? [],
-              createdFolders[i].id,
-              concurrency
-            )
-          )
-        )
+      if (nodes.length === 0) {
+        setImportStatus("That file contains no bookmarks.")
+        return
       }
 
-      for (const root of imported) {
-        if (root.children) {
-          await writeNodesParallel(root.children, targetRootId)
-        }
-      }
-
-      await refresh()
+      // Ask where it goes only once a file is in hand, so the counts below
+      // can tell the user what they are about to import.
+      setPendingImport({ nodes, ...summarize(nodes) })
+      setImportParentId(defaultImportParentId)
+      setImportFolderName("")
     }
     input.click()
+  }
+
+  const cancelImport = () => {
+    setPendingImport(null)
+    setImportFolderName("")
+  }
+
+  const handleConfirmImport = async () => {
+    if (!pendingImport || !adapter || !importParentId) return
+
+    setIsImporting(true)
+    setImportStatus(null)
+    try {
+      let target = importParentId
+
+      const subfolder = importFolderName.trim()
+      if (subfolder) {
+        const created = await adapter.bookmarks.create({
+          parentId: target,
+          title: subfolder,
+        })
+        target = created.id
+      }
+
+      const result = await importBookmarkNodes(
+        adapter.bookmarks,
+        pendingImport.nodes,
+        target
+      )
+      await refresh()
+      setImportStatus(formatImportResult(result))
+      setPendingImport(null)
+      setImportFolderName("")
+    } catch (error) {
+      // Only reached when the destination itself could not be created —
+      // per-node failures are counted inside `importBookmarkNodes`.
+      setImportStatus(
+        `Import failed: ${error instanceof Error ? error.message : String(error)}`
+      )
+    } finally {
+      setIsImporting(false)
+    }
   }
 
   return (
@@ -289,22 +362,102 @@ export function SettingsDialog() {
               <div className="flex flex-col gap-2">
                 <Label className="text-sm font-medium">Bookmarks Data</Label>
                 <div className="flex gap-2">
-                  {/* The vault is the source of truth in daemon mode, so
-                      client-side HTML import isn't offered there yet. */}
-                  {import.meta.env.VITE_BUILD_TARGET !== "daemon" && (
-                    <Button variant="outline" size="sm" onClick={handleImport}>
-                      Import
-                    </Button>
-                  )}
-                  <Button variant="outline" size="sm" onClick={handleExport}>
-                    Export
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={!adapter || !defaultImportParentId}
+                    onClick={handlePickImportFile}
+                  >
+                    Import
                   </Button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger
+                      render={
+                        <Button variant="outline" size="sm">
+                          Export
+                        </Button>
+                      }
+                    />
+                    <DropdownMenuContent align="start">
+                      <DropdownMenuItem
+                        onClick={() => handleExport("dashboard")}
+                      >
+                        Dashboard folder
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => handleExport("everything")}
+                      >
+                        Everything
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  {import.meta.env.VITE_BUILD_TARGET === "daemon"
-                    ? "Export bookmarks as HTML (standard browser format)."
-                    : "Import or export bookmarks as HTML (standard browser format)."}
+                  Import or export bookmarks as HTML (standard browser format).
                 </p>
+
+                {pendingImport && (
+                  <div className="flex flex-col gap-2 rounded-lg border border-dashed border-border/70 p-3">
+                    <p className="text-xs text-muted-foreground">
+                      Found {pendingImport.bookmarks} bookmark
+                      {pendingImport.bookmarks === 1 ? "" : "s"} in{" "}
+                      {pendingImport.folders} folder
+                      {pendingImport.folders === 1 ? "" : "s"}. Choose where to
+                      put them.
+                    </p>
+
+                    <Select
+                      value={importParentId ?? ""}
+                      onValueChange={setImportParentId}
+                    >
+                      <SelectTrigger className="w-full">
+                        <span className="truncate">
+                          {folderOptions.find((f) => f.id === importParentId)
+                            ?.label ?? "Select a folder"}
+                        </span>
+                      </SelectTrigger>
+                      <SelectContent>
+                        {folderOptions.map((folder) => (
+                          <SelectItem key={folder.id} value={folder.id}>
+                            {folder.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+
+                    <Input
+                      value={importFolderName}
+                      onChange={(e) => setImportFolderName(e.target.value)}
+                      placeholder="Optional: import into a new subfolder"
+                      aria-label="New subfolder name"
+                      disabled={isImporting}
+                    />
+
+                    <div className="flex gap-2">
+                      <Button
+                        size="sm"
+                        disabled={isImporting || !importParentId}
+                        onClick={() => void handleConfirmImport()}
+                      >
+                        {isImporting ? "Importing…" : "Import here"}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={isImporting}
+                        onClick={cancelImport}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {importStatus && (
+                  <p role="status" className="text-xs text-muted-foreground">
+                    {importStatus}
+                  </p>
+                )}
               </div>
 
               <div className="flex flex-col gap-2">

--- a/src/features/settings/settings-dialog.tsx
+++ b/src/features/settings/settings-dialog.tsx
@@ -17,6 +17,11 @@ import {
 } from "@/components/ui/select"
 import { Input } from "@/components/ui/input"
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -397,14 +402,27 @@ export function SettingsDialog() {
                 <div className="flex flex-col gap-2">
                   <Label className="text-sm font-medium">Bookmarks Data</Label>
                   <div className="flex gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={!adapter || !defaultImportParentId}
-                      onClick={handlePickImportFile}
-                    >
-                      Import
-                    </Button>
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={!adapter || !defaultImportParentId}
+                            onClick={handlePickImportFile}
+                          >
+                            Import
+                          </Button>
+                        }
+                      />
+                      {!adapter || !defaultImportParentId ? (
+                        <TooltipContent side="bottom">
+                          {adapter
+                            ? "There is no folder to import into yet. Create one first, or choose a root folder above."
+                            : "Bookmarks are still loading."}
+                        </TooltipContent>
+                      ) : null}
+                    </Tooltip>
                     <DropdownMenu>
                       <DropdownMenuTrigger
                         render={
@@ -414,7 +432,16 @@ export function SettingsDialog() {
                         }
                       />
                       <DropdownMenuContent align="start">
+                        {/* With no root folder chosen there is nothing to
+                            narrow to, so this would hand back the same file
+                            as "Everything" — two entries, one outcome. */}
                         <DropdownMenuItem
+                          disabled={!rootFolderId}
+                          title={
+                            rootFolderId
+                              ? undefined
+                              : "Choose a root folder above to export just that folder."
+                          }
                           onClick={() => handleExport("dashboard")}
                         >
                           Dashboard folder
@@ -473,6 +500,11 @@ export function SettingsDialog() {
                         <Button
                           size="sm"
                           disabled={isImporting || !importParentId}
+                          title={
+                            importParentId
+                              ? undefined
+                              : "Pick a destination folder first."
+                          }
                           onClick={() => void handleConfirmImport()}
                         >
                           {isImporting ? "Importing…" : "Import here"}

--- a/src/features/settings/settings-dialog.tsx
+++ b/src/features/settings/settings-dialog.tsx
@@ -29,6 +29,7 @@ import type { BookmarkNode } from "@/browser"
 export function SettingsDialog() {
   const open = useUIStore((s) => s.settingsOpen)
   const closeSettings = useUIStore((s) => s.closeSettings)
+  const openOnboarding = useUIStore((s) => s.openOnboarding)
   const nestedFolders = usePreferencesStore((s) => s.nestedFolders)
   const setNestedFolders = usePreferencesStore((s) => s.setNestedFolders)
   const rootFolderId = useBookmarkStore((s) => s.rootFolderId)
@@ -59,6 +60,12 @@ export function SettingsDialog() {
     a.download = "bookmarks.html"
     a.click()
     URL.revokeObjectURL(url)
+  }
+
+  const handleShowOnboarding = async () => {
+    await adapter?.storage.set("onboardingCompleted", false)
+    closeSettings()
+    openOnboarding()
   }
 
   const handleImport = () => {
@@ -297,6 +304,23 @@ export function SettingsDialog() {
                   {import.meta.env.VITE_BUILD_TARGET === "daemon"
                     ? "Export bookmarks as HTML (standard browser format)."
                     : "Import or export bookmarks as HTML (standard browser format)."}
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <Label className="text-sm font-medium">Setup Wizard</Label>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void handleShowOnboarding()}
+                  >
+                    Show setup wizard
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Walk through the first-run setup again, including choosing a
+                  bookmark source and a root folder.
                 </p>
               </div>
             </div>

--- a/src/features/settings/settings-dialog.tsx
+++ b/src/features/settings/settings-dialog.tsx
@@ -33,7 +33,13 @@ import { serializeNetscapeBookmarks } from "@/browser/import-export/netscape-ser
 import { parseNetscapeBookmarks } from "@/browser/import-export/netscape-parser"
 import { isDaemonModeSupported } from "@/browser/daemon"
 import { resolveDefaultImportParentId } from "./import-target"
-import { importBookmarkNodes, formatImportResult } from "./import-bookmarks"
+import { executeImportPlan, formatImportResult } from "./import-bookmarks"
+import {
+  planImport,
+  type ConflictResolution,
+  type ImportPlan,
+} from "./import-plan"
+import { ImportConflictDialog } from "./import-conflict-dialog"
 import {
   resolveExportTree,
   exportFileName,
@@ -101,6 +107,10 @@ export function SettingsDialog() {
   const [importFolderName, setImportFolderName] = React.useState("")
   const [importStatus, setImportStatus] = React.useState<string | null>(null)
   const [isImporting, setIsImporting] = React.useState(false)
+  const [activePlan, setActivePlan] = React.useState<{
+    plan: ImportPlan
+    parentId: string
+  } | null>(null)
 
   const folderOptions = React.useMemo(
     () => buildRootFolderOptions(tree),
@@ -174,312 +184,339 @@ export function SettingsDialog() {
   const cancelImport = () => {
     setPendingImport(null)
     setImportFolderName("")
+    setActivePlan(null)
   }
 
-  const handleConfirmImport = async () => {
-    if (!pendingImport || !adapter || !importParentId) return
+  const runPlan = async (
+    plan: ImportPlan,
+    parentId: string,
+    resolutions: Record<string, ConflictResolution>
+  ) => {
+    if (!adapter) return
 
+    setActivePlan(null)
     setIsImporting(true)
-    setImportStatus(null)
     try {
-      let target = importParentId
-
-      const subfolder = importFolderName.trim()
-      if (subfolder) {
-        const created = await adapter.bookmarks.create({
-          parentId: target,
-          title: subfolder,
-        })
-        target = created.id
-      }
-
-      const result = await importBookmarkNodes(
+      const result = await executeImportPlan(
         adapter.bookmarks,
-        pendingImport.nodes,
-        target
+        plan.nodes,
+        parentId,
+        resolutions
       )
       await refresh()
       setImportStatus(formatImportResult(result))
       setPendingImport(null)
       setImportFolderName("")
-    } catch (error) {
-      // Only reached when the destination itself could not be created —
-      // per-node failures are counted inside `importBookmarkNodes`.
-      setImportStatus(
-        `Import failed: ${error instanceof Error ? error.message : String(error)}`
-      )
     } finally {
       setIsImporting(false)
     }
   }
 
+  const handleConfirmImport = async () => {
+    if (!pendingImport || !adapter || !importParentId) return
+
+    setImportStatus(null)
+
+    // The optional subfolder rides along as a plain folder in the tree being
+    // imported, so it goes through the same name-merging as everything else
+    // instead of blindly creating a second folder of that name.
+    const subfolder = importFolderName.trim()
+    const nodes: BookmarkNode[] = subfolder
+      ? [{ id: "", title: subfolder, children: pendingImport.nodes }]
+      : pendingImport.nodes
+
+    const plan = planImport(tree, importParentId, nodes)
+
+    if (plan.conflicts.length > 0) {
+      // Nothing has been written yet, so cancelling from here is free.
+      setActivePlan({ plan, parentId: importParentId })
+      return
+    }
+
+    await runPlan(plan, importParentId, {})
+  }
+
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(o) => {
-        if (!o) closeSettings()
-      }}
-    >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Settings</DialogTitle>
-          <DialogDescription>
-            Configure your bookmarks dashboard.
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      {activePlan && (
+        <ImportConflictDialog
+          conflicts={activePlan.plan.conflicts}
+          onCancel={cancelImport}
+          onResolve={(resolutions) =>
+            void runPlan(activePlan.plan, activePlan.parentId, resolutions)
+          }
+        />
+      )}
+      <Dialog
+        open={open}
+        onOpenChange={(o) => {
+          if (!o) closeSettings()
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Settings</DialogTitle>
+            <DialogDescription>
+              Configure your bookmarks dashboard.
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="-mx-4 no-scrollbar max-h-[50vh] overflow-y-auto px-4">
-          <div className="flex flex-col gap-6">
-            {/* Bookmarks section */}
-            <RootFolderSelect
-              value={rootFolderId}
-              onChange={setRootFolderId}
-              label="Root Folder"
-              description="Choose which folder to display as the root of your bookmarks."
-            />
-
-            <div className="flex items-center justify-between">
-              <div className="flex flex-col gap-1">
-                <Label className="text-sm font-medium">Nested Folders</Label>
-                <p className="text-xs text-muted-foreground">
-                  Show subfolders inside their parent cards.
-                </p>
-              </div>
-              <Switch
-                checked={nestedFolders}
-                onCheckedChange={(checked) => setNestedFolders(checked)}
+          <div className="-mx-4 no-scrollbar max-h-[50vh] overflow-y-auto px-4">
+            <div className="flex flex-col gap-6">
+              {/* Bookmarks section */}
+              <RootFolderSelect
+                value={rootFolderId}
+                onChange={setRootFolderId}
+                label="Root Folder"
+                description="Choose which folder to display as the root of your bookmarks."
               />
-            </div>
 
-            {/* Layout section */}
-            <div className="flex flex-col gap-4">
-              <div className="border-t pt-4">
-                <span className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-                  Layout
-                </span>
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-1">
+                  <Label className="text-sm font-medium">Nested Folders</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Show subfolders inside their parent cards.
+                  </p>
+                </div>
+                <Switch
+                  checked={nestedFolders}
+                  onCheckedChange={(checked) => setNestedFolders(checked)}
+                />
               </div>
 
-              <div className="flex flex-col gap-2">
-                <Label className="text-sm font-medium">Max Columns</Label>
-                <Select
-                  value={String(maxColumns)}
-                  onValueChange={(val) => setMaxColumns(Number(val))}
-                >
-                  <SelectTrigger className="w-full">
-                    <span>{maxColumns} columns</span>
-                  </SelectTrigger>
-                  <SelectContent>
-                    {[2, 3, 4, 5, 6].map((n) => (
-                      <SelectItem key={n} value={String(n)}>
-                        {n} columns
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="text-xs text-muted-foreground">
-                  Maximum number of columns in the dashboard grid. Fewer columns
-                  are used on smaller screens.
-                </p>
-              </div>
+              {/* Layout section */}
+              <div className="flex flex-col gap-4">
+                <div className="border-t pt-4">
+                  <span className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                    Layout
+                  </span>
+                </div>
 
-              <div className="flex flex-col gap-2">
-                <Label className="text-sm font-medium">Container</Label>
-                <Select
-                  value={containerMode}
-                  onValueChange={(val) =>
-                    setContainerMode(val as "fluid" | "contained")
-                  }
-                >
-                  <SelectTrigger className="w-full">
-                    <span>
-                      {containerMode === "fluid" ? "Fluid" : "Contained"}
-                    </span>
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="fluid">Fluid</SelectItem>
-                    <SelectItem value="contained">Contained</SelectItem>
-                  </SelectContent>
-                </Select>
-                <p className="text-xs text-muted-foreground">
-                  Contained limits the dashboard to 1440px wide and centers it
-                  on the screen.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-4">
-              <div className="border-t pt-4">
-                <span className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-                  Data
-                </span>
-              </div>
-
-              {/* Adapter mode: not applicable in the daemon build, which always
-                  serves its own same-origin daemon adapter. */}
-              {import.meta.env.VITE_BUILD_TARGET !== "daemon" && (
                 <div className="flex flex-col gap-2">
-                  <Label className="text-sm font-medium">Bookmark Source</Label>
-                  <div className="flex gap-2">
-                    {(["browser", "standalone"] as const).map((mode) => (
-                      <Button
-                        key={mode}
-                        variant={
-                          adapterMode === mode && !daemonSelected
-                            ? "default"
-                            : "outline"
-                        }
-                        size="sm"
-                        onClick={() => {
-                          setDaemonSelected(false)
-                          setAdapterMode(mode)
-                        }}
-                        className="capitalize"
-                      >
-                        {mode === "browser" ? "Browser" : "Standalone"}
-                      </Button>
-                    ))}
-                    {/* Hidden rather than shown-and-broken on a mobile
+                  <Label className="text-sm font-medium">Max Columns</Label>
+                  <Select
+                    value={String(maxColumns)}
+                    onValueChange={(val) => setMaxColumns(Number(val))}
+                  >
+                    <SelectTrigger className="w-full">
+                      <span>{maxColumns} columns</span>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {[2, 3, 4, 5, 6].map((n) => (
+                        <SelectItem key={n} value={String(n)}>
+                          {n} columns
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Maximum number of columns in the dashboard grid. Fewer
+                    columns are used on smaller screens.
+                  </p>
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <Label className="text-sm font-medium">Container</Label>
+                  <Select
+                    value={containerMode}
+                    onValueChange={(val) =>
+                      setContainerMode(val as "fluid" | "contained")
+                    }
+                  >
+                    <SelectTrigger className="w-full">
+                      <span>
+                        {containerMode === "fluid" ? "Fluid" : "Contained"}
+                      </span>
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="fluid">Fluid</SelectItem>
+                      <SelectItem value="contained">Contained</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Contained limits the dashboard to 1440px wide and centers it
+                    on the screen.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-4">
+                <div className="border-t pt-4">
+                  <span className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                    Data
+                  </span>
+                </div>
+
+                {/* Adapter mode: not applicable in the daemon build, which always
+                  serves its own same-origin daemon adapter. */}
+                {import.meta.env.VITE_BUILD_TARGET !== "daemon" && (
+                  <div className="flex flex-col gap-2">
+                    <Label className="text-sm font-medium">
+                      Bookmark Source
+                    </Label>
+                    <div className="flex gap-2">
+                      {(["browser", "standalone"] as const).map((mode) => (
+                        <Button
+                          key={mode}
+                          variant={
+                            adapterMode === mode && !daemonSelected
+                              ? "default"
+                              : "outline"
+                          }
+                          size="sm"
+                          onClick={() => {
+                            setDaemonSelected(false)
+                            setAdapterMode(mode)
+                          }}
+                          className="capitalize"
+                        >
+                          {mode === "browser" ? "Browser" : "Standalone"}
+                        </Button>
+                      ))}
+                      {/* Hidden rather than shown-and-broken on a mobile
                         browser: there is no local daemon to reach there. */}
-                    {daemonModeSupported && (
-                      <Button
-                        variant={showDaemonPanel ? "default" : "outline"}
-                        size="sm"
-                        onClick={() => setDaemonSelected(true)}
-                      >
-                        Daemon
-                      </Button>
-                    )}
+                      {daemonModeSupported && (
+                        <Button
+                          variant={showDaemonPanel ? "default" : "outline"}
+                          size="sm"
+                          onClick={() => setDaemonSelected(true)}
+                        >
+                          Daemon
+                        </Button>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Use browser bookmarks, manage an independent collection,
+                      or connect to a local <code>bbb</code> daemon. Browser and
+                      Standalone require a page reload to take effect.
+                    </p>
+                    {showDaemonPanel && <DaemonConnectionPanel />}
+                  </div>
+                )}
+
+                <div className="flex flex-col gap-2">
+                  <Label className="text-sm font-medium">Bookmarks Data</Label>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={!adapter || !defaultImportParentId}
+                      onClick={handlePickImportFile}
+                    >
+                      Import
+                    </Button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger
+                        render={
+                          <Button variant="outline" size="sm">
+                            Export
+                          </Button>
+                        }
+                      />
+                      <DropdownMenuContent align="start">
+                        <DropdownMenuItem
+                          onClick={() => handleExport("dashboard")}
+                        >
+                          Dashboard folder
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => handleExport("everything")}
+                        >
+                          Everything
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    Use browser bookmarks, manage an independent collection, or
-                    connect to a local <code>bbb</code> daemon. Browser and
-                    Standalone require a page reload to take effect.
+                    Import or export bookmarks as HTML (standard browser
+                    format).
                   </p>
-                  {showDaemonPanel && <DaemonConnectionPanel />}
-                </div>
-              )}
 
-              <div className="flex flex-col gap-2">
-                <Label className="text-sm font-medium">Bookmarks Data</Label>
-                <div className="flex gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={!adapter || !defaultImportParentId}
-                    onClick={handlePickImportFile}
-                  >
-                    Import
-                  </Button>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger
-                      render={
-                        <Button variant="outline" size="sm">
-                          Export
-                        </Button>
-                      }
-                    />
-                    <DropdownMenuContent align="start">
-                      <DropdownMenuItem
-                        onClick={() => handleExport("dashboard")}
+                  {pendingImport && (
+                    <div className="flex flex-col gap-2 rounded-lg border border-dashed border-border/70 p-3">
+                      <p className="text-xs text-muted-foreground">
+                        Found {pendingImport.bookmarks} bookmark
+                        {pendingImport.bookmarks === 1 ? "" : "s"} in{" "}
+                        {pendingImport.folders} folder
+                        {pendingImport.folders === 1 ? "" : "s"}. Choose where
+                        to put them.
+                      </p>
+
+                      <Select
+                        value={importParentId ?? ""}
+                        onValueChange={setImportParentId}
                       >
-                        Dashboard folder
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => handleExport("everything")}
-                      >
-                        Everything
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  Import or export bookmarks as HTML (standard browser format).
-                </p>
+                        <SelectTrigger className="w-full">
+                          <span className="truncate">
+                            {folderOptions.find((f) => f.id === importParentId)
+                              ?.label ?? "Select a folder"}
+                          </span>
+                        </SelectTrigger>
+                        <SelectContent>
+                          {folderOptions.map((folder) => (
+                            <SelectItem key={folder.id} value={folder.id}>
+                              {folder.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
 
-                {pendingImport && (
-                  <div className="flex flex-col gap-2 rounded-lg border border-dashed border-border/70 p-3">
-                    <p className="text-xs text-muted-foreground">
-                      Found {pendingImport.bookmarks} bookmark
-                      {pendingImport.bookmarks === 1 ? "" : "s"} in{" "}
-                      {pendingImport.folders} folder
-                      {pendingImport.folders === 1 ? "" : "s"}. Choose where to
-                      put them.
-                    </p>
-
-                    <Select
-                      value={importParentId ?? ""}
-                      onValueChange={setImportParentId}
-                    >
-                      <SelectTrigger className="w-full">
-                        <span className="truncate">
-                          {folderOptions.find((f) => f.id === importParentId)
-                            ?.label ?? "Select a folder"}
-                        </span>
-                      </SelectTrigger>
-                      <SelectContent>
-                        {folderOptions.map((folder) => (
-                          <SelectItem key={folder.id} value={folder.id}>
-                            {folder.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-
-                    <Input
-                      value={importFolderName}
-                      onChange={(e) => setImportFolderName(e.target.value)}
-                      placeholder="Optional: import into a new subfolder"
-                      aria-label="New subfolder name"
-                      disabled={isImporting}
-                    />
-
-                    <div className="flex gap-2">
-                      <Button
-                        size="sm"
-                        disabled={isImporting || !importParentId}
-                        onClick={() => void handleConfirmImport()}
-                      >
-                        {isImporting ? "Importing…" : "Import here"}
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
+                      <Input
+                        value={importFolderName}
+                        onChange={(e) => setImportFolderName(e.target.value)}
+                        placeholder="Optional: import into a new subfolder"
+                        aria-label="New subfolder name"
                         disabled={isImporting}
-                        onClick={cancelImport}
-                      >
-                        Cancel
-                      </Button>
+                      />
+
+                      <div className="flex gap-2">
+                        <Button
+                          size="sm"
+                          disabled={isImporting || !importParentId}
+                          onClick={() => void handleConfirmImport()}
+                        >
+                          {isImporting ? "Importing…" : "Import here"}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={isImporting}
+                          onClick={cancelImport}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
 
-                {importStatus && (
-                  <p role="status" className="text-xs text-muted-foreground">
-                    {importStatus}
-                  </p>
-                )}
-              </div>
-
-              <div className="flex flex-col gap-2">
-                <Label className="text-sm font-medium">Setup Wizard</Label>
-                <div className="flex gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => void handleShowOnboarding()}
-                  >
-                    Show setup wizard
-                  </Button>
+                  {importStatus && (
+                    <p role="status" className="text-xs text-muted-foreground">
+                      {importStatus}
+                    </p>
+                  )}
                 </div>
-                <p className="text-xs text-muted-foreground">
-                  Walk through the first-run setup again, including choosing a
-                  bookmark source and a root folder.
-                </p>
+
+                <div className="flex flex-col gap-2">
+                  <Label className="text-sm font-medium">Setup Wizard</Label>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => void handleShowOnboarding()}
+                    >
+                      Show setup wizard
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Walk through the first-run setup again, including choosing a
+                    bookmark source and a root folder.
+                  </p>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/src/hooks/use-app-bootstrap.ts
+++ b/src/hooks/use-app-bootstrap.ts
@@ -2,6 +2,7 @@ import * as React from "react"
 import { detectAdapter } from "@/browser"
 import { useBookmarkStore } from "@/stores/bookmark-store"
 import { usePreferencesStore } from "@/stores/preferences-store"
+import { useUIStore } from "@/stores/ui-store"
 import { getScreenshotMode } from "@/hooks/use-screenshot-mode"
 
 /**
@@ -16,7 +17,7 @@ import { getScreenshotMode } from "@/hooks/use-screenshot-mode"
 export function useAppBootstrap() {
   const initBookmarks = useBookmarkStore((s) => s.init)
   const initPreferences = usePreferencesStore((s) => s.init)
-  const [showOnboarding, setShowOnboarding] = React.useState(false)
+  const openOnboarding = useUIStore((s) => s.openOnboarding)
   const [onboardingChecked, setOnboardingChecked] = React.useState(false)
   const screenshotMode = React.useMemo(() => getScreenshotMode(), [])
 
@@ -38,16 +39,16 @@ export function useAppBootstrap() {
       cleanupBookmarks = bookmarksCleanup ?? undefined
 
       if (screenshotMode === "onboarding") {
-        setShowOnboarding(true)
+        openOnboarding()
       } else if (!screenshotMode) {
         const onboardingCompleted = await adapter.storage.get<boolean>(
           "onboardingCompleted"
         )
         if (!cancelled && !onboardingCompleted) {
-          setShowOnboarding(true)
+          openOnboarding()
         }
       }
-      // screenshotMode === 'default': showOnboarding stays false (suppressed)
+      // screenshotMode === 'default': onboarding stays hidden (suppressed)
 
       if (!cancelled) {
         setOnboardingChecked(true)
@@ -60,11 +61,9 @@ export function useAppBootstrap() {
       cancelled = true
       cleanupBookmarks?.()
     }
-  }, [initBookmarks, initPreferences, screenshotMode])
+  }, [initBookmarks, initPreferences, openOnboarding, screenshotMode])
 
   return {
-    showOnboarding,
-    setShowOnboarding,
     onboardingChecked,
     screenshotMode,
   }

--- a/src/index.css
+++ b/src/index.css
@@ -49,6 +49,7 @@
 }
 
 :root {
+    color-scheme: light;
     --radius: 0.65rem;
     --background: oklch(1 0 0);
     --foreground: oklch(0.145 0 0);
@@ -85,6 +86,7 @@
 }
 
 .dark {
+    color-scheme: dark;
     --background: oklch(0.145 0 0);
     --foreground: oklch(0.985 0 0);
     --card: oklch(0.205 0 0);

--- a/src/stores/bookmark-store.ts
+++ b/src/stores/bookmark-store.ts
@@ -128,7 +128,8 @@ interface BookmarkState {
   ): Promise<void>
   deleteBookmark(id: string): Promise<void>
   deleteFolder(id: string): Promise<void>
-  createFolder(parentId: string, title: string): Promise<void>
+  /** Resolves the created folder, or `null` when there was no adapter or the create failed. */
+  createFolder(parentId: string, title: string): Promise<BookmarkNode | null>
   /**
    * Resolves `true` when the move was applied. Callers that only open a
    * dialog can keep ignoring the result and read `mutationError` afterwards;
@@ -288,12 +289,14 @@ export const useBookmarkStore = create<BookmarkState>((set, get) => ({
 
   async createFolder(parentId: string, title: string) {
     const { adapter } = get()
-    if (!adapter) return
+    if (!adapter) return null
     try {
-      await adapter.bookmarks.create({ parentId, title })
+      const created = await adapter.bookmarks.create({ parentId, title })
       set({ mutationError: null })
+      return created
     } catch (error) {
       set({ mutationError: toErrorMessage(error) })
+      return null
     }
   },
 

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -16,6 +16,7 @@ interface CreateItemRequest {
 interface UIState {
   settingsOpen: boolean
   bookmarkOrganizerOpen: boolean
+  onboardingOpen: boolean
   editingBookmark: BookmarkNode | null
   deletingItem: DeletingItem | null
   creatingItem: CreateItemRequest | null
@@ -25,6 +26,8 @@ interface UIState {
   closeSettings(): void
   openBookmarkOrganizer(): void
   closeBookmarkOrganizer(): void
+  openOnboarding(): void
+  closeOnboarding(): void
   openEditor(bookmark: BookmarkNode): void
   closeEditor(): void
   openDeleteConfirm(item: DeletingItem): void
@@ -36,6 +39,7 @@ interface UIState {
 export const useUIStore = create<UIState>((set) => ({
   settingsOpen: false,
   bookmarkOrganizerOpen: false,
+  onboardingOpen: false,
   editingBookmark: null,
   deletingItem: null,
   creatingItem: null,
@@ -44,6 +48,8 @@ export const useUIStore = create<UIState>((set) => ({
   closeSettings: () => set({ settingsOpen: false }),
   openBookmarkOrganizer: () => set({ bookmarkOrganizerOpen: true }),
   closeBookmarkOrganizer: () => set({ bookmarkOrganizerOpen: false }),
+  openOnboarding: () => set({ onboardingOpen: true }),
+  closeOnboarding: () => set({ onboardingOpen: false }),
   openEditor: (bookmark) => set({ editingBookmark: bookmark }),
   closeEditor: () => set({ editingBookmark: null }),
   openDeleteConfirm: (item) => set({ deletingItem: item }),


### PR DESCRIPTION
Sixteen commits of first-run and data-management fixes. Every commit is independently green (`bun run check`: format, lint, typecheck, 450 tests, all three builds), and the whole branch went through four rounds of independent review — eight findings, seven fixed, one withdrawn.

## Onboarding

- **Setup wizard reworked.** Adds a mode step (Browser / Daemon, with Standalone as an advanced option) and a conditional daemon-setup step that links the repo as the install reference and embeds the existing connection panel. Daemon is never persisted directly — `connectToDaemon` remains the only thing allowed to, after its own validate/permission/health-check.
- **The root-folder step explains itself** and offers to create a dedicated folder inline, since "Browser Root (all bookmarks)" is a poor default for a dashboard.
- **Settings can re-open the wizard.** Wizard visibility moved into `useUIStore`, so this needs no page reload.

## Creating the first item

Previously there was no way to create anything from an empty dashboard: create actions lived only in a per-row dropdown, which needs a row to exist.

- Real empty states for the grid and the organizer, both with working create actions.
- A persistent "New" menu in the organizer header.
- New `rootIsCreatable` capability. The browsers' synthetic tree root (`"0"`, `root________`) is rejected as a parent, but the daemon's vault root is a real folder — so daemon and standalone users get working create buttons with no root folder selected at all, which is correct there since a root folder is meaningless in those modes.
- The default parent now matches the Bookmarks Bar **by id** rather than taking the first child folder. Firefox orders its permanent roots menu → toolbar → unfiled → mobile, so the positional walk landed on the Bookmarks *Menu* there.

## Import / export

- **Import worked only in browser mode.** It threw unless a dashboard root was selected, and the button was hidden entirely in the daemon build. Both fixed; the daemon path writes through the daemon's own API.
- **A single bad node used to abort everything silently.** Creates were batched through `Promise.all` with no error handling, so one rejection threw out of the file-input handler as an unhandled rejection — half-written tree, no message. Each write is now isolated and counted.
- **The parser emitted nodes no adapter can store.** Chrome exports untitled bookmarks, and the parser turned `<A>` with no HREF into an empty url; the daemon answers `422 a title cannot be empty` / `a url cannot be empty` for both. Untitled bookmarks now fall back to their host, and unusable anchors are dropped.
- **Duplicate handling.** Re-importing a file used to double everything. Import now plans the whole write first: folders merge by name, bookmarks collide on normalized URL within the folder they land in. Conflicts open on a summary with Skip all / Replace all / Keep both for all, with review-one-by-one (and Back) behind it. Nothing is written while that dialog is up, so Cancel truly leaves the tree untouched.
- **Import target and export scope are now choices.** Picking a file reveals the parsed counts, a destination select, and an optional new subfolder; export offers "Dashboard folder" or "Everything".

## Inert controls

- "Create" did nothing at all with an empty title or URL — no error, no disabled state. Now disabled with the reason, and blank visited fields explain themselves.
- Enter submitted inconsistently: no dialog had a submit button, so implicit submission applied only to single-field forms. Enter created a folder, was ignored for a bookmark, and never saved an edit. Both dialogs are real forms now.
- "Dashboard folder" produced a byte-identical file to "Everything" when no root folder was selected. Disabled in that state.
- Every remaining disabled control (Import, Import here, daemon Connect, wizard Create folder) now says why.

## Fixes from independent review

The last five commits came out of an adversarial review pass. Each is a real defect the earlier commits introduced or left standing:

- **`8087f8b`** — two incoming bookmarks with the same URL both matched one existing node, so "replace all" fired two concurrent updates at a single bookmark. Whichever landed last won the title, and the daemon rejected the loser on a stale revision. Only the first incoming copy claims a match now.
- **`258fda3`** — `concurrency` bounded only the bookmarks within one folder. Every folder at a level was created at once and every subtree then ran in parallel with its own allowance, so a file with 100 sibling folders opened hundreds of simultaneous requests from a limit that reads as eight. A single shared pool now covers the whole import.
- **`cd3a884`** — `rootFolderId` is persisted separately from the bookmarks, so a folder deleted elsewhere left the id pointing at nothing. Import sent every write to a parent that does not exist; the grid and organizer offered create buttons that could only error. `resolveCreateParentId` verifies the id against the tree.
- **`e96a417`** — `rootIsCreatable: true` promises `tree[0]` is a creatable folder, but standalone returned a bare forest, so `tree[0]` was whichever row sorted first. Creating "at the root" wrote inside an arbitrary folder, or underneath a *bookmark*, where nothing renders it again. `getTree()` now wraps the rows in a synthetic root that `create()`/`move()` map back to "no parentId" — no migration, since nothing new is persisted.
- **`c2d73f0`** — three follow-ups: the organizer still resolved its root without the existence check, so a deleted root left it permanently empty while its own New button targeted the fallback; the synthetic root regressed dev seeding by stacking on the seed file's own titleless root; and the root-folder picker printed a raw id whenever the selection was not in its options list.

## Verification

Beyond the unit suite, the import path was exercised end-to-end against a live `bbb` daemon (v4.0.0-beta.3):

- A Chrome-shaped export containing untitled bookmarks, HREF-less anchors, `javascript:` URLs and folder names with `/` and `:` imported with `failed: 0`.
- The same file imported three times produced no duplicates, with every conflict detected and the folder merged rather than recreated.
- "Replace all" against a file carrying in-file duplicates of an existing URL resolved to one conflict and one new bookmark, `failed: 0` — the race from `8087f8b` is gone.
- A 210-write import held peak in-flight requests at exactly the configured 8.