### PR TITLE
Prepare version 4 for stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,99 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **Capture pages directly from Chrome and Firefox into a daemon vault.** The
-  extension action now opens a compact popup that saves the active page into a
-  writable vault folder, without mirroring or importing the browser's native
-  bookmark store
-- **Search daemon bookmarks from the browser address bar.** Type
-  `bookmarks-but-better`, press <kbd>Tab</kbd>, and enter a title or URL
-  fragment to see live suggestions; choosing one opens the current bookmark URL
-  with the browser's requested tab disposition
-- A bounded, case-insensitive `GET /api/v1/search` daemon endpoint for bookmark
-  titles and URLs, with deterministic ranking and opaque bookmark identifiers
-- **`npx bookmarks-but-better@latest` installs the daemon.** A published npm
-  package carrying no binaries: it downloads the installer for your platform
-  from the GitHub Release, verifies it against its published SHA-256, and runs
-  it, so the install it performs is as persistent as any other. Every installer
-  flag is forwarded, and `--version <tag>` pins the installer and the daemon to
-  the same release
-- **`install.sh` and `install.ps1` are release assets** under those exact names,
-  each with a `.sha256`. The documented command now fetches
-  `…/releases/latest/download/install.sh`, so what runs is the script published
-  alongside the archives it installs rather than whatever `main` holds
-
-### Fixed
-
-- **`install.sh` and `install.ps1` no longer fail out of the box.** Both default
-  to the latest *stable* release, and every stable release before this one is an
-  extension-only one carrying no daemon archive — so the documented
-  copy-and-paste command ended in `release v3.2.0 has no asset named
-  bookmarks-but-better-…` and installed nothing. Each now reports that and falls
-  back to the newest prerelease that does have a build for the platform. The
-  fallback needs no undoing later: a stable release shipping daemon archives is
-  resolved and installed normally
-- **`install.sh` can finish `bookmarks-but-better setup` under `curl … | bash`.**
-  Standard input there is the pipe the script itself arrived on, already read to
-  the end, so setup was handed an immediate EOF and died on its first question.
-  It is now run against the terminal, and where there is no terminal at all the
-  install completes and says to run `bookmarks-but-better setup` by hand
-
-### Changed
-
-- **Everything the project ships is named `bookmarks-but-better`.** The
-  executable, the crates, the release archives, the install directories and the
-  environment prefix (`BOOKMARKS_BUT_BETTER_*`) all use the full name; the
-  omnibox keyword is now `bookmarks-but-better`. This is a breaking change with
-  no aliases and no migration: an existing pre-release install has to be
-  reinstalled, and any vault created by an earlier beta has to be recreated or
-  updated manually to use the renamed metadata and control files
-- **The npm launcher has its own version lifecycle.** Its initial version is
-  `0.1.0`; future versions track changes to the bootstrapper itself rather than
-  mirroring daemon and extension releases
-- **`install.sh` needs no `jq`.** Both installers resolve a release from GitHub
-  Release URLs only — the `/releases/latest` redirect, the releases Atom feed
-  and `/releases/download/<tag>/<asset>` — instead of the GitHub JSON API, so
-  `curl`, `tar` and a SHA-256 tool are the whole toolchain
-
-- **The daemon's default port is now 52222** (was 47321). Several browsers on
-  one machine have to agree on where the daemon is without being told, so the
-  default moved to a port far less likely to collide. There is no compatibility
-  listener — the daemon binds one port — but an installation that was
-  *explicitly* configured on 47321 keeps working unchanged, and an explicit
-  `--port` is never replaced by the new default.
-
-## [4.0.0] - 2026-07-29
+## [4.0.0] - 2026-08-11
 
 ### Added
 
-- **Local-first daemon (`bookmarks-but-better`)** — a Rust daemon, HTTP API and CLI that serves a
-  Markdown vault, and optionally the built web UI, over loopback only. Ships as a
-  downloadable release archive for Linux (x86_64, aarch64), macOS (Intel, Apple
-  Silicon) and Windows (x86_64), each with a SHA-256 checksum and the built UI
-  bundled alongside the binary
-- `bookmarks-but-better init`, `doctor`, `rescan` and `serve` subcommands; every
-  one names its vault explicitly, with no path discovery and no configured
-  default
-- Canonical Markdown vault format (`bookmarks-but-better-vault-core`): parsing, validation,
-  deterministic scanning and byte-preserving updates, with stable identities that
-  survive moves, renames and restarts
+- **Local-first daemon (`bookmarks-but-better`)** — a Rust daemon, HTTP API and
+  CLI that serves a Markdown vault and, optionally, the web UI over loopback
+  only. Release archives cover Linux (x86_64 and aarch64), macOS (Intel and
+  Apple Silicon), and Windows (x86_64), each with a SHA-256 checksum
+- `bookmarks-but-better init`, `doctor`, `rescan`, `setup`, `serve` and
+  user-level service-management commands
+- Canonical Markdown vault format with deterministic scanning, byte-preserving
+  updates, stable identities, optimistic revisions and crash-safe recovery
 - Daemon-managed manual child ordering, so the organizer's drag-and-drop order
   persists in the vault
 - A daemon build target for the web UI (`bun run build:daemon`), served by the
   daemon from `--ui-dir`
