### PR TITLE
Add daemon capture popup and omnibox search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Capture pages directly from Chrome and Firefox into a daemon vault.** The
+  extension action now opens a compact popup that saves the active page into a
+  writable vault folder, without mirroring or importing the browser's native
+  bookmark store
+- **Search daemon bookmarks from the browser address bar.** Type `bbb`, press
+  <kbd>Tab</kbd>, and enter a title or URL fragment to see live suggestions;
+  choosing one opens the current bookmark URL with the browser's requested tab
+  disposition
+- A bounded, case-insensitive `GET /api/v1/search` daemon endpoint for bookmark
+  titles and URLs, with deterministic ranking and opaque bookmark identifiers
+
 ### Fixed
 
 - **`install.sh` and `install.ps1` no longer fail out of the box.** Both default

--- a/crates/bbb/README.md
+++ b/crates/bbb/README.md
@@ -84,6 +84,7 @@ stable `code`.
 | -------- | ------------------------ | ------------------------------------------------ |
 | `GET`    | `/health`                | `{status, version, generation, warnings}`        |
 | `GET`    | `/tree`                  | `{tree: [root]}` — one root holding the subtree   |
+| `GET`    | `/search?q=…&limit=…`    | `{results: [{id, title, url}]}` — bookmarks only |
 | `GET`    | `/bookmarks/{id}`        | one entry                                         |
 | `POST`   | `/bookmarks`             | `{parentId, title, url?, index?, parentStateRevision?}`; no `url` ⇒ folder |
 | `PATCH`  | `/bookmarks/{id}`        | `{revision, title?, url?}`                        |
@@ -112,6 +113,20 @@ stable `code`.
   "diagnostics": [ … ]        // present only when there is something to say
 }
 ```
+
+### Search
+
+`GET /search` reads the currently published vault snapshot and never triggers
+a rescan. `q` is trimmed, matched case-insensitively as a substring against
+bookmark titles and URLs, and limited to 256 characters. An omitted or empty
+query safely returns `{"results":[]}`.
+
+`limit` defaults to 8 and must be between 1 and 20. Exact and prefix title
+matches come first, followed by other title matches and then URL matches; ties
+are ordered deterministically by lowercased title, URL, and stable identity.
+Folders are never returned. A client selecting a result should treat `id` as
+opaque and fetch `/bookmarks/{id}` again before navigating, because the
+bookmark may have changed since the search snapshot.
 
 ### Error codes
 

--- a/crates/bbb/src/api.rs
+++ b/crates/bbb/src/api.rs
@@ -29,7 +29,8 @@ use bbb_vault_core::{ChildKind, Id};
 
 use crate::dto::{
     self, BookmarkDto, CreateBookmarkRequest, CreateFolderRequest, DeleteQuery, HealthResponse,
-    MoveRequest, OrderChild, OrderRequest, Placement, RescanResponse, TreeResponse, UpdateRequest,
+    MoveRequest, OrderChild, OrderRequest, Placement, RescanResponse, SearchQuery, SearchResponse,
+    TreeResponse, UpdateRequest,
 };
 use crate::entry::EntryRef;
 use crate::extract::{ApiJson, ApiQuery};
@@ -38,6 +39,8 @@ use crate::vault::{MovePlan, Vault};
 
 /// How often an idle event stream is nudged so proxies and clients keep it open.
 const SSE_KEEP_ALIVE: Duration = Duration::from_secs(15);
+const MAX_SEARCH_QUERY_CHARS: usize = 256;
+const MAX_SEARCH_LIMIT: usize = 20;
 
 /// What every handler shares.
 #[derive(Debug, Clone)]
@@ -55,6 +58,7 @@ pub fn router(state: ApiState) -> Router {
     Router::new()
         .route("/health", get(health))
         .route("/tree", get(tree))
+        .route("/search", get(search))
         .route("/events", get(events))
         .route("/rescan", post(rescan))
         .route("/bookmarks", post(create_bookmark))
@@ -95,6 +99,34 @@ async fn health(State(state): State<ApiState>) -> Json<HealthResponse> {
 async fn tree(State(state): State<ApiState>) -> Json<TreeResponse> {
     let snapshot = state.vault.snapshot();
     Json(dto::tree(&snapshot.scan))
+}
+
+async fn search(
+    State(state): State<ApiState>,
+    ApiQuery(query): ApiQuery<SearchQuery>,
+) -> Result<Json<SearchResponse>, Problem> {
+    let query_text = query.q.trim();
+    if query_text.chars().count() > MAX_SEARCH_QUERY_CHARS {
+        return Err(Problem::new(
+            ProblemCode::InvalidRequest,
+            format!("`q` must be at most {MAX_SEARCH_QUERY_CHARS} characters"),
+        ));
+    }
+    if !(1..=MAX_SEARCH_LIMIT).contains(&query.limit) {
+        return Err(Problem::new(
+            ProblemCode::InvalidRequest,
+            format!("`limit` must be between 1 and {MAX_SEARCH_LIMIT}"),
+        ));
+    }
+
+    if query_text.is_empty() {
+        return Ok(Json(SearchResponse {
+            results: Vec::new(),
+        }));
+    }
+
+    let snapshot = state.vault.snapshot();
+    Ok(Json(dto::search(&snapshot.scan, query_text, query.limit)))
 }
 
 async fn rescan(State(state): State<ApiState>) -> Result<Json<RescanResponse>, Problem> {

--- a/crates/bbb/src/dto.rs
+++ b/crates/bbb/src/dto.rs
@@ -109,6 +109,46 @@ pub struct TreeResponse {
     pub tree: Vec<BookmarkDto>,
 }
 
+/// One bookmark returned by `GET /api/v1/search`.
+///
+/// Search deliberately exposes only the fields an omnibox needs. In
+/// particular, it never serializes folders and does not turn the URL into a
+/// selection token; clients must treat `id` as the opaque identity and fetch
+/// the current node again before navigating.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchResultDto {
+    /// The bookmark's stable identity.
+    pub id: String,
+    /// The bookmark's display title.
+    pub title: String,
+    /// The bookmark's current target URL.
+    pub url: String,
+}
+
+/// The body of `GET /api/v1/search`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchResponse {
+    /// Ranked bookmark matches, never folders.
+    pub results: Vec<SearchResultDto>,
+}
+
+/// The query string of `GET /api/v1/search`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SearchQuery {
+    /// Case-insensitive substring matched against title and URL.
+    #[serde(default)]
+    pub q: String,
+    /// Maximum number of results to return.
+    #[serde(default = "default_search_limit")]
+    pub limit: usize,
+}
+
+const fn default_search_limit() -> usize {
+    8
+}
+
 /// The body of `GET /api/v1/health`.
 #[derive(Debug, Clone, Serialize)]
 pub struct HealthResponse {
@@ -340,6 +380,55 @@ pub(crate) fn folder_ref(node: &FolderNode) -> EntryRef {
 pub(crate) fn tree(scan: &VaultScan) -> TreeResponse {
     TreeResponse {
         tree: vec![folder_dto(scan.folder(), None)],
+    }
+}
+
+pub(crate) fn search(scan: &VaultScan, query: &str, limit: usize) -> SearchResponse {
+    let needle = query.to_lowercase();
+    let mut matches = scan
+        .bookmarks()
+        .filter_map(|bookmark| {
+            let url = bookmark.url()?;
+            let title_key = bookmark.title().to_lowercase();
+            let url_key = url.to_lowercase();
+            let rank = if title_key == needle {
+                0
+            } else if title_key.starts_with(&needle) {
+                1
+            } else if title_key.contains(&needle) {
+                2
+            } else if url_key.starts_with(&needle) {
+                3
+            } else if url_key.contains(&needle) {
+                4
+            } else {
+                return None;
+            };
+
+            Some((
+                rank,
+                title_key,
+                url_key,
+                bookmark.id().to_string(),
+                SearchResultDto {
+                    id: bookmark.id().to_string(),
+                    title: bookmark.title().to_owned(),
+                    url: url.to_owned(),
+                },
+            ))
+        })
+        .collect::<Vec<_>>();
+
+    matches.sort_by(|left, right| {
+        (&left.0, &left.1, &left.2, &left.3).cmp(&(&right.0, &right.1, &right.2, &right.3))
+    });
+
+    SearchResponse {
+        results: matches
+            .into_iter()
+            .take(limit)
+            .map(|(_, _, _, _, result)| result)
+            .collect(),
     }
 }
 

--- a/crates/bbb/tests/api_search.rs
+++ b/crates/bbb/tests/api_search.rs
@@ -1,0 +1,83 @@
+//! Bookmark search contract and edge cases.
+
+mod support;
+
+use axum::http::StatusCode;
+use support::Harness;
+
+#[tokio::test]
+async fn search_is_case_insensitive_ranked_and_bookmark_only() {
+    let harness = Harness::new();
+    let root = harness.root_id().await;
+    harness
+        .create_bookmark(&root, "Rust", "https://www.rust-lang.org")
+        .await;
+    harness
+        .create_bookmark(&root, "Rust Book", "https://doc.rust-lang.org/book")
+        .await;
+    harness
+        .create_bookmark(&root, "Language", "https://example.com/RUST")
+        .await;
+    harness.create_folder(&root, "Rust folder").await;
+
+    let response = harness.get("/api/v1/search?q=rUsT&limit=10").await;
+    assert_eq!(response.status, StatusCode::OK, "{}", response.text());
+    let body = response.json();
+    let results = body["results"].as_array().expect("results array");
+
+    assert_eq!(results.len(), 3, "folders are never search results: {body}");
+    assert_eq!(results[0]["title"], "Rust");
+    assert_eq!(results[1]["title"], "Rust Book");
+    assert_eq!(results[2]["title"], "Language");
+    assert!(results.iter().all(|item| item["url"].is_string()));
+}
+
+#[tokio::test]
+async fn empty_search_is_safe_and_returns_nothing() {
+    let harness = Harness::new();
+    let root = harness.root_id().await;
+    harness
+        .create_bookmark(&root, "Example", "https://example.com")
+        .await;
+
+    for path in ["/api/v1/search", "/api/v1/search?q=%20%20%20"] {
+        let response = harness.get(path).await;
+        assert_eq!(response.status, StatusCode::OK, "{}", response.text());
+        assert_eq!(response.json()["results"], serde_json::json!([]));
+    }
+}
+
+#[tokio::test]
+async fn search_enforces_limit_and_query_bounds() {
+    let harness = Harness::new();
+    let root = harness.root_id().await;
+    for index in 0..4 {
+        harness
+            .create_bookmark(
+                &root,
+                &format!("Example {index}"),
+                &format!("https://example.com/{index}"),
+            )
+            .await;
+    }
+
+    let response = harness.get("/api/v1/search?q=example&limit=2").await;
+    assert_eq!(response.status, StatusCode::OK, "{}", response.text());
+    assert_eq!(response.json()["results"].as_array().map(Vec::len), Some(2));
+
+    for path in [
+        "/api/v1/search?q=example&limit=0",
+        "/api/v1/search?q=example&limit=21",
+    ] {
+        harness
+            .get(path)
+            .await
+            .expect_problem(StatusCode::BAD_REQUEST, "invalid_request");
+    }
+
+    let too_long = "x".repeat(257);
+    harness
+        .get(&format!("/api/v1/search?q={too_long}"))
+        .await
+        .expect_problem(StatusCode::BAD_REQUEST, "invalid_request");
+}

--- a/manifests/manifest.chrome.json
+++ b/manifests/manifest.chrome.json
@@ -6,7 +6,24 @@
   "chrome_url_overrides": {
     "newtab": "index.html"
   },
-  "permissions": ["bookmarks", "storage", "favicon", "tabs", "clipboardWrite"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Save bookmark"
+  },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "omnibox": {
+    "keyword": "bbb"
+  },
+  "permissions": [
+    "activeTab",
+    "bookmarks",
+    "storage",
+    "favicon",
+    "clipboardWrite"
+  ],
   "host_permissions": ["https://t1.gstatic.com/*", "https://www.google.com/*"],
   "optional_host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
   "icons": {

--- a/manifests/manifest.firefox.json
+++ b/manifests/manifest.firefox.json
@@ -21,7 +21,17 @@
   "chrome_settings_overrides": {
     "homepage": "index.html"
   },
-  "permissions": ["bookmarks", "storage"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Save bookmark"
+  },
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "omnibox": {
+    "keyword": "bbb"
+  },
+  "permissions": ["activeTab", "bookmarks", "storage"],
   "host_permissions": ["https://t1.gstatic.com/*"],
   "optional_host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
   "icons": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "dev": "vite",
     "dev:daemon-ui": "VITE_BUILD_TARGET=daemon vite",
-    "build:chrome": "VITE_BUILD_TARGET=chrome vite build --outDir dist-chrome && cp manifests/manifest.chrome.json dist-chrome/manifest.json",
-    "build:firefox": "VITE_BUILD_TARGET=firefox vite build --outDir dist-firefox && cp manifests/manifest.firefox.json dist-firefox/manifest.json",
+    "build:chrome": "VITE_BUILD_TARGET=chrome vite build --outDir dist-chrome && vite build --config vite.background.config.ts --outDir dist-chrome && cp manifests/manifest.chrome.json dist-chrome/manifest.json",
+    "build:firefox": "VITE_BUILD_TARGET=firefox vite build --outDir dist-firefox && vite build --config vite.background.config.ts --outDir dist-firefox && cp manifests/manifest.firefox.json dist-firefox/manifest.json",
     "build:daemon": "VITE_BUILD_TARGET=daemon vite build --outDir dist-daemon",
     "build": "bun run build:chrome && bun run build:firefox",
     "zip:firefox": "cd dist-firefox && zip -r ../bookmarks-but-better-firefox.zip .",

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      html,
+      body {
+        margin: 0;
+        background: oklch(0.145 0 0);
+        color-scheme: dark;
+      }
+
+      html.light,
+      html.light body {
+        background: white;
+        color-scheme: light;
+      }
+    </style>
+    <script src="/theme-bootstrap.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Save bookmark</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/popup/main.tsx"></script>
+  </body>
+</html>

--- a/src/browser/daemon/__tests__/client.test.ts
+++ b/src/browser/daemon/__tests__/client.test.ts
@@ -42,6 +42,17 @@ describe("daemon client", () => {
     expect(fetchMock.mock.calls[0][0]).toBe("/api/v1/tree")
   })
 
+  it("encodes daemon search query and bounded result count", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ results: [] }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await served().search("rust & web", 8)
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/v1/search?q=rust+%26+web&limit=8"
+    )
+  })
+
   it("routes bookmark creation to /bookmarks with a JSON body", async () => {
     const fetchMock = vi
       .fn()

--- a/src/browser/daemon/client.ts
+++ b/src/browser/daemon/client.ts
@@ -70,6 +70,16 @@ export interface DaemonTreeResponse {
   tree: BookmarkNode[]
 }
 
+export interface DaemonSearchResult {
+  id: string
+  title: string
+  url: string
+}
+
+export interface DaemonSearchResponse {
+  results: DaemonSearchResult[]
+}
+
 export type DaemonNodeKind = "bookmark" | "folder"
 
 function segmentFor(kind: DaemonNodeKind): string {
@@ -233,6 +243,12 @@ export class DaemonClient {
 
   fetchTree(): Promise<DaemonTreeResponse> {
     return this.request<DaemonTreeResponse>("/tree")
+  }
+
+  /** Bookmark-only, case-insensitive search over the daemon's current snapshot. */
+  search(query: string, limit = 8): Promise<DaemonSearchResponse> {
+    const params = new URLSearchParams({ q: query, limit: String(limit) })
+    return this.request<DaemonSearchResponse>(`/search?${params.toString()}`)
   }
 
   /** Bare DTO, not wrapped — the daemon exposes a single item under /bookmarks/:id regardless of kind. */

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-action"
+      className={cn("absolute top-2.5 right-3", className)}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction }

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -1,0 +1,236 @@
+import { useMemo } from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-6 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "mb-3 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const fieldVariants = cva(
+  "group/field flex w-full gap-3 data-[invalid=true]:text-destructive",
+  {
+    variants: {
+      orientation: {
+        vertical: "flex-col *:w-full [&>.sr-only]:w-auto",
+        horizontal:
+          "flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        responsive:
+          "flex-col *:w-full @md/field-group:flex-row @md/field-group:items-center @md/field-group:*:w-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:*:data-[slot=field-label]:flex-auto [&>.sr-only]:w-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+      },
+    },
+    defaultVariants: {
+      orientation: "vertical",
+    },
+  }
+)
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        "group/field-content flex flex-1 flex-col gap-1 leading-5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        "group/field-label peer/field-label flex w-fit gap-2 leading-5 group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-xl has-[>[data-slot=field]]:border *:data-[slot=field]:p-4 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        "text-left text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
+        "last:mt-0 nth-last-2:-mt-1",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  children?: React.ReactNode
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn(
+        "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+        className
+      )}
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children
+    }
+
+    if (!errors?.length) {
+      return null
+    }
+
+    const uniqueErrors = [
+      ...new Map(errors.map((error) => [error?.message, error])).values(),
+    ]
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map(
+          (error, index) =>
+            error?.message && <li key={index}>{error.message}</li>
+        )}
+      </ul>
+    )
+  }, [children, errors])
+
+  if (!content) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-sm font-normal text-destructive", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  )
+}
+
+export {
+  Field,
+  FieldLabel,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldContent,
+  FieldTitle,
+}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@/lib/utils"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Loading03Icon } from "@hugeicons/core-free-icons"
+import type * as React from "react"
+
+function Spinner({
+  className,
+  ...props
+}: Omit<React.ComponentProps<typeof HugeiconsIcon>, "icon">) {
+  return (
+    <HugeiconsIcon
+      icon={Loading03Icon}
+      strokeWidth={2}
+      data-slot="spinner"
+      role="status"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin", className)}
+      {...props}
+    />
+  )
+}
+
+export { Spinner }

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -1,0 +1,6 @@
+import { createBrowserOmniboxFacade, registerOmniboxListeners } from "./omnibox"
+
+// MV3 workers can be stopped between any two events. Listener registration is
+// therefore synchronous, while every event reconstructs its daemon client
+// state from persistence and owns only the request it is currently handling.
+registerOmniboxListeners(createBrowserOmniboxFacade())

--- a/src/extension/build-contract.test.ts
+++ b/src/extension/build-contract.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+
+import { readFile } from "node:fs/promises"
+import { describe, expect, it } from "vitest"
+import {
+  BACKGROUND_OUTPUT_FILE,
+  BACKGROUND_OUTPUT_FORMAT,
+  buildEntryNames,
+} from "./build-contract"
+
+async function manifest(name: "chrome" | "firefox") {
+  return JSON.parse(
+    await readFile(
+      new URL(`../../manifests/manifest.${name}.json`, import.meta.url),
+      "utf8"
+    )
+  ) as Record<string, unknown>
+}
+
+describe("extension build contract", () => {
+  it("builds the new tab, popup, and stable background entries for extensions", () => {
+    expect(buildEntryNames("chrome")).toEqual(["index", "popup", "background"])
+    expect(buildEntryNames("firefox")).toEqual(["index", "popup", "background"])
+    expect(BACKGROUND_OUTPUT_FILE).toBe("background.js")
+    expect(BACKGROUND_OUTPUT_FORMAT).toBe("iife")
+  })
+
+  it("keeps the daemon-served build free of extension-only entries", () => {
+    expect(buildEntryNames("daemon")).toEqual(["index"])
+  })
+
+  it("wires each MV3 manifest to the popup, omnibox, and correct background form", async () => {
+    const chrome = await manifest("chrome")
+    const firefox = await manifest("firefox")
+
+    expect(chrome.action).toMatchObject({ default_popup: "popup.html" })
+    expect(chrome.background).toEqual({
+      service_worker: BACKGROUND_OUTPUT_FILE,
+      type: "module",
+    })
+    expect(firefox.action).toMatchObject({ default_popup: "popup.html" })
+    expect(firefox.background).toEqual({ scripts: [BACKGROUND_OUTPUT_FILE] })
+    expect(chrome.omnibox).toEqual({ keyword: "bbb" })
+    expect(firefox.omnibox).toEqual({ keyword: "bbb" })
+    expect(chrome.permissions).toContain("activeTab")
+    expect(chrome.permissions).not.toContain("tabs")
+    expect(firefox.permissions).toContain("activeTab")
+    expect(firefox.permissions).not.toContain("clipboardWrite")
+  })
+})

--- a/src/extension/build-contract.ts
+++ b/src/extension/build-contract.ts
@@ -1,0 +1,8 @@
+export const BACKGROUND_OUTPUT_FILE = "background.js"
+export const BACKGROUND_OUTPUT_FORMAT = "iife"
+
+export function buildEntryNames(
+  buildTarget: string | undefined
+): readonly string[] {
+  return buildTarget === "daemon" ? ["index"] : ["index", "popup", "background"]
+}

--- a/src/extension/omnibox.test.ts
+++ b/src/extension/omnibox.test.ts
@@ -1,0 +1,272 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { installFakeIndexedDB } from "@/browser/__tests__/fake-indexeddb"
+import {
+  setAdapterModePreference,
+  setDaemonConnectionConfig,
+} from "@/browser/adapter-preference"
+import type { DaemonSearchResponse } from "@/browser/daemon/client"
+import type { BookmarkNode } from "@/browser/types"
+import {
+  decodeOpaqueSuggestion,
+  createBrowserOmniboxFacade,
+  escapeSuggestionDescription,
+  opaqueSuggestionContent,
+  registerOmniboxListeners,
+  type OmniboxDisposition,
+  type OmniboxFacade,
+  type OmniboxSuggestion,
+} from "./omnibox"
+
+installFakeIndexedDB()
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  installFakeIndexedDB()
+})
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function fakeFacade() {
+  let changed:
+    | ((text: string, suggest: (items: OmniboxSuggestion[]) => void) => void)
+    | undefined
+  let entered:
+    | ((text: string, disposition: OmniboxDisposition) => void)
+    | undefined
+  const facade: OmniboxFacade = {
+    onInputChanged: vi.fn((listener) => {
+      changed = listener
+    }),
+    onInputEntered: vi.fn((listener) => {
+      entered = listener
+    }),
+    setDefaultSuggestion: vi.fn(),
+    getDaemonSelection: vi.fn().mockResolvedValue({
+      mode: "daemon",
+      config: { origin: "http://127.0.0.1:52222" },
+    }),
+    hasHostPermission: vi.fn().mockResolvedValue(true),
+    search: vi.fn().mockResolvedValue({ results: [] }),
+    fetchNode: vi.fn(),
+    navigate: vi.fn(),
+  }
+  return {
+    facade,
+    changed: () => changed!,
+    entered: () => entered!,
+  }
+}
+
+describe("omnibox listener registration", () => {
+  it("registers both listeners synchronously", () => {
+    const fake = fakeFacade()
+    registerOmniboxListeners(fake.facade)
+
+    expect(fake.facade.onInputChanged).toHaveBeenCalledOnce()
+    expect(fake.facade.onInputEntered).toHaveBeenCalledOnce()
+    expect(fake.facade.setDefaultSuggestion).toHaveBeenCalledOnce()
+  })
+
+  it("does nothing unless persisted daemon mode and permission are both present", async () => {
+    const fake = fakeFacade()
+    vi.mocked(fake.facade.getDaemonSelection).mockResolvedValue(null)
+    registerOmniboxListeners(fake.facade)
+    const suggest = vi.fn()
+
+    fake.changed()("rust", suggest)
+    await flush()
+
+    expect(fake.facade.search).not.toHaveBeenCalled()
+    expect(suggest).toHaveBeenCalledWith([])
+  })
+
+  it("ignores stale asynchronous results and escapes description text", async () => {
+    const fake = fakeFacade()
+    const first = deferred<DaemonSearchResponse>()
+    const second = deferred<DaemonSearchResponse>()
+    vi.mocked(fake.facade.search)
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+    registerOmniboxListeners(fake.facade)
+    const oldSuggest = vi.fn()
+    const newSuggest = vi.fn()
+
+    fake.changed()("old", oldSuggest)
+    await flush()
+    fake.changed()("new", newSuggest)
+    await flush()
+    second.resolve({
+      results: [
+        {
+          id: "opaque/id",
+          title: "<script>& title",
+          url: "https://example.com/?a=<b>",
+        },
+      ],
+    })
+    await flush()
+    first.resolve({
+      results: [{ id: "old", title: "Old", url: "https://old.example" }],
+    })
+    await flush()
+
+    expect(oldSuggest).not.toHaveBeenCalled()
+    expect(newSuggest).toHaveBeenCalledOnce()
+    const [items] = newSuggest.mock.calls[0] as [OmniboxSuggestion[]]
+    expect(items[0].description).toBe(
+      "&lt;script&gt;&amp; title — <dim>https://example.com/?a=&lt;b&gt;</dim>"
+    )
+    expect(items[0].content).not.toContain("opaque/id")
+    expect(decodeOpaqueSuggestion(items[0].content)).toBe("opaque/id")
+  })
+})
+
+describe("omnibox selection", () => {
+  it.each(["currentTab", "newForegroundTab", "newBackgroundTab"] as const)(
+    "re-fetches the opaque id before %s navigation",
+    async (disposition) => {
+      const fake = fakeFacade()
+      const node: BookmarkNode = {
+        id: "bookmark-1",
+        title: "Example",
+        url: "https://example.com",
+      }
+      vi.mocked(fake.facade.fetchNode).mockResolvedValue(node)
+      registerOmniboxListeners(fake.facade)
+
+      fake.entered()(opaqueSuggestionContent(node.id), disposition)
+      await flush()
+
+      expect(fake.facade.fetchNode).toHaveBeenCalledWith(
+        { origin: "http://127.0.0.1:52222" },
+        node.id
+      )
+      expect(fake.facade.navigate).toHaveBeenCalledWith(
+        node.url + "/",
+        disposition
+      )
+    }
+  )
+
+  it("does nothing for free-form unselected input", async () => {
+    const fake = fakeFacade()
+    registerOmniboxListeners(fake.facade)
+
+    fake.entered()("just some words", "currentTab")
+    await flush()
+
+    expect(fake.facade.getDaemonSelection).not.toHaveBeenCalled()
+    expect(fake.facade.fetchNode).not.toHaveBeenCalled()
+    expect(fake.facade.navigate).not.toHaveBeenCalled()
+  })
+
+  it("does not navigate when the selected node became a folder or unsafe URL", async () => {
+    const fake = fakeFacade()
+    vi.mocked(fake.facade.fetchNode).mockResolvedValue({
+      id: "bookmark-1",
+      title: "Changed",
+      url: "javascript:alert(1)",
+    })
+    registerOmniboxListeners(fake.facade)
+
+    fake.entered()(opaqueSuggestionContent("bookmark-1"), "currentTab")
+    await flush()
+
+    expect(fake.facade.navigate).not.toHaveBeenCalled()
+  })
+})
+
+describe("omnibox encoding", () => {
+  it("round-trips unicode ids and rejects unrelated text", () => {
+    const content = opaqueSuggestionContent("é/书签")
+    expect(decodeOpaqueSuggestion(content)).toBe("é/书签")
+    expect(decodeOpaqueSuggestion("not a selection")).toBeNull()
+  })
+
+  it("escapes all XML-significant characters", () => {
+    expect(escapeSuggestionDescription(`<&>"'`)).toBe(
+      "&lt;&amp;&gt;&quot;&apos;"
+    )
+  })
+})
+
+describe("browser omnibox facade", () => {
+  it("reads daemon selection through the shared adapter preference APIs", async () => {
+    const facade = createBrowserOmniboxFacade()
+    await setDaemonConnectionConfig({
+      origin: "LOCALHOST",
+      bearerToken: "secret",
+    })
+
+    await expect(facade.getDaemonSelection()).resolves.toBeNull()
+
+    await setAdapterModePreference("daemon")
+    await expect(facade.getDaemonSelection()).resolves.toEqual({
+      mode: "daemon",
+      config: {
+        origin: "http://localhost:52222",
+        bearerToken: "secret",
+      },
+    })
+  })
+
+  it("reuses the daemon permission check for both allowed loopback hosts", async () => {
+    const contains = vi.fn(
+      (
+        _permissions: chrome.permissions.Permissions,
+        callback: (granted: boolean) => void
+      ) => callback(true)
+    )
+    vi.stubGlobal("chrome", {
+      permissions: { contains },
+      omnibox: {},
+      tabs: {},
+    })
+
+    await expect(
+      createBrowserOmniboxFacade().hasHostPermission()
+    ).resolves.toBe(true)
+    expect(contains).toHaveBeenCalledWith(
+      { origins: ["http://127.0.0.1/*", "http://localhost/*"] },
+      expect.any(Function)
+    )
+  })
+
+  it("maps all three dispositions to current, foreground, and background tabs", async () => {
+    const update = vi.fn().mockResolvedValue(undefined)
+    const create = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal("chrome", {
+      tabs: { update, create },
+      omnibox: {},
+      permissions: {},
+      runtime: {},
+    })
+    const facade = createBrowserOmniboxFacade()
+
+    await facade.navigate("https://current.example/", "currentTab")
+    await facade.navigate("https://foreground.example/", "newForegroundTab")
+    await facade.navigate("https://background.example/", "newBackgroundTab")
+
+    expect(update).toHaveBeenCalledWith({ url: "https://current.example/" })
+    expect(create).toHaveBeenNthCalledWith(1, {
+      url: "https://foreground.example/",
+      active: true,
+    })
+    expect(create).toHaveBeenNthCalledWith(2, {
+      url: "https://background.example/",
+      active: false,
+    })
+  })
+})