-- Release pipeline: `v4.0.0-beta.N` tags produce a GitHub prerelease with
-  downloadable artifacts and never contact a store; stable `v4.0.0` tags produce a
-  normal release and gate store publishing behind a manually approved
-  `production-stores` environment
+- **Capture pages directly from Chrome and Firefox into a daemon vault** from a
+  compact extension popup, without importing the browser bookmark store
+- **Search daemon bookmarks from the address bar** with the
+  `bookmarks-but-better` omnibox keyword and deterministic title/URL ranking
+- **`npx bookmarks-but-better@latest` installs the daemon** through the same
+  checksum-verified release installers as the shell and PowerShell entry points
+- Release assets now include `install.sh` and `install.ps1`, their checksums,
+  both extension packages and five platform-specific daemon archives
+- Stable store publishing is gated by the manually approved
+  `production-stores` environment; beta tags never contact either store
 
 ### Fixed
 
-- Daemon mode now shows real site favicons instead of a generated letter placeholder for every bookmark
+- Existing v2/v3 users retain their completed setup state during upgrade, and
+  changing between Browser, Standalone and Daemon never reopens onboarding
+- Daemon mode now shows real site favicons instead of generated placeholders
+- Installers now fall back explicitly when a selected historical stable release
+  has no daemon archive, and piped shell installs correctly attach interactive
+  setup to the terminal
 
 ### Changed
 
+- Everything shipped by the project now uses the `bookmarks-but-better` name.
+  This only breaks pre-release daemon installations; released extension IDs and
+  user storage remain unchanged
+- The daemon's default port is now `52222`. An installation explicitly
+  configured on the previous `47321` default keeps that port
+- The npm launcher has an independent version lifecycle and ships no binaries
+- Installers resolve releases without `jq` or the GitHub JSON API
 - Daemon mode fetches favicons from Google's public favicon services. The primary
   provider (`t1.gstatic.com/faviconV2`) is the one every build already uses; the
   fallback is standalone's (`www.google.com/s2/favicons`), not the extension
@@ -211,7 +163,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rewrote README for end users with screenshots and badges
 
-[4.0.0]: https://github.com/farhadeidi/bookmarks-but-better/compare/v3.2.0...v4.0.0
+[4.0.0]: https://github.com/farhadeidi/bookmarks-but-better/compare/v3.2.1...v4.0.0
 [3.2.0]: https://github.com/farhadeidi/bookmarks-but-better/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/farhadeidi/bookmarks-but-better/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/farhadeidi/bookmarks-but-better/compare/v2.1.0...v3.0.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </picture>
 </p>
 
-<h1 align="center">Bookmarks - But Better</h1>
+<h1 align="center">Bookmarks But Better</h1>
 
 <p align="center">
   A clean, beautiful bookmarks dashboard that replaces your new tab page.
@@ -35,8 +35,14 @@
 - **Choose your root folder** — Display bookmarks from any folder
 - **Import and export** — Standard HTML bookmark files
 - **Smart favicons** — Sharp, high-quality site icons with a clean letter fallback when a site has none
-- **Always in sync** — Changes saved directly to your browser bookmarks
-- **100% private** — No analytics, no tracking, no data leaves your browser
+- **Quick capture** — Save the active tab from the extension popup
+- **Address-bar search** — Search a connected daemon vault with the `bookmarks-but-better` omnibox keyword
+- **Three bookmark sources** — Browser bookmarks, a browser-local standalone collection, or an optional Markdown vault daemon
+- **Private by design** — No account, analytics, tracking, ads, or bookmark-content collection
+
+Existing extension users upgrade in place. Version 4 preserves their selected
+root folder, layouts, themes and completed setup state; the setup wizard is not
+shown again unless they explicitly choose **Show setup wizard** in Settings.
 
 ## Install
 
@@ -85,6 +91,9 @@ npx bookmarks-but-better@latest
 All three install the same thing, from the same GitHub Release, checksum-verified.
 See [docs/DAEMON.md](docs/DAEMON.md) for what the install scripts do, and how to
 point the extension at the daemon.
+
+The daemon binds to loopback only. Connecting from the extension requests
+optional localhost access at that moment, not during extension installation.
 
 ## Screenshots
 

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -37,10 +37,13 @@ builtin option, and `/bin/sh` is dash on Debian and Ubuntu.
 
 ### Choosing a release
 
-Each installer resolves the latest **stable** release by default. Every stable
-release up to and including `v3.2.0` was extension-only and carried no daemon
-build; when the resolved release has no build for your platform, each reports
-that and falls back to the newest prerelease that does:
+Each installer resolves the latest **stable** release by default. Version 4 is
+the first stable release that carries daemon builds, so a normal install now
+resolves the stable archive directly.
+
+For historical or pinned extension-only releases up to `v3.2.0`, the installer
+reports the missing daemon asset and falls back to the newest prerelease that
+does carry a build. The fallback is explicit, never silent:
 
 ```
 resolving the latest stable release
@@ -49,8 +52,8 @@ falling back to the latest prerelease — pass --version <tag> to pin a specific
 installing v4.0.0-beta.2 (version 4.0.0-beta.2)
 ```
 