--- a/src/extension/omnibox.ts
+++ b/src/extension/omnibox.ts
@@ -1,0 +1,236 @@
+import type {
+  DaemonSearchResponse,
+  DaemonSearchResult,
+} from "@/browser/daemon/client"
+import { hasDaemonHostPermission } from "@/browser/daemon/permissions"
+import {
+  getAdapterModePreference,
+  getDaemonConnectionConfig,
+} from "@/browser/adapter-preference"
+import type { BookmarkNode, DaemonConnectionConfig } from "@/browser/types"
+
+export type OmniboxDisposition =
+  | "currentTab"
+  | "newForegroundTab"
+  | "newBackgroundTab"
+
+export interface OmniboxSuggestion {
+  content: string
+  description: string
+}
+
+export interface PersistedDaemonSelection {
+  mode: "daemon"
+  config: DaemonConnectionConfig
+}
+
+export interface OmniboxFacade {
+  onInputChanged(
+    listener: (
+      text: string,
+      suggest: (suggestions: OmniboxSuggestion[]) => void
+    ) => void
+  ): void
+  onInputEntered(
+    listener: (text: string, disposition: OmniboxDisposition) => void
+  ): void
+  setDefaultSuggestion(description: string): void
+  getDaemonSelection(): Promise<PersistedDaemonSelection | null>
+  hasHostPermission(): Promise<boolean>
+  search(
+    config: DaemonConnectionConfig,
+    query: string,
+    limit: number
+  ): Promise<DaemonSearchResponse>
+  fetchNode(config: DaemonConnectionConfig, id: string): Promise<BookmarkNode>
+  navigate(url: string, disposition: OmniboxDisposition): Promise<void>
+}
+
+const SEARCH_LIMIT = 8
+const OPAQUE_PREFIX = "bbb:"
+const API_BASE = "/api/v1"
+
+export function escapeSuggestionDescription(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;")
+}
+
+function encodeUtf8(value: string): string {
+  const bytes = new TextEncoder().encode(value)
+  let binary = ""
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}
+
+function decodeUtf8(value: string): string {
+  const binary = atob(value)
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0))
+  return new TextDecoder().decode(bytes)
+}
+
+export function opaqueSuggestionContent(id: string): string {
+  return `${OPAQUE_PREFIX}${encodeUtf8(id)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "")}`
+}
+
+export function decodeOpaqueSuggestion(content: string): string | null {
+  if (!content.startsWith(OPAQUE_PREFIX)) return null
+  const token = content.slice(OPAQUE_PREFIX.length)
+  if (!token || !/^[A-Za-z0-9_-]+$/.test(token)) return null
+
+  try {
+    const base64 = token.replaceAll("-", "+").replaceAll("_", "/")
+    const padding = "=".repeat((4 - (base64.length % 4)) % 4)
+    const id = decodeUtf8(base64 + padding)
+    return id || null
+  } catch {
+    return null
+  }
+}
+
+function suggestion(result: DaemonSearchResult): OmniboxSuggestion {
+  return {
+    content: opaqueSuggestionContent(result.id),
+    description: `${escapeSuggestionDescription(result.title)} — <dim>${escapeSuggestionDescription(result.url)}</dim>`,
+  }
+}
+
+function navigableUrl(value: string | undefined): string | null {
+  if (!value) return null
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.href
+      : null
+  } catch {
+    return null
+  }
+}
+
+export function registerOmniboxListeners(facade: OmniboxFacade): void {
+  let inputRevision = 0
+
+  facade.setDefaultSuggestion("Search bookmarks in your local daemon")
+  facade.onInputChanged((text, suggestResults) => {
+    const revision = ++inputRevision
+    const query = text.trim()
+    if (!query) {
+      suggestResults([])
+      return
+    }
+
+    void (async () => {
+      try {
+        const selection = await facade.getDaemonSelection()
+        if (!selection) {
+          if (revision === inputRevision) suggestResults([])
+          return
+        }
+        if (!(await facade.hasHostPermission())) {
+          if (revision === inputRevision) suggestResults([])
+          return
+        }
+
+        const response = await facade.search(
+          selection.config,
+          query,
+          SEARCH_LIMIT
+        )
+        if (revision !== inputRevision) return
+        suggestResults(response.results.slice(0, SEARCH_LIMIT).map(suggestion))
+      } catch {
+        if (revision === inputRevision) suggestResults([])
+      }
+    })()
+  })
+
+  facade.onInputEntered((text, disposition) => {
+    const id = decodeOpaqueSuggestion(text)
+    if (!id) return
+
+    void (async () => {
+      try {
+        const selection = await facade.getDaemonSelection()
+        if (!selection) return
+        if (!(await facade.hasHostPermission())) return
+        const node = await facade.fetchNode(selection.config, id)
+        const url = navigableUrl(node.url)
+        if (!url) return
+        await facade.navigate(url, disposition)
+      } catch {
+        // Omnibox navigation is best-effort. A stale/deleted result, revoked
+        // permission, or stopped daemon leaves the current tab untouched.
+      }
+    })()
+  })
+}
+
+async function getDaemonSelection(): Promise<PersistedDaemonSelection | null> {
+  const [mode, config] = await Promise.all([
+    getAdapterModePreference(),
+    getDaemonConnectionConfig(),
+  ])
+  return mode === "daemon" && config ? { mode, config } : null
+}
+
+async function daemonRequest<T>(
+  config: DaemonConnectionConfig,
+  path: string
+): Promise<T> {
+  const response = await fetch(`${config.origin}${API_BASE}${path}`, {
+    headers: {
+      Accept: "application/json",
+      ...(config.bearerToken
+        ? { Authorization: `Bearer ${config.bearerToken}` }
+        : {}),
+    },
+  })
+  if (!response.ok)
+    throw new Error(`Daemon request failed (${response.status})`)
+  return (await response.json()) as T
+}
+
+export function createBrowserOmniboxFacade(): OmniboxFacade {
+  return {
+    onInputChanged(listener) {
+      chrome.omnibox.onInputChanged.addListener(listener)
+    },
+    onInputEntered(listener) {
+      chrome.omnibox.onInputEntered.addListener(listener)
+    },
+    setDefaultSuggestion(description) {
+      chrome.omnibox.setDefaultSuggestion({ description })
+    },
+    getDaemonSelection,
+    hasHostPermission: hasDaemonHostPermission,
+    search(config, query, limit) {
+      const params = new URLSearchParams({ q: query, limit: String(limit) })
+      return daemonRequest<DaemonSearchResponse>(
+        config,
+        `/search?${params.toString()}`
+      )
+    },
+    fetchNode(config, id) {
+      return daemonRequest<BookmarkNode>(
+        config,
+        `/bookmarks/${encodeURIComponent(id)}`
+      )
+    },
+    async navigate(url, disposition) {
+      if (disposition === "currentTab") {
+        await chrome.tabs.update({ url })
+        return
+      }
+      await chrome.tabs.create({
+        url,
+        active: disposition === "newForegroundTab",
+      })
+    },
+  }
+}

--- a/src/popup/capture-controller.test.ts
+++ b/src/popup/capture-controller.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest"
+import type { BookmarkNode, BrowserAdapter } from "@/browser/types"
+import {
+  CaptureController,
+  type CaptureControllerDependencies,
+} from "./capture-controller"
+
+function bookmarkAdapter(
+  overrides: {
+    tree?: BookmarkNode[]
+    rootFolderId?: string | null
+    rootIsCreatable?: boolean
+    healthReady?: boolean
+    create?: BrowserAdapter["bookmarks"]["create"]
+  } = {}
+): BrowserAdapter {
+  const tree = overrides.tree ?? [
+    {
+      id: "0",
+      title: "",
+      children: [
+        {
+          id: "1",
+          title: "Bookmarks Bar",
+          children: [{ id: "work", title: "Work", children: [] }],
+        },
+      ],
+    },
+  ]
+  return {
+    bookmarks: {
+      getTree: vi.fn().mockResolvedValue(tree),
+      getSubTree: vi.fn(),
+      create:
+        overrides.create ??
+        vi.fn().mockResolvedValue({ id: "created", title: "Example" }),
+      update: vi.fn(),
+      remove: vi.fn(),
+      removeTree: vi.fn(),
+      move: vi.fn(),
+      onChanged: vi.fn(() => vi.fn()),
+      onCreated: vi.fn(() => vi.fn()),
+      onRemoved: vi.fn(() => vi.fn()),
+      onMoved: vi.fn(() => vi.fn()),
+      openInManager: vi.fn(),
+      checkHealth: vi.fn().mockResolvedValue({
+        ready: overrides.healthReady ?? true,
+      }),
+      dispose: vi.fn(),
+    },
+    storage: {
+      get: vi
+        .fn()
+        .mockImplementation((key: string) =>
+          Promise.resolve(
+            key === "rootFolderId" ? (overrides.rootFolderId ?? null) : null
+          )
+        ),
+      set: vi.fn(),
+      remove: vi.fn(),
+    },
+    favicon: { getUrl: vi.fn(), isAvailable: vi.fn(() => false) },
+    capabilities: {
+      openInManager: false,
+      move: true,
+      reorder: false,
+      setChildOrder: false,
+      rootIsCreatable: overrides.rootIsCreatable,
+    },
+  }
+}
+
+function dependencies(
+  adapter: BrowserAdapter,
+  tab = { title: "Example page", url: "https://example.com/path" }
+): CaptureControllerDependencies {
+  return {
+    getActiveTab: vi.fn().mockResolvedValue(tab),
+    selectAdapter: vi.fn().mockResolvedValue({ mode: "browser", adapter }),
+  }
+}
+
+describe("CaptureController", () => {
+  it("uses the persisted root folder and exposes readable hierarchical paths", async () => {
+    const adapter = bookmarkAdapter({ rootFolderId: "work" })
+    const controller = new CaptureController(dependencies(adapter))
+
+    await controller.initialize()
+
+    expect(controller.getSnapshot()).toMatchObject({
+      phase: "ready",
+      title: "Example page",
+      url: "https://example.com/path",
+      folderId: "work",
+      sourceLabel: "Browser bookmarks",
+    })
+    expect(controller.getSnapshot().folders).toContainEqual({
+      id: "work",
+      label: "Bookmarks Bar > Work",
+    })
+    expect(adapter.bookmarks.checkHealth).toHaveBeenCalledOnce()
+  })
+
+  it("falls back through resolveCreateParentId when the stored root is stale", async () => {
+    const adapter = bookmarkAdapter({ rootFolderId: "deleted" })
+    const controller = new CaptureController(dependencies(adapter))
+
+    await controller.initialize()
+
+    expect(controller.getSnapshot().folderId).toBe("1")
+  })
+
+  it("rejects non-http pages without constructing an adapter", async () => {
+    const adapter = bookmarkAdapter()
+    const deps = dependencies(adapter, {
+      title: "Extensions",
+      url: "chrome://extensions",
+    })
+    const controller = new CaptureController(deps)
+
+    await controller.initialize()
+
+    expect(controller.getSnapshot()).toMatchObject({
+      phase: "error",
+      message: expect.stringContaining("regular http or https page"),
+    })
+    expect(deps.selectAdapter).not.toHaveBeenCalled()
+  })
+
+  it("prevents double submission and never persists the per-capture folder", async () => {
+    let finish!: (node: BookmarkNode) => void
+    const pending = new Promise<BookmarkNode>((resolve) => {
+      finish = resolve
+    })
+    const create = vi.fn().mockReturnValue(pending)
+    const adapter = bookmarkAdapter({ rootFolderId: "work", create })
+    const controller = new CaptureController(dependencies(adapter))
+    await controller.initialize()
+    controller.setFolderId("1")
+
+    const first = controller.submit()
+    const second = controller.submit()
+    finish({ id: "created", title: "Example page" })
+    await Promise.all([first, second])
+
+    expect(create).toHaveBeenCalledOnce()
+    expect(create).toHaveBeenCalledWith({
+      parentId: "1",
+      title: "Example page",
+      url: "https://example.com/path",
+    })
+    expect(adapter.storage.set).not.toHaveBeenCalled()
+    expect(controller.getSnapshot()).toMatchObject({
+      phase: "success",
+      message: "Saved to Bookmarks Bar.",
+    })
+  })
+
+  it("surfaces an unavailable selected source and disposes adapter resources", async () => {
+    const adapter = bookmarkAdapter({ healthReady: false })
+    const controller = new CaptureController(dependencies(adapter))
+
+    await controller.initialize()
+    expect(controller.getSnapshot()).toMatchObject({
+      phase: "error",
+      message: "The selected bookmark source is not ready.",
+    })
+
+    controller.dispose()
+    controller.dispose()
+    expect(adapter.bookmarks.dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/src/popup/capture-controller.ts
+++ b/src/popup/capture-controller.ts
@@ -1,0 +1,251 @@
+import type { AdapterMode, BrowserAdapter } from "@/browser/types"
+import { detectAdapter } from "@/browser"
+import { getAdapterModePreference } from "@/browser/adapter-preference"
+import {
+  buildRootFolderOptions,
+  resolveCreateParentId,
+  type RootFolderOption,
+} from "@/features/root-folder-select"
+
+export interface ActiveTab {
+  title?: string
+  url?: string
+}
+
+export interface CaptureSelection {
+  adapter: BrowserAdapter
+  mode: AdapterMode
+}
+
+export interface CaptureControllerDependencies {
+  getActiveTab(): Promise<ActiveTab | null>
+  selectAdapter(): Promise<CaptureSelection>
+}
+
+export type CapturePhase =
+  | "loading"
+  | "ready"
+  | "submitting"
+  | "success"
+  | "error"
+
+export interface CaptureSnapshot {
+  phase: CapturePhase
+  title: string
+  url: string
+  folders: RootFolderOption[]
+  folderId: string
+  sourceLabel: string
+  message: string | null
+}
+
+const INITIAL_SNAPSHOT: CaptureSnapshot = {
+  phase: "loading",
+  title: "",
+  url: "",
+  folders: [],
+  folderId: "",
+  sourceLabel: "",
+  message: null,
+}
+
+const SOURCE_LABELS: Record<AdapterMode, string> = {
+  browser: "Browser bookmarks",
+  daemon: "Local daemon",
+  standalone: "Standalone bookmarks",
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message
+    ? error.message
+    : "The bookmark could not be saved."
+}
+
+function parseCapturableUrl(value: string | undefined): URL | null {
+  if (!value) return null
+
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:" ? url : null
+  } catch {
+    return null
+  }
+}
+
+function readableTitle(tab: ActiveTab, url: URL): string {
+  const title = tab.title?.trim()
+  return title || url.hostname || url.href
+}
+
+function ensureSelectedFolderOption(
+  folders: RootFolderOption[],
+  folderId: string
+): RootFolderOption[] {
+  if (folders.some((folder) => folder.id === folderId)) return folders
+  return [{ id: folderId, label: "Bookmarks" }, ...folders]
+}
+
+export async function selectCurrentAdapter(): Promise<CaptureSelection> {
+  const mode = (await getAdapterModePreference()) ?? "browser"
+  const adapter = await detectAdapter()
+  return { adapter, mode }
+}
+
+export async function getCurrentTab(): Promise<ActiveTab | null> {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true })
+  return tab ? { title: tab.title, url: tab.url } : null
+}
+
+export function createCaptureDependencies(): CaptureControllerDependencies {
+  return {
+    getActiveTab: getCurrentTab,
+    selectAdapter: selectCurrentAdapter,
+  }
+}
+
+export class CaptureController {
+  private snapshot: CaptureSnapshot = INITIAL_SNAPSHOT
+  private adapter: BrowserAdapter | null = null
+  private disposed = false
+  private listeners = new Set<(snapshot: CaptureSnapshot) => void>()
+  private readonly dependencies: CaptureControllerDependencies
+
+  constructor(dependencies: CaptureControllerDependencies) {
+    this.dependencies = dependencies
+  }
+
+  getSnapshot(): CaptureSnapshot {
+    return this.snapshot
+  }
+
+  subscribe(listener: (snapshot: CaptureSnapshot) => void): () => void {
+    this.listeners.add(listener)
+    listener(this.snapshot)
+    return () => this.listeners.delete(listener)
+  }
+
+  private publish(next: CaptureSnapshot): void {
+    if (this.disposed) return
+    this.snapshot = next
+    for (const listener of this.listeners) listener(next)
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      const tab = await this.dependencies.getActiveTab()
+      const url = parseCapturableUrl(tab?.url)
+      if (!tab || !url) {
+        this.publish({
+          ...INITIAL_SNAPSHOT,
+          phase: "error",
+          message:
+            "This page cannot be bookmarked. Open a regular http or https page and try again.",
+        })
+        return
+      }
+
+      const selection = await this.dependencies.selectAdapter()
+      if (this.disposed) {
+        selection.adapter.bookmarks.dispose?.()
+        return
+      }
+      this.adapter = selection.adapter
+
+      if (selection.adapter.bookmarks.checkHealth) {
+        const health = await selection.adapter.bookmarks.checkHealth()
+        if (!health.ready) {
+          throw new Error("The selected bookmark source is not ready.")
+        }
+      }
+
+      const [tree, rootFolderId] = await Promise.all([
+        selection.adapter.bookmarks.getTree(),
+        selection.adapter.storage.get<string>("rootFolderId"),
+      ])
+      const folderId = resolveCreateParentId(
+        tree,
+        rootFolderId,
+        selection.adapter.capabilities.rootIsCreatable ?? false
+      )
+      if (!folderId) {
+        throw new Error("The selected bookmark source has no writable folder.")
+      }
+
+      const folders = ensureSelectedFolderOption(
+        buildRootFolderOptions(tree),
+        folderId
+      )
+      this.publish({
+        phase: "ready",
+        title: readableTitle(tab, url),
+        url: url.href,
+        folders,
+        folderId,
+        sourceLabel: SOURCE_LABELS[selection.mode],
+        message: null,
+      })
+    } catch (error) {
+      this.publish({
+        ...INITIAL_SNAPSHOT,
+        phase: "error",
+        message: errorMessage(error),
+      })
+    }
+  }
+
+  setTitle(title: string): void {
+    if (this.snapshot.phase !== "ready") return
+    this.publish({ ...this.snapshot, title })
+  }
+
+  setFolderId(folderId: string): void {
+    if (this.snapshot.phase !== "ready") return
+    if (!this.snapshot.folders.some((folder) => folder.id === folderId)) return
+    this.publish({ ...this.snapshot, folderId })
+  }
+
+  async submit(): Promise<void> {
+    if (this.snapshot.phase !== "ready" || !this.adapter) return
+    const title = this.snapshot.title.trim()
+    if (!title) {
+      this.publish({
+        ...this.snapshot,
+        message: "Enter a title before saving.",
+      })
+      return
+    }
+
+    const submitting = { ...this.snapshot, phase: "submitting" as const }
+    this.publish(submitting)
+    try {
+      await this.adapter.bookmarks.create({
+        parentId: submitting.folderId,
+        title,
+        url: submitting.url,
+      })
+      const folderLabel =
+        submitting.folders.find((folder) => folder.id === submitting.folderId)
+          ?.label ?? "the selected folder"
+      this.publish({
+        ...submitting,
+        phase: "success",
+        title,
+        message: `Saved to ${folderLabel}.`,
+      })
+    } catch (error) {
+      this.publish({
+        ...submitting,
+        phase: "ready",
+        message: errorMessage(error),
+      })
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.adapter?.bookmarks.dispose?.()
+    this.adapter = null
+    this.listeners.clear()
+  }
+}

--- a/src/popup/capture-popup.test.tsx
+++ b/src/popup/capture-popup.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { BrowserAdapter } from "@/browser/types"
+import type { CaptureControllerDependencies } from "./capture-controller"
+import { CapturePopup } from "./capture-popup"
+
+afterEach(cleanup)
+
+function popupDependencies(): {
+  dependencies: CaptureControllerDependencies
+  adapter: BrowserAdapter
+} {
+  const adapter: BrowserAdapter = {
+    bookmarks: {
+      getTree: vi.fn().mockResolvedValue([
+        {
+          id: "0",
+          title: "",
+          children: [{ id: "1", title: "Bookmarks Bar", children: [] }],
+        },
+      ]),
+      getSubTree: vi.fn(),
+      create: vi.fn().mockResolvedValue({
+        id: "created",
+        title: "Example",
+        url: "https://example.com/",
+      }),
+      update: vi.fn(),
+      remove: vi.fn(),
+      removeTree: vi.fn(),
+      move: vi.fn(),
+      onChanged: vi.fn(() => vi.fn()),
+      onCreated: vi.fn(() => vi.fn()),
+      onRemoved: vi.fn(() => vi.fn()),
+      onMoved: vi.fn(() => vi.fn()),
+      openInManager: vi.fn(),
+      dispose: vi.fn(),
+    },
+    storage: {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn(),
+      remove: vi.fn(),
+    },
+    favicon: { getUrl: vi.fn(), isAvailable: vi.fn(() => false) },
+    capabilities: {
+      openInManager: false,
+      move: true,
+      reorder: true,
+      setChildOrder: false,
+      rootIsCreatable: false,
+    },
+  }
+  return {
+    adapter,
+    dependencies: {
+      getActiveTab: vi.fn().mockResolvedValue({
+        title: "Example",
+        url: "https://example.com",
+      }),
+      selectAdapter: vi.fn().mockResolvedValue({ mode: "browser", adapter }),
+    },
+  }
+}
+
+describe("CapturePopup", () => {
+  it("renders accessible fields and a single primary save action", async () => {
+    const { dependencies, adapter } = popupDependencies()
+    const user = userEvent.setup()
+    render(<CapturePopup dependencies={dependencies} />)
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "Loading page details"
+    )
+    expect(
+      (await screen.findByRole("heading", { name: "Save this page" }))
+        .isConnected
+    ).toBe(true)
+    expect((screen.getByLabelText("Title") as HTMLInputElement).value).toBe(
+      "Example"
+    )
+    expect((screen.getByLabelText("Page") as HTMLInputElement).value).toBe(
+      "https://example.com/"
+    )
+    expect(screen.getByLabelText("Folder").textContent).toContain(
+      "Bookmarks Bar"
+    )
+
+    await user.click(screen.getByRole("button", { name: "Save bookmark" }))
+    await waitFor(() =>
+      expect(screen.getByText("Bookmark saved").isConnected).toBe(true)
+    )
+    expect(adapter.bookmarks.create).toHaveBeenCalledOnce()
+  })
+
+  it("clearly rejects an unsupported active page", async () => {
+    const { dependencies } = popupDependencies()
+    vi.mocked(dependencies.getActiveTab).mockResolvedValue({
+      title: "Settings",
+      url: "about:preferences",
+    })
+    render(<CapturePopup dependencies={dependencies} />)
+
+    expect((await screen.findByText("Cannot save this page")).isConnected).toBe(
+      true
+    )
+    expect(screen.getByRole("alert").textContent).toContain(
+      "regular http or https page"
+    )
+    expect(dependencies.selectAdapter).not.toHaveBeenCalled()
+  })
+})

--- a/src/popup/capture-popup.tsx
+++ b/src/popup/capture-popup.tsx
@@ -1,0 +1,200 @@
+import * as React from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { BookmarkAdd01Icon } from "@hugeicons/core-free-icons"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select"
+import { Spinner } from "@/components/ui/spinner"
+import {
+  CaptureController,
+  createCaptureDependencies,
+  type CaptureControllerDependencies,
+  type CaptureSnapshot,
+} from "./capture-controller"
+
+export interface CapturePopupProps {
+  dependencies?: CaptureControllerDependencies
+}
+
+export function CapturePopup({ dependencies }: CapturePopupProps) {
+  const [snapshot, setSnapshot] = React.useState<CaptureSnapshot>(() => ({
+    phase: "loading",
+    title: "",
+    url: "",
+    folders: [],
+    folderId: "",
+    sourceLabel: "",
+    message: null,
+  }))
+  const controllerRef = React.useRef<CaptureController | null>(null)
+
+  React.useEffect(() => {
+    const controller = new CaptureController(
+      dependencies ?? createCaptureDependencies()
+    )
+    controllerRef.current = controller
+    const unsubscribe = controller.subscribe(setSnapshot)
+    void controller.initialize()
+
+    return () => {
+      unsubscribe()
+      controller.dispose()
+      if (controllerRef.current === controller) controllerRef.current = null
+    }
+  }, [dependencies])
+
+  const isBusy = snapshot.phase === "loading" || snapshot.phase === "submitting"
+  const canSubmit =
+    snapshot.phase === "ready" && snapshot.title.trim().length > 0
+
+  return (
+    <main className="isolate flex min-h-64 w-96 max-w-full flex-col gap-5 bg-background p-5 text-foreground antialiased">
+      <header className="flex min-w-0 items-start gap-3">
+        <HugeiconsIcon
+          icon={BookmarkAdd01Icon}
+          className="size-4 shrink-0 stroke-foreground"
+          aria-hidden="true"
+        />
+        <div className="min-w-0 flex-1">
+          <h1 className="font-semibold text-balance">Save this page</h1>
+          <p className="truncate text-base text-pretty text-muted-foreground sm:text-sm">
+            {snapshot.sourceLabel || "Preparing bookmark source…"}
+          </p>
+        </div>
+      </header>
+
+      {snapshot.phase === "loading" ? (
+        <div
+          className="flex flex-1 items-center justify-center gap-2 text-base text-muted-foreground sm:text-sm"
+          role="status"
+          aria-live="polite"
+        >
+          <Spinner aria-hidden="true" />
+          Loading page details…
+        </div>
+      ) : snapshot.phase === "error" ? (
+        <Alert variant="destructive">
+          <AlertTitle>Cannot save this page</AlertTitle>
+          <AlertDescription>{snapshot.message}</AlertDescription>
+        </Alert>
+      ) : (
+        <form
+          className="flex flex-1 flex-col gap-5"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void controllerRef.current?.submit()
+          }}
+        >
+          <FieldGroup className="gap-4">
+            <Field
+              data-invalid={!snapshot.title.trim()}
+              data-disabled={isBusy || snapshot.phase === "success"}
+            >
+              <FieldLabel htmlFor="capture-title">Title</FieldLabel>
+              <Input
+                id="capture-title"
+                value={snapshot.title}
+                onChange={(event) =>
+                  controllerRef.current?.setTitle(event.target.value)
+                }
+                disabled={isBusy || snapshot.phase === "success"}
+                autoFocus
+                autoComplete="off"
+                aria-invalid={!snapshot.title.trim()}
+              />
+              {!snapshot.title.trim() ? (
+                <FieldError>A title is required.</FieldError>
+              ) : null}
+            </Field>
+
+            <Field>
+              <FieldLabel htmlFor="capture-url">Page</FieldLabel>
+              <Input id="capture-url" value={snapshot.url} readOnly />
+            </Field>
+
+            <Field data-disabled={isBusy || snapshot.phase === "success"}>
+              <FieldLabel htmlFor="capture-folder">Folder</FieldLabel>
+              <Select
+                value={snapshot.folderId}
+                onValueChange={(folderId) => {
+                  if (folderId) controllerRef.current?.setFolderId(folderId)
+                }}
+                disabled={isBusy || snapshot.phase === "success"}
+              >
+                <SelectTrigger id="capture-folder" className="w-full">
+                  <span className="truncate">
+                    {snapshot.folders.find(
+                      (folder) => folder.id === snapshot.folderId
+                    )?.label ?? "Choose a folder"}
+                  </span>
+                </SelectTrigger>
+                <SelectContent align="start" alignItemWithTrigger={false}>
+                  <SelectGroup>
+                    {snapshot.folders.map((folder) => (
+                      <SelectItem key={folder.id} value={folder.id}>
+                        {folder.label}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              <FieldDescription>
+                This choice applies only to this bookmark.
+              </FieldDescription>
+            </Field>
+          </FieldGroup>
+
+          {snapshot.message ? (
+            <Alert
+              variant={snapshot.phase === "success" ? "default" : "destructive"}
+              aria-live="polite"
+            >
+              <AlertTitle>
+                {snapshot.phase === "success"
+                  ? "Bookmark saved"
+                  : "Save failed"}
+              </AlertTitle>
+              <AlertDescription>{snapshot.message}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <Button
+            type="submit"
+            size="sm"
+            disabled={!canSubmit}
+            className="w-full"
+          >
+            {snapshot.phase === "submitting" ? (
+              <Spinner data-icon="inline-start" aria-hidden="true" />
+            ) : (
+              <HugeiconsIcon
+                icon={BookmarkAdd01Icon}
+                data-icon="inline-start"
+                aria-hidden="true"
+              />
+            )}
+            {snapshot.phase === "submitting"
+              ? "Saving…"
+              : snapshot.phase === "success"
+                ? "Saved"
+                : "Save bookmark"}
+          </Button>
+        </form>
+      )}
+    </main>
+  )
+}

--- a/src/popup/main.tsx
+++ b/src/popup/main.tsx
@@ -1,0 +1,14 @@
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+import { ThemeProvider } from "@/components/theme-provider"
+import { CapturePopup } from "./capture-popup"
+
+import "@/index.css"
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <ThemeProvider defaultTheme="dark">
+      <CapturePopup />
+    </ThemeProvider>
+  </StrictMode>
+)

--- a/vite.background.config.ts
+++ b/vite.background.config.ts
@@ -1,0 +1,36 @@
+/// <reference types="vitest/config" />
+import path from "path"
+import { defineConfig } from "vite"
+import pkg from "./package.json"
+import {
+  BACKGROUND_OUTPUT_FILE,
+  BACKGROUND_OUTPUT_FORMAT,
+} from "./src/extension/build-contract"
+
+/**
+ * The extension pages and background share adapter-preference modules. Build
+ * the background once more as a single IIFE after the multi-entry build so
+ * Firefox can load it as a classic MV3 background script without ESM imports.
+ * The same self-contained artifact is also valid as Chrome's module service
+ * worker. `emptyOutDir: false` preserves the extension pages and assets.
+ */
+export default defineConfig({
+  publicDir: false,
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
+  build: {
+    emptyOutDir: false,
+    lib: {
+      entry: path.resolve(__dirname, "./src/extension/background.ts"),
+      formats: [BACKGROUND_OUTPUT_FORMAT],
+      name: "BookmarksButBetterBackground",
+      fileName: () => BACKGROUND_OUTPUT_FILE,
+    },
+  },
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,10 @@ import tailwindcss from "@tailwindcss/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 import pkg from "./package.json"
+import {
+  BACKGROUND_OUTPUT_FILE,
+  buildEntryNames,
+} from "./src/extension/build-contract"
 
 /**
  * `bun run dev:daemon-ui` runs the Vite dev server against the frontend
@@ -23,6 +27,29 @@ export default defineConfig({
   },
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+  },
+  build: {
+    rollupOptions: {
+      input: Object.fromEntries(
+        buildEntryNames(process.env.VITE_BUILD_TARGET).map((name) => [
+          name,
+          path.resolve(
+            __dirname,
+            name === "index"
+              ? "index.html"
+              : name === "popup"
+                ? "popup.html"
+                : "src/extension/background.ts"
+          ),
+        ])
+      ),
+      output: {
+        entryFileNames: (chunk) =>
+          chunk.name === "background"
+            ? BACKGROUND_OUTPUT_FILE
+            : "assets/[name]-[hash].js",
+      },
+    },
   },
   server:
     process.env.VITE_BUILD_TARGET === "daemon"


### PR DESCRIPTION
## Summary

- add a browser-action capture popup for saving the active page into daemon-backed bookmarks
- add daemon bookmark search through the browser omnibox using the `bbb` keyword
- add the daemon search API, multi-target extension builds, manifests, and supporting UI components
- keep Firefox background output self-contained and extension assets out of the daemon build

## Why

Daemon-backed users could manage bookmarks in the application, but could not quickly capture the current browser page or surface daemon bookmarks as address-bar suggestions. This adds those browser-native entry points without synchronizing against a browser bookmark store.

## Validation

- 474 frontend tests
- TypeScript typecheck, ESLint, and Prettier
- Chrome, Firefox, and daemon production builds
- Rust workspace tests and doctests
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- independent Claude Sonnet review