-The fallback is announced, never silent, and it is not reached at all once the
-resolved stable release carries daemon archives.
+The fallback is not reached for v4 or later stable releases that carry daemon
+archives.
 
 To choose explicitly rather than rely on the fallback:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -73,6 +73,20 @@ manifests. That is fine, because no store ever sees them.
 
 ## Cutting the stable release
 
+Before creating the stable tag:
+
+1. Install the unpacked Chrome and Firefox builds over profiles that have
+   completed setup on v3.2.1. Confirm the dashboard opens directly, the selected
+   root and appearance are unchanged, and the setup wizard is not shown.
+2. In a fresh profile, complete setup once in each bookmark-source mode. Restart
+   the extension and confirm setup stays closed. Then switch sources and repeat.
+3. Review `marketing/store-description.chrome.txt` and
+   `marketing/store-description.firefox.txt` against the final manifests,
+   especially permission and privacy disclosures.
+4. Confirm the store screenshots and promotional assets show the current v4 UI.
+5. Run `bun run check` and confirm the latest CI run is green on Linux, macOS
+   and Windows.
+
 ```sh
 git tag v4.0.0
 git push origin v4.0.0

--- a/marketing/store-description.chrome.txt
+++ b/marketing/store-description.chrome.txt
@@ -1,77 +1,57 @@
-Bookmarks But Better replaces your new tab page with a clean, organized bookmarks dashboard that puts your favorite sites front and center.
+Bookmarks But Better replaces your new tab page with a clean, organized dashboard for the bookmarks you already have.
 
-Every time you open a new tab, instead of an empty page or a search bar, you see your bookmarks laid out in a beautiful masonry grid. No more digging through menus, no more forgetting what you saved. Your bookmarks are right there, exactly where you need them.
+Open a new tab and see your folders in a responsive masonry layout instead of digging through browser menus. There is no account, no advertising, no analytics and no tracking.
 
-🆕 What's new in v3.1.0:
-- Bookmark Organizer: a full tree editor to drag, reorder, rename, create, and delete bookmarks and folders in one place
-- Create subfolders and bookmarks directly inside any folder from the tree or the folder card menu
-- Expand All / Collapse All and a Folders Only toggle to focus on structure
-- Cleaner toolbar with a frosted background so footer actions always stay visible
+WHAT'S NEW IN VERSION 4
 
-💡 Why you'll love it:
-Your browser already has your bookmarks. You already organized them into folders. But the default bookmark experience buries them behind menus and clicks. This extension takes what you already have and presents it beautifully. There's nothing to set up, no account to create, no data to import. Install it, open a new tab, and your bookmarks are already there.
+- Optional local-first Markdown vault powered by the Bookmarks But Better daemon
+- Save the active page from the extension popup when connected to a daemon vault
+- Search daemon bookmarks from the address bar: type “bookmarks-but-better”, press Tab, then search by title or URL
+- Import and export standard browser bookmark HTML files
+- Improved setup flow that preserves completed setup and existing preferences during upgrades
+- Reliable bookmark-root recovery when a previously selected folder was deleted
 
-✨ Features:
-- Drag and drop: reorder bookmarks within a folder or move them between folders by simply dragging and dropping
-- Bookmark Organizer: a dedicated tree editor to drag-and-drop reorder, rename, create, and delete bookmarks and folders across your entire library in one sheet
-- Folder management: create new folders, rename them, delete them, and rearrange folder tabs with drag-and-drop ordering
-- Masonry layout: your bookmark folders are displayed as cards in a responsive, Pinterest-style grid that adapts to your screen size
-- Two view modes per folder: switch between a detailed list view with titles and favicons, or a compact icon grid for folders you know by heart
-- Beautiful themes: choose from 10 handcrafted color themes including Default, Amber, Bubblegum, Caffeine, Claude, Claymorphism, Cyberpunk, Solar Dusk, T3 Chat, and Vintage Paper
-- Light and dark mode: follows your system preference automatically, or toggle manually with a single click. Press D on your keyboard to switch instantly
-- Edit everything inline: rename bookmarks, change URLs, create new bookmarks, and manage folders without ever leaving the page
-- Choose your root folder: pick any bookmark folder as your starting point. Only want to see your work bookmarks? Or just your personal ones? Set it in seconds
-- Import and export: bring bookmarks in or take them out using the standard HTML bookmark format that every browser understands
-- High-quality favicons: every bookmark gets a sharp, recognizable icon, even on high-resolution displays
-- Always in sync: every change you make is saved directly to your Chrome bookmarks. Edit a bookmark here and it updates everywhere
+FEATURES
 
-🔒 Built for privacy:
-This extension was built with a simple principle: your bookmarks are yours. There is no data collection. No analytics. No tracking. No ads. No account required. All your data stays in your browser using Chrome's built-in bookmarks and storage APIs. The only external request the extension makes is fetching website icons from Google's public favicon service, which is the same service Chrome itself uses.
+- Responsive masonry dashboard
+- Full Bookmark Organizer tree editor
+- Drag bookmarks between folders and reorder them
+- Create, rename and delete bookmarks and folders
+- List and icon-grid views per folder
+- Choose any folder as the dashboard root
+- Ten color themes plus light, dark and system modes
+- High-quality favicons with a clean letter fallback
+- Browser, standalone and optional daemon bookmark sources
+- Standard HTML import and export
 
-Your bookmarks deserve better than a dropdown menu. Give them a home.
+UPGRADING
 
-📋 Changelog:
+Version 4 upgrades in place. Existing users keep their root folder, layouts, themes and completed setup state. The setup wizard is shown again only when requested from Settings.
 
-v3.1.0 — Bookmark Organizer
-- Full tree editor: drag-and-drop reorder, rename, create, and delete bookmarks and folders
-- Per-folder create actions: add a subfolder or bookmark directly inside any folder
-- Expand All / Collapse All and Folders Only toggle
-- New Bookmark option in folder card context menu
-- Frosted FAB toolbar background for better visibility
+PRIVACY
 
-v3.0.0 — Drag & Drop, Folder Management, and Performance
-- Drag-and-drop bookmark sorting within and across folders
-- Folder order dialog for rearranging folder tabs
-- Create folder button
-- Performance: memoized components, lazy-loaded dialogs, eliminated double-refresh
-- Fixed bookmark links opening in new tab, drop indicator duplication, native drag interference
+Bookmarks But Better has no account system, analytics, tracking, ads or bookmark-content collection. Browser mode reads and updates bookmarks through Chrome's built-in APIs. Preferences remain local to the browser profile.
 
-v2.1.0 — Folder Actions and Layout Settings
-- Folder actions: rename, delete, and reorder folders
-- Layout settings for customizing bookmark grid columns
+Bookmark origins are sent to Google's public favicon service to retrieve icons; URL paths are not sent. Chrome can use its on-device favicon API as a fallback. Daemon mode is optional, binds to localhost only and is contacted only after the user explicitly connects it.
 
-v2.0.0 — Public Release
-- First-run onboarding wizard with theme selection
-- Curated seed bookmarks for new users
-- "Show in bookmark manager" action
-- Google Favicon V2 for higher quality icons
-- 10 handcrafted color themes
-- Import and export bookmarks
+PERMISSION JUSTIFICATIONS
 
-🔑 Permission justifications:
+activeTab: Reads the active tab's title and URL only when the user opens the extension popup to save that page.
 
-bookmarks: Core functionality. The extension reads and displays your Chrome bookmarks on the new tab page. It also allows you to create, edit, and delete bookmarks directly from the dashboard.
+bookmarks: Displays and manages the user's Chrome bookmark tree.
 
-storage: Used to save your preferences such as selected root folder, color theme, card layout mode, and onboarding completion status. All data is stored locally in your browser using Chrome's built-in storage API.
+storage: Saves local preferences, the selected root folder and completed setup state.
 
-favicon: Used to retrieve website icons for each bookmark via Chrome's built-in favicon API, so every bookmark displays a recognizable icon next to its title.
+favicon: Uses Chrome's local favicon API when the public favicon provider has no usable icon.
 
-tabs: Used to open Chrome's built-in bookmark manager when the user clicks "Show in bookmark manager" on a folder. This action opens a new tab pointing to chrome://bookmarks.
+clipboardWrite: Copies a bookmark URL when the user chooses Copy link.
 
-clipboardWrite: Used to copy bookmark URLs to the clipboard when the user clicks the "Copy link" action on a bookmark card.
+HOST PERMISSIONS
 
-Host permissions:
+https://t1.gstatic.com/*: Primary Google Favicon V2 provider.
 
-https://t1.gstatic.com/*: Used to fetch high-quality favicons from Google's Favicon V2 service. This is the primary source for bookmark icons displayed in the dashboard.
+https://www.google.com/*: Fallback Google S2 favicon provider.
 
-https://www.google.com/*: Used as a fallback favicon source via Google's S2 favicon service, in case the primary source does not return an icon for a given website.
+OPTIONAL HOST PERMISSIONS
+
+http://127.0.0.1/* and http://localhost/*: Requested only when the user connects the extension to their optional local daemon. They are not granted during installation.

--- a/marketing/store-description.firefox.txt
+++ b/marketing/store-description.firefox.txt
@@ -1,68 +1,51 @@
-Bookmarks But Better replaces your new tab page with a clean, organized bookmarks dashboard that puts your favorite sites front and center.
+Bookmarks But Better replaces your new tab page with a clean, organized dashboard for the bookmarks you already have. It can also be set as your Firefox homepage.
 
-Every time you open a new tab, instead of an empty page or a search bar, you see your bookmarks laid out in a beautiful masonry grid. No more digging through menus, no more forgetting what you saved. Your bookmarks are right there, exactly where you need them.
+Open a new tab and see your folders in a responsive masonry layout instead of digging through browser menus. There is no account, no advertising, no analytics and no tracking.
 
-🆕 What's new in v3.1.0:
-- Bookmark Organizer: a full tree editor to drag, reorder, rename, create, and delete bookmarks and folders in one place
-- Create subfolders and bookmarks directly inside any folder from the tree or the folder card menu
-- Expand All / Collapse All and a Folders Only toggle to focus on structure
-- Cleaner toolbar with a frosted background so footer actions always stay visible
+WHAT'S NEW IN VERSION 4
 
-💡 Why you'll love it:
-Your browser already has your bookmarks. You already organized them into folders. But the default bookmark experience buries them behind menus and clicks. This extension takes what you already have and presents it beautifully. There's nothing to set up, no account to create, no data to import. Install it, open a new tab, and your bookmarks are already there.
+- Optional local-first Markdown vault powered by the Bookmarks But Better daemon
+- Save the active page from the extension popup when connected to a daemon vault
+- Search daemon bookmarks from the address bar: type “bookmarks-but-better”, press Tab, then search by title or URL
+- Import and export standard browser bookmark HTML files
+- Improved setup flow that preserves completed setup and existing preferences during upgrades
+- Reliable bookmark-root recovery when a previously selected folder was deleted
 
-✨ Features:
-- Drag and drop: reorder bookmarks within a folder or move them between folders by simply dragging and dropping
-- Bookmark Organizer: a dedicated tree editor to drag-and-drop reorder, rename, create, and delete bookmarks and folders across your entire library in one sheet
-- Folder management: create new folders, rename them, delete them, and rearrange folder tabs with drag-and-drop ordering
-- Masonry layout: your bookmark folders are displayed as cards in a responsive, Pinterest-style grid that adapts to your screen size
-- Two view modes per folder: switch between a detailed list view with titles and favicons, or a compact icon grid for folders you know by heart
-- Beautiful themes: choose from 10 handcrafted color themes including Default, Amber, Bubblegum, Caffeine, Claude, Claymorphism, Cyberpunk, Solar Dusk, T3 Chat, and Vintage Paper
-- Light and dark mode: follows your system preference automatically, or toggle manually with a single click. Press D on your keyboard to switch instantly
-- Edit everything inline: rename bookmarks, change URLs, create new bookmarks, and manage folders without ever leaving the page
-- Choose your root folder: pick any bookmark folder as your starting point. Only want to see your work bookmarks? Or just your personal ones? Set it in seconds
-- Import and export: bring bookmarks in or take them out using the standard HTML bookmark format that every browser understands
-- High-quality favicons: every bookmark gets a sharp, recognizable icon, even on high-resolution displays
-- Always in sync: every change you make is saved directly to your browser bookmarks. Edit a bookmark here and it updates everywhere
+FEATURES
 
-🔒 Built for privacy:
-This extension was built with a simple principle: your bookmarks are yours. There is no data collection. No analytics. No tracking. No ads. No account required. All your data stays in your browser using your browser's built-in bookmarks and storage APIs. The only external request the extension makes is fetching website icons from Google's public favicon service.
+- Responsive masonry dashboard
+- Full Bookmark Organizer tree editor
+- Drag bookmarks between folders and reorder them
+- Create, rename and delete bookmarks and folders
+- List and icon-grid views per folder
+- Choose any folder as the dashboard root
+- Ten color themes plus light, dark and system modes
+- High-quality favicons with a clean letter fallback
+- Browser, standalone and optional daemon bookmark sources
+- Standard HTML import and export
 
-Your bookmarks deserve better than a dropdown menu. Give them a home.
+UPGRADING
 
-📋 Changelog:
+Version 4 upgrades in place. Existing users keep their root folder, layouts, themes and completed setup state. The setup wizard is shown again only when requested from Settings.
 
-v3.1.0 — Bookmark Organizer
-- Full tree editor: drag-and-drop reorder, rename, create, and delete bookmarks and folders
-- Per-folder create actions: add a subfolder or bookmark directly inside any folder
-- Expand All / Collapse All and Folders Only toggle
-- New Bookmark option in folder card context menu
-- Frosted FAB toolbar background for better visibility
+PRIVACY
 
-v3.0.0 — Drag & Drop, Folder Management, and Performance
-- Drag-and-drop bookmark sorting within and across folders
-- Folder order dialog for rearranging folder tabs
-- Create folder button
-- Performance: memoized components, lazy-loaded dialogs, eliminated double-refresh
-- Fixed bookmark links opening in new tab, drop indicator duplication, native drag interference
+Bookmarks But Better has no account system, analytics, tracking, ads or bookmark-content collection. Browser mode reads and updates bookmarks through Firefox's built-in APIs. Preferences remain local to the browser profile.
 
-v2.1.0 — Folder Actions and Layout Settings
-- Folder actions: rename, delete, and reorder folders
-- Layout settings for customizing bookmark grid columns
+Bookmark origins are sent to Google's public favicon service to retrieve icons; URL paths are not sent. Daemon mode is optional, binds to localhost only and is contacted only after the user explicitly connects it.
 
-v2.0.0 — Public Release
-- First-run onboarding wizard with theme selection
-- Curated seed bookmarks for new users
-- Google Favicon V2 for higher quality icons
-- 10 handcrafted color themes
-- Import and export bookmarks
+PERMISSION JUSTIFICATIONS
 
-🔑 Permission justifications:
+activeTab: Reads the active tab's title and URL only when the user opens the extension popup to save that page.
 
-bookmarks: Core functionality. The extension reads and displays your bookmarks on the new tab page. It also allows you to create, edit, and delete bookmarks directly from the dashboard.
+bookmarks: Displays and manages the user's Firefox bookmark tree.
 
-storage: Used to save your preferences such as selected root folder, color theme, card layout mode, and onboarding completion status. All data is stored locally in your browser using the browser's built-in storage API.
+storage: Saves local preferences, the selected root folder and completed setup state.
 
-Host permissions:
+HOST PERMISSIONS
 
-https://t1.gstatic.com/*: Used to fetch high-quality favicons from Google's Favicon V2 service. This is the sole source for bookmark icons displayed in the dashboard.
+https://t1.gstatic.com/*: Google Favicon V2 provider.
+
+OPTIONAL HOST PERMISSIONS
+
+http://127.0.0.1/* and http://localhost/*: Requested only when the user connects the extension to their optional local daemon. They are not granted during installation.

--- a/src/browser/onboarding-preference.test.ts
+++ b/src/browser/onboarding-preference.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { installFakeIndexedDB } from "./__tests__/fake-indexeddb"
+import {
+  getOnboardingCompleted,
+  setOnboardingCompleted,
+} from "./onboarding-preference"
+
+beforeEach(() => {
+  installFakeIndexedDB()
+})
+
+describe("onboarding preference", () => {
+  it("distinguishes an unset profile from explicit completion state", async () => {
+    expect(await getOnboardingCompleted()).toBeNull()
+
+    await setOnboardingCompleted(true)
+    expect(await getOnboardingCompleted()).toBe(true)
+
+    await setOnboardingCompleted(false)
+    expect(await getOnboardingCompleted()).toBe(false)
+  })
+})

--- a/src/browser/onboarding-preference.ts
+++ b/src/browser/onboarding-preference.ts
@@ -1,0 +1,62 @@
+/**
+ * Adapter-independent onboarding state.
+ *
+ * The active adapter can change between Browser, Standalone and Daemon, but
+ * completing product onboarding is a property of this extension profile, not
+ * of a bookmark source. Keeping it in the same fixed IndexedDB store as the
+ * adapter-routing preference makes it survive source changes.
+ *
+ * Older releases stored `onboardingCompleted` behind the active
+ * StorageAdapter. Bootstrap migrates that value into this key on first use and
+ * the wizard continues writing the legacy key for downgrade compatibility.
+ */
+
+const DB_NAME = "bookmarks-but-better-prefs"
+const DB_VERSION = 1
+const STORE_NAME = "preferences"
+const ONBOARDING_COMPLETED_KEY = "bookmarks-but-better.onboardingCompleted"
+
+function openPreferenceDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION)
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME)
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+}
+
+export async function getOnboardingCompleted(): Promise<boolean | null> {
+  try {
+    const db = await openPreferenceDB()
+    return await new Promise<boolean | null>((resolve) => {
+      const tx = db.transaction(STORE_NAME, "readonly")
+      const request = tx.objectStore(STORE_NAME).get(ONBOARDING_COMPLETED_KEY)
+      request.onsuccess = () =>
+        resolve(typeof request.result === "boolean" ? request.result : null)
+      request.onerror = () => resolve(null)
+    })
+  } catch {
+    return null
+  }
+}
+
+export async function setOnboardingCompleted(value: boolean): Promise<void> {
+  try {
+    const db = await openPreferenceDB()
+    await new Promise<void>((resolve) => {
+      const tx = db.transaction(STORE_NAME, "readwrite")
+      const request = tx
+        .objectStore(STORE_NAME)
+        .put(value, ONBOARDING_COMPLETED_KEY)
+      request.onsuccess = () => resolve()
+      request.onerror = () => resolve()
+    })
+  } catch {
+    // Best-effort, matching the adapter preference persistence contract.
+  }
+}

--- a/src/features/onboarding/__tests__/onboarding-wizard.test.tsx
+++ b/src/features/onboarding/__tests__/onboarding-wizard.test.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from "@/components/theme-provider"
 import { usePreferencesStore } from "@/stores/preferences-store"
 import { useBookmarkStore } from "@/stores/bookmark-store"
 import { OnboardingWizard } from "../onboarding-wizard"
+import { getOnboardingCompleted } from "@/browser/onboarding-preference"
 
 class StubResizeObserver {
   observe() {}
@@ -157,6 +158,9 @@ describe("OnboardingWizard mode step", () => {
       expect(
         usePreferencesStore.getState().setAdapterMode
       ).toHaveBeenCalledWith("browser")
+    })
+    await waitFor(async () => {
+      expect(await getOnboardingCompleted()).toBe(true)
     })
   })
 })

--- a/src/features/onboarding/onboarding-wizard.tsx
+++ b/src/features/onboarding/onboarding-wizard.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { resolveEffectiveCreateParentId } from "@/features/root-folder-select"
 import type { AdapterMode } from "@/browser/types"
+import { setOnboardingCompleted } from "@/browser/onboarding-preference"
 
 type ThemeMode = "light" | "dark" | "system"
 
@@ -166,8 +167,12 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
     setStoreColorTheme(colorTheme)
     setTheme(themeMode)
 
-    // Set onboarding completed flag
-    await adapter?.storage.set("onboardingCompleted", true)
+    // The global value survives adapter changes. Keep the legacy adapter value
+    // too so a downgrade to v3 does not show onboarding again.
+    await Promise.all([
+      setOnboardingCompleted(true),
+      adapter?.storage.set("onboardingCompleted", true),
+    ])
 
     onComplete()
   }
@@ -180,7 +185,10 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
     setStoreColorTheme("default")
     setTheme("dark")
 
-    await adapter?.storage.set("onboardingCompleted", true)
+    await Promise.all([
+      setOnboardingCompleted(true),
+      adapter?.storage.set("onboardingCompleted", true),
+    ])
 
     onComplete()
   }

--- a/src/features/settings/__tests__/settings-dialog-onboarding.test.tsx
+++ b/src/features/settings/__tests__/settings-dialog-onboarding.test.tsx
@@ -7,6 +7,7 @@ import { useUIStore } from "@/stores/ui-store"
 import { usePreferencesStore } from "@/stores/preferences-store"
 import { useBookmarkStore } from "@/stores/bookmark-store"
 import { SettingsDialog } from "../settings-dialog"
+import { getOnboardingCompleted } from "@/browser/onboarding-preference"
 
 class StubResizeObserver {
   observe() {}
@@ -58,6 +59,9 @@ describe("SettingsDialog setup wizard", () => {
     fireEvent.click(screen.getByRole("button", { name: "Show setup wizard" }))
 
     expect(storageSet).toHaveBeenCalledWith("onboardingCompleted", false)
+    await vi.waitFor(async () => {
+      expect(await getOnboardingCompleted()).toBe(false)
+    })
     await vi.waitFor(() => {
       expect(useUIStore.getState().settingsOpen).toBe(false)
       expect(useUIStore.getState().onboardingOpen).toBe(true)

--- a/src/features/settings/settings-dialog.tsx
+++ b/src/features/settings/settings-dialog.tsx
@@ -52,6 +52,7 @@ import {
 } from "./export-scope"
 import { DaemonConnectionPanel } from "./daemon-connection-panel"
 import type { BookmarkNode } from "@/browser"
+import { setOnboardingCompleted } from "@/browser/onboarding-preference"
 
 /** A parsed file waiting for the user to confirm where it should land. */
 interface PendingImport {
@@ -145,7 +146,10 @@ export function SettingsDialog() {
   }
 
   const handleShowOnboarding = async () => {
-    await adapter?.storage.set("onboardingCompleted", false)
+    await Promise.all([
+      setOnboardingCompleted(false),
+      adapter?.storage.set("onboardingCompleted", false),
+    ])
     closeSettings()
     openOnboarding()
   }

--- a/src/hooks/use-app-bootstrap.test.tsx
+++ b/src/hooks/use-app-bootstrap.test.tsx
@@ -1,17 +1,25 @@
 // @vitest-environment jsdom
 
 import * as React from "react"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { render, waitFor, cleanup } from "@testing-library/react"
 import { useAppBootstrap } from "./use-app-bootstrap"
 import { useBookmarkStore } from "@/stores/bookmark-store"
+import { useUIStore } from "@/stores/ui-store"
+import { installFakeIndexedDB } from "@/browser/__tests__/fake-indexeddb"
+import {
+  getOnboardingCompleted,
+  setOnboardingCompleted,
+} from "@/browser/onboarding-preference"
 import type { BrowserAdapter } from "@/browser"
 
 vi.mock("@/browser", () => ({
   detectAdapter: vi.fn(),
 }))
 
-function createMockAdapter() {
+installFakeIndexedDB()
+
+function createMockAdapter(legacyOnboardingCompleted: boolean | null = null) {
   const listeners = {
     changed: new Set<() => void>(),
     created: new Set<() => void>(),
@@ -47,7 +55,13 @@ function createMockAdapter() {
       openInManager: vi.fn(),
     },
     storage: {
-      get: vi.fn().mockResolvedValue(null),
+      get: vi
+        .fn()
+        .mockImplementation((key: string) =>
+          Promise.resolve(
+            key === "onboardingCompleted" ? legacyOnboardingCompleted : null
+          )
+        ),
       set: vi.fn().mockResolvedValue(undefined),
       remove: vi.fn().mockResolvedValue(undefined),
     },
@@ -82,12 +96,61 @@ function Harness() {
   return null
 }
 
+beforeEach(() => {
+  installFakeIndexedDB()
+  useUIStore.setState({ onboardingOpen: false })
+})
+
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
+  installFakeIndexedDB()
 })
 
 describe("useAppBootstrap", () => {
+  it("migrates a completed v2-v3 setup and does not reopen onboarding", async () => {
+    const { adapter } = createMockAdapter(true)
+    const { detectAdapter } = await import("@/browser")
+    vi.mocked(detectAdapter).mockResolvedValue(adapter)
+
+    render(<Harness />)
+
+    await waitFor(() => {
+      expect(adapter.storage.get).toHaveBeenCalledWith("onboardingCompleted")
+    })
+    await waitFor(async () => {
+      expect(await getOnboardingCompleted()).toBe(true)
+    })
+    expect(useUIStore.getState().onboardingOpen).toBe(false)
+  })
+
+  it("keeps onboarding closed after the adapter changes", async () => {
+    await setOnboardingCompleted(true)
+    const { adapter } = createMockAdapter(null)
+    const { detectAdapter } = await import("@/browser")
+    vi.mocked(detectAdapter).mockResolvedValue(adapter)
+
+    render(<Harness />)
+
+    await waitFor(() => {
+      expect(useBookmarkStore.getState().isLoading).toBe(false)
+    })
+    expect(adapter.storage.get).not.toHaveBeenCalledWith("onboardingCompleted")
+    expect(useUIStore.getState().onboardingOpen).toBe(false)
+  })
+
+  it("opens onboarding for a genuinely fresh profile", async () => {
+    const { adapter } = createMockAdapter(null)
+    const { detectAdapter } = await import("@/browser")
+    vi.mocked(detectAdapter).mockResolvedValue(adapter)
+
+    render(<Harness />)
+
+    await waitFor(() => {
+      expect(useUIStore.getState().onboardingOpen).toBe(true)
+    })
+  })
+
   it("unsubscribes all bookmark listeners on unmount, including under StrictMode double-invoke", async () => {
     const { adapter, listeners } = createMockAdapter()
     const { detectAdapter } = await import("@/browser")

--- a/src/hooks/use-app-bootstrap.ts
+++ b/src/hooks/use-app-bootstrap.ts
@@ -4,6 +4,10 @@ import { useBookmarkStore } from "@/stores/bookmark-store"
 import { usePreferencesStore } from "@/stores/preferences-store"
 import { useUIStore } from "@/stores/ui-store"
 import { getScreenshotMode } from "@/hooks/use-screenshot-mode"
+import {
+  getOnboardingCompleted,
+  setOnboardingCompleted,
+} from "@/browser/onboarding-preference"
 
 /**
  * Detects the active adapter and initializes the bookmark and preferences
@@ -41,9 +45,21 @@ export function useAppBootstrap() {
       if (screenshotMode === "onboarding") {
         openOnboarding()
       } else if (!screenshotMode) {
-        const onboardingCompleted = await adapter.storage.get<boolean>(
-          "onboardingCompleted"
-        )
+        let onboardingCompleted = await getOnboardingCompleted()
+
+        // v2-v3 stored this flag behind the active adapter. Import a completed
+        // setup into the adapter-independent key once, so changing bookmark
+        // sources in v4 can never make an established user look new again.
+        if (onboardingCompleted === null) {
+          const legacyCompleted = await adapter.storage.get<boolean>(
+            "onboardingCompleted"
+          )
+          onboardingCompleted = legacyCompleted === true
+          if (onboardingCompleted) {
+            await setOnboardingCompleted(true)
+          }
+        }
+
         if (!cancelled && !onboardingCompleted) {
           openOnboarding()
         }


### PR DESCRIPTION
## Summary

- make onboarding completion profile-wide instead of bookmark-adapter-specific
- migrate the legacy v2/v3 `onboardingCompleted` value without showing setup again
- preserve the legacy adapter value for downgrade compatibility
- keep the explicit “Show setup wizard” action working across all bookmark sources
- add regression coverage for legacy upgrades, fresh profiles and adapter switches
- finalize the v4 changelog, README, daemon docs and stable-release checklist
- update Chrome Web Store and Firefox AMO listing copy, permissions and privacy disclosures
- leave all existing marketing images unchanged

## Why

Version 4 introduces Browser, Standalone and Daemon bookmark sources. Onboarding completion previously lived behind the active source, so changing sources could make an established profile appear new and reopen the wizard. Existing extension users must upgrade without losing preferences or seeing setup again.

The new profile-wide preference is stored in the fixed IndexedDB preferences store. On first v4 startup, a completed v2/v3 adapter-local value is migrated automatically. The legacy value continues to be written so downgrading does not reopen onboarding.

## User impact

Existing Chrome and Firefox users retain their selected root folder, layouts, themes and completed setup state. Fresh profiles still see setup once. Users can still reopen it explicitly from Settings.

## Validation

- `bun run check`
  - Prettier
  - ESLint
  - TypeScript
  - 54 test files / 478 tests
  - Chrome production build
  - Firefox production build
  - daemon UI production build
- `bun run test:npm`: 17/17 passed
- `bash tests/install/smoke-test.sh`: 19/19 passed
- version alignment confirmed at `4.0.0` in package, Chrome manifest, Firefox manifest and Cargo workspace
- no image assets are changed