### PR TITLE
chore: prepare v4.1.0 beta release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,13 @@ name: Release
 
 # What a tag does — and nothing else does it.
 #
-#   git push origin v4.0.0-beta.1
+#   git push origin v4.1.0-beta.1
 #       Builds and tests every deliverable, then publishes a GitHub
-#       *prerelease* carrying the Chrome zip, the Firefox zip and a daemon
-#       archive for each supported platform. No store is contacted. There is no
-#       approval to give, because there is no job to approve.
+#       *prerelease* carrying the Chrome, Firefox and Safari zips plus a daemon
+#       archive for each supported platform. No store is contacted. There is
+#       no approval to give, because there is no job to approve.
 #
-#   git push origin v4.0.0
+#   git push origin v4.1.0
 #       The same build and the same tests, published as a normal GitHub
 #       Release. Only then does `publish-stores` become available, and it waits
 #       on the `production-stores` environment — a human has to approve the
@@ -116,8 +116,8 @@ jobs:
             exit 1
           fi
 
-          version="${REF_NAME#v}"     # 4.0.0        or 4.0.0-beta.1
-          base="${version%%-*}"       # 4.0.0        either way
+          version="${REF_NAME#v}"     # 4.1.0        or 4.1.0-beta.1
+          base="${version%%-*}"       # 4.1.0        either way
           if [ "$version" = "$base" ]; then prerelease=false; else prerelease=true; fi
 
           # Every version file carries the *base* version. A browser manifest
@@ -130,6 +130,7 @@ jobs:
           pkg=$(jq -r '.version' package.json)
           chrome=$(jq -r '.version' manifests/manifest.chrome.json)
           firefox=$(jq -r '.version' manifests/manifest.firefox.json)
+          safari=$(jq -r '.version' manifests/manifest.safari.json)
           cargo=$(awk '
             /^\[workspace\.package\]/ { in_section = 1; next }
             /^\[/                     { in_section = 0 }
@@ -142,7 +143,8 @@ jobs:
 
           for pair in "package.json:$pkg" \
                       "manifest.chrome.json:$chrome" \
-                      "manifest.firefox.json:$firefox" "Cargo.toml:$cargo"; do
+                      "manifest.firefox.json:$firefox" \
+                      "manifest.safari.json:$safari" "Cargo.toml:$cargo"; do
             file="${pair%%:*}"; value="${pair#*:}"
             if [ "$value" != "$base" ]; then
               note "$file says '$value' but tag $REF_NAME means '$base'."
@@ -151,7 +153,9 @@ jobs:
 
           # A manifest that ever grew a prerelease suffix would be rejected by
           # the store at upload time, which is far too late to find out.
-          for pair in "manifest.chrome.json:$chrome" "manifest.firefox.json:$firefox"; do
+          for pair in "manifest.chrome.json:$chrome" \
+                      "manifest.firefox.json:$firefox" \
+                      "manifest.safari.json:$safari"; do
             file="${pair%%:*}"; value="${pair#*:}"
             if [[ ! "$value" =~ ^[0-9]+(\.[0-9]+){0,3}$ ]]; then
               note "$file version '$value' is not a valid browser extension version" \
@@ -214,7 +218,7 @@ jobs:
       contents: read
 
   # --------------------------------------------------------------------------
-  # 3. The web deliverables: both extensions, and the UI the daemon serves.
+  # 3. The web deliverables: all three extensions, and the UI the daemon serves.
   # --------------------------------------------------------------------------
   web:
     name: Build the extensions and the daemon UI
@@ -235,11 +239,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # The three `build:*` scripts, unchanged and called by their own names.
+      # The extension and daemon build scripts, unchanged and called by name.
       # Nothing here patches a manifest or rewrites a version: what ships is
       # what `bun run build:chrome` produces on a developer's machine.
       - name: Build the extensions
-        run: bun run build
+        run: bun run build && bun run build:safari
 
       - name: Build the daemon UI
         run: bun run build:daemon
@@ -250,7 +254,7 @@ jobs:
         run: |
           set -euo pipefail
           base="${VERSION%%-*}"
-          for dist in dist-chrome dist-firefox; do
+          for dist in dist-chrome dist-firefox dist-safari; do
             built=$(jq -r '.version' "$dist/manifest.json")
             if [ "$built" != "$base" ]; then
               echo "::error::$dist/manifest.json says '$built', expected '$base'."
@@ -271,6 +275,7 @@ jobs:
           mkdir -p artifacts
           (cd dist-chrome && zip -r -q "../artifacts/bookmarks-but-better-chrome-$VERSION.zip" .)
           (cd dist-firefox && zip -r -q "../artifacts/bookmarks-but-better-firefox-$VERSION.zip" .)
+          (cd dist-safari && zip -r -q "../artifacts/bookmarks-but-better-safari-$VERSION.zip" .)
           cd artifacts
           for file in *.zip; do
             sha256sum "$file" > "$file.sha256"
@@ -1074,7 +1079,7 @@ jobs:
         env:
           OUTCOME: ${{ steps.chrome.outcome }}
           VERSION: ${{ needs.validate.outputs.version }}
-          # The ref to pick under *Use workflow from* is the tag, `v4.0.0` —
+          # The ref to pick under *Use workflow from* is the tag, `v4.1.0` —
           # not the bare version. Naming the wrong one sends the operator to a
           # dropdown entry that does not exist.
           TAG: ${{ needs.validate.outputs.tag }}
@@ -1159,8 +1164,8 @@ jobs:
           OUTCOME: ${{ steps.amo.outcome }}
           ADDON_ID: ${{ steps.amo.outputs.addon_id }}
           VERSION: ${{ needs.validate.outputs.version }}
-          # The tag, `v4.0.0` — the ref to select under *Use workflow from*.
-          # `VERSION` is the bare `4.0.0` and matches no dropdown entry.
+          # The tag, `v4.1.0` — the ref to select under *Use workflow from*.
+          # `VERSION` is the bare `4.1.0` and matches no dropdown entry.
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0] - 2026-08-17
+
 ### Added
 
 - **Source Configuration** — enabled sources plus one Active Source per browser
@@ -32,9 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`bun run build:safari`) whose manifest omits the bookmarks API, omnibox and
   new-tab override Safari does not provide; product code branches on
   capabilities, not browser names
-- **Categorized settings** — General, Sources, Appearance, Bookmarks,
-  Data & Migration, Advanced and About, as vertical tabs on wide screens and a
-  compact selector on narrow ones
+- **Categorized settings** — General, Sources, Appearance, Data & Migration,
+  Advanced and About, as vertical tabs on wide screens and a compact selector
+  on narrow ones. Browser-specific bookmark options live inside the Browser
+  Source section rather than appearing for Daemon Sources
+- **Profile-local source labels and Vault controls** — rename source labels,
+  refresh a daemon's Vault list, enable sources independently, and forget a
+  connection without conflating those actions
 - **Dev Workbench** — `bun run dev` opens the complete application in a plain
   browser, no extension and no daemon required, against deterministic
   URL-addressable scenarios (`browser-daemon` by default, plus
@@ -60,6 +66,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profile-wide preferences (theme, layout width, nested folders) now survive
   source switches unchanged; per-folder layouts and the root folder remain
   scoped to their source
+- The dashboard source switcher follows the active theme, has responsive
+  spacing, and bookmark cards use the full available width on mobile
+- The floating action toolbar now contains only Bookmark Tree and Settings;
+  appearance and product information remain available inside Settings
+
+### Fixed
+
+- Daemon discovery now keeps Source Configuration and the live Source Session
+  synchronized when an Active Vault disappears or changes protocol, without
+  restarting for a display-label-only rename
+- Daemon-only onboarding starts with the Daemon Source selected, so Safari
+  users cannot skip the required connection step
+- Dev Workbench Reset clears source preferences as well as bookmark trees and
+  rejects late writes from the previous scenario
+- Development seed scenarios now use the complete bookmark fixture and load
+  real favicons with the same fallback behavior as production
 
 ## [4.0.0] - 2026-08-11
 
@@ -217,6 +239,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rewrote README for end users with screenshots and badges
 
+[4.1.0]: https://github.com/farhadeidi/bookmarks-but-better/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/farhadeidi/bookmarks-but-better/compare/v3.2.1...v4.0.0
 [3.2.0]: https://github.com/farhadeidi/bookmarks-but-better/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/farhadeidi/bookmarks-but-better/compare/v3.0.0...v3.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "bookmarks-but-better"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "axum",
  "bookmarks-but-better-vault-core",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "bookmarks-but-better-vault-core"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "cap-fs-ext",
  "cap-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ members = ["crates/bookmarks-but-better", "crates/bookmarks-but-better-vault-cor
 
 [workspace.package]
 # The Rust crates carry the product version, the same one `package.json` and
-# both extension manifests carry, so a release tag names one number rather than
+# all extension manifests carry, so a release tag names one number rather than
 # one per language. `GET /api/v1/health` and `bookmarks-but-better --version` report it straight
 # from `CARGO_PKG_VERSION`.
-version = "4.0.0"
+version = "4.1.0"
 edition = "2024"
 rust-version = "1.97.1"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -55,12 +55,14 @@ shown again unless they explicitly choose **Show setup wizard** in Settings.
 Or load manually:
 
 **Chrome**
+
 1. Clone this repository
 2. Run `bun install && bun run build:chrome`
 3. Open `chrome://extensions`, enable **Developer mode**
 4. Click **Load unpacked** and select the `dist-chrome/` folder
 
 **Firefox**
+
 1. Clone this repository
 2. Run `bun install && bun run build:firefox`
 3. Open `about:debugging#/runtime/this-firefox`
@@ -137,8 +139,8 @@ permission and mutation behavior. See
 A tag ships everything, and nothing else does:
 
 ```bash
-git push origin v4.0.0-beta.1   # GitHub prerelease with downloadable artifacts, no store
-git push origin v4.0.0          # GitHub release, then store publishing after an approval
+git push origin v4.1.0-beta.1   # GitHub prerelease with downloadable artifacts, no store
+git push origin v4.1.0          # GitHub release, then store publishing after an approval
 ```
 
 See [docs/RELEASING.md](docs/RELEASING.md) for the version checklist, the

--- a/crates/bookmarks-but-better/Cargo.toml
+++ b/crates/bookmarks-but-better/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 # The format itself lives in `bookmarks-but-better-vault-core`; nothing here re-implements
 # parsing, scanning or byte-preserving updates.
 [dependencies]
-bookmarks-but-better-vault-core = { path = "../bookmarks-but-better-vault-core", version = "4.0.0" }
+bookmarks-but-better-vault-core = { path = "../bookmarks-but-better-vault-core", version = "4.1.0" }
 # HTTP routing, extractors and the SSE response type.
 axum = "0.8.9"
 # Capability-oriented filesystem handles, the same ones the format core walks
@@ -82,7 +82,7 @@ windows-sys = { version = "0.61.2", features = [
 # Integration tests are their own crates, so the pieces they touch directly are
 # listed again here; Cargo unifies them with the versions above.
 axum = "0.8.9"
-bookmarks-but-better-vault-core = { path = "../bookmarks-but-better-vault-core", version = "4.0.0" }
+bookmarks-but-better-vault-core = { path = "../bookmarks-but-better-vault-core", version = "4.1.0" }
 serde_json = "1.0.151"
 # `ServiceExt::oneshot`, which drives the router without binding a socket.
 tower = { version = "0.5.3", features = ["util"] }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-One product version covers the app, both extension manifests and the Cargo
+One product version covers the app, all three extension manifests and the Cargo
 workspace, and a tag is what turns that version into a release. The small `npx`
 launcher has an independent version and is published only when its own code
 changes.
@@ -8,8 +8,8 @@ changes.
 Two commands do the whole job:
 
 ```sh
-git push origin v4.0.0-beta.1   # a prerelease: artifacts to download, no store
-git push origin v4.0.0          # the real thing: stores, after an approval
+git push origin v4.1.0-beta.1   # a prerelease: artifacts to download, no store
+git push origin v4.1.0          # the real thing: stores, after an approval
 ```
 
 No product artifact is published another way. Merging to `main` runs
@@ -18,10 +18,10 @@ the separately versioned, manual publishing step documented below.
 
 ## What each tag does
 
-| You push          | You get                                                                  | Stores                                       |
-| ----------------- | ------------------------------------------------------------------------ | -------------------------------------------- |
-| `v4.0.0-beta.N`   | A GitHub **prerelease** with both extension zips, five daemon archives and both installers | **Never contacted.** The job does not exist.  |
-| `v4.0.0`          | A normal GitHub **Release** with the same artifacts                      | After a maintainer approves the deployment.   |
+| You push        | You get                                                                                     | Stores                                       |
+| --------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `v4.1.0-beta.N` | A GitHub **prerelease** with three extension zips, five daemon archives and both installers | **Never contacted.** The job does not exist. |
+| `v4.1.0`        | A normal GitHub **Release** with the same artifacts                                         | After a maintainer approves the deployment.  |
 
 Both run the identical build and the identical test suite — the release workflow
 calls `ci.yml` rather than keeping a second copy of the gates that could drift
@@ -29,24 +29,24 @@ from it. A beta is a real build; the only thing it does not do is publish.
 
 ## Cutting a beta
 
-1. Reconcile the product version everywhere. For `4.0.0` that means `4.0.0` —
-   exactly this string — in these six places:
-
+1. Reconcile the product version everywhere. For `4.1.0` that means `4.1.0` —
+   exactly this string — in these seven places:
    - `package.json`
    - `manifests/manifest.chrome.json`
    - `manifests/manifest.firefox.json`
+   - `manifests/manifest.safari.json`
    - `Cargo.toml` (`[workspace.package] version`)
    - `crates/bookmarks-but-better/Cargo.toml` (the
      `bookmarks-but-better-vault-core` constraint, twice)
    - `Cargo.lock` — run `cargo update --workspace` after the two above
 
-2. Add a `## [4.0.0]` section to `CHANGELOG.md`.
+2. Add a `## [4.1.0]` section to `CHANGELOG.md`.
 
 3. Tag and push:
 
    ```sh
-   git tag v4.0.0-beta.1
-   git push origin v4.0.0-beta.1
+   git tag v4.1.0-beta.1
+   git push origin v4.1.0-beta.1
    ```
 
 The `validate` job checks every one of those before anything is built, and fails
@@ -55,20 +55,20 @@ not a bad release.
 
 ### Betas keep the plain version, on purpose
 
-A beta tag is `v4.0.0-beta.1`, but every manifest inside it still reads `4.0.0`.
+A beta tag is `v4.1.0-beta.1`, but every manifest inside it still reads `4.1.0`.
 That is not an oversight and must not be "fixed":
 
 - Chrome accepts one to four dot-separated integers as a version and nothing
-  else. `4.0.0-beta.1` is not a valid extension version.
+  else. `4.1.0-beta.1` is not a valid extension version.
 - AMO rejects it too.
 
 So the beta-ness lives in the tag and in the GitHub prerelease, never in a
-manifest. The artifact *filenames* carry the full tag (`…-chrome-4.0.0-beta.1.zip`)
+manifest. The artifact _filenames_ carry the full tag (`…-chrome-4.1.0-beta.1.zip`)
 so a downloaded build is still identifiable, and the release notes say so. The
 `validate` job enforces both halves: manifests must equal the base version, and
 must be numeric.
 
-Iterating means `-beta.2`, `-beta.3`, and so on. All of them build `4.0.0`
+Iterating means `-beta.2`, `-beta.3`, and so on. All of them build `4.1.0`
 manifests. That is fine, because no store ever sees them.
 
 ## Cutting the stable release
@@ -78,8 +78,9 @@ Before creating the stable tag:
 1. Install the unpacked Chrome and Firefox builds over profiles that have
    completed setup on v3.2.1. Confirm the dashboard opens directly, the selected
    root and appearance are unchanged, and the setup wizard is not shown.
-2. In a fresh profile, complete setup once in each bookmark-source mode. Restart
-   the extension and confirm setup stays closed. Then switch sources and repeat.
+2. In a fresh profile, complete setup once with the Browser Source and once with
+   a Daemon Source. Restart the extension and confirm setup stays closed. Then
+   switch sources and repeat.
 3. Review `marketing/store-description.chrome.txt` and
    `marketing/store-description.firefox.txt` against the final manifests,
    especially permission and privacy disclosures.
@@ -88,8 +89,8 @@ Before creating the stable tag:
    and Windows.
 
 ```sh
-git tag v4.0.0
-git push origin v4.0.0
+git tag v4.1.0
+git push origin v4.1.0
 ```
 
 The build, the tests, the GitHub Release and its artifacts all happen without
@@ -138,7 +139,7 @@ The job summary says this on every run, and links the dashboard. Check it:
 
 > **"Re-run failed jobs" is not the recovery mechanism — for any run.** It
 > publishes nothing, by design. Store submission is limited to the **first
-> attempt**, of a tag push *and* of a manual dispatch alike, and a re-run writes
+> attempt**, of a tag push _and_ of a manual dispatch alike, and a re-run writes
 > a job summary saying so and pointing here.
 >
 > **That includes re-running a manual recovery that failed.** This is the one
@@ -156,8 +157,8 @@ The job summary says this on every run, and links the dashboard. Check it:
 > uploaded — but re-running still will not publish.
 >
 > On a tag push the restriction exists for a second reason too: a re-run cannot
-> tell the two situations apart. Without the limit it would re-run *both* store
-> steps with neither toggle consulted; and if the previous attempt *did* reach a
+> tell the two situations apart. Without the limit it would re-run _both_ store
+> steps with neither toggle consulted; and if the previous attempt _did_ reach a
 > store, Chrome goes first, so it would re-upload an already-published version,
 > be rejected, and abort before reaching the Firefox step that needed retrying.
 
@@ -182,7 +183,7 @@ was created and re-running will not create it — pick one:
 1. **Delete the tag and push it again.** A clean first attempt does everything.
    Simplest, and correct as long as nothing was published anywhere yet.
 2. **Create the release by hand** from the run's artifacts
-   (`gh release create v4.0.0 artifacts/*`), then dispatch for the stores.
+   (`gh release create v4.1.0 artifacts/*`), then dispatch for the stores.
 
 Do not skip this. A dispatch **refuses to run** unless a published release
 already exists for the tag — see [What stops an accidental
@@ -195,7 +196,7 @@ Whether a store failed or the run never got that far, the way to publish is the
 same — run the workflow manually:
 
 1. **Actions → Release → Run workflow**.
-2. Under **Use workflow from**, pick the **tag** (`v4.0.0`), not a branch. A
+2. Under **Use workflow from**, pick the **tag** (`v4.1.0`), not a branch. A
    dispatch from a branch is refused — the pipeline will not publish something
    that was never tagged.
 3. Tick the store or stores you need. **Both default to off**, because a re-run
@@ -252,11 +253,11 @@ secrets, and the six store credentials are repository-scoped on purpose
 ([step 2](#2-the-six-store-credentials-stay-at-repository-scope)).
 
 Store submission is additionally limited to the **first attempt of a run** — a
-tag push *or* a manual dispatch — and so is creating the GitHub release. A re-run
+tag push _or_ a manual dispatch — and so is creating the GitHub release. A re-run
 can neither publish to a store nor overwrite a release that already exists.
 
 A **manual dispatch** carries one more precondition, because its whole premise is
-that it is *finishing* a release rather than starting one. Before any credential
+that it is _finishing_ a release rather than starting one. Before any credential
 is touched it queries the GitHub API and refuses unless there is a release for
 the exact validated tag that is **published, not a draft, and not a prerelease**.
 An unanswerable query — an API error rather than a clean "not found" — is also a
@@ -279,13 +280,13 @@ workflow**.
 
 Each release carries five, one per supported platform, each with a `.sha256`:
 
-| Target                       | Archive   |
-| ---------------------------- | --------- |
-| `x86_64-unknown-linux-gnu`   | `.tar.gz` |
-| `aarch64-unknown-linux-gnu`  | `.tar.gz` |
-| `x86_64-apple-darwin`        | `.tar.gz` |
-| `aarch64-apple-darwin`       | `.tar.gz` |
-| `x86_64-pc-windows-msvc`     | `.zip`    |
+| Target                      | Archive   |
+| --------------------------- | --------- |
+| `x86_64-unknown-linux-gnu`  | `.tar.gz` |
+| `aarch64-unknown-linux-gnu` | `.tar.gz` |
+| `x86_64-apple-darwin`       | `.tar.gz` |
+| `aarch64-apple-darwin`      | `.tar.gz` |
+| `x86_64-pc-windows-msvc`    | `.zip`    |
 
 Each unpacks to:
 
@@ -319,7 +320,7 @@ release job started.
 There is no Apple Developer ID signature or notarization, and no Authenticode
 signature. Gatekeeper and SmartScreen will both object, and users will need
 `xattr -d com.apple.quarantine ./bookmarks-but-better` on macOS or
-*More info → Run anyway* on Windows. The release notes say so on every release.
+_More info → Run anyway_ on Windows. The release notes say so on every release.
 
 Changing that means buying an Apple Developer account and a code-signing
 certificate, and adding signing keys to the release pipeline. Until then the
@@ -350,7 +351,7 @@ content `<hash>  <filename>`), or the top-level directory inside the archive is
 a breaking change for both scripts and needs to update them alongside
 `release.yml`.
 
-Both also default to the latest *stable* release. A stable release carrying no
+Both also default to the latest _stable_ release. A stable release carrying no
 daemon archive — every one up to and including `v3.2.0` — is reported rather
 than failed on, and each falls back to the newest prerelease that does have a
 build for the platform (see [DAEMON.md](DAEMON.md)). The fallback is not a
@@ -400,7 +401,7 @@ checksum verification, unpack, symlink swap, upgrade, rollback-on-tamper)
 against a locally served fake release that speaks the same three GitHub
 endpoints. The launcher tests cover its platform, argument and URL decisions,
 which are pure functions, so neither touches the network. Neither runs on a
-tag, so together they do not prove the scripts work against a *real* published
+tag, so together they do not prove the scripts work against a _real_ published
 release — only that they still do exactly what they did the last time this
 suite ran.
 
@@ -411,18 +412,18 @@ state is auditable and so it can be rebuilt if the repository is ever recreated.
 
 Current state:
 
-| Item | Status |
-| --- | --- |
-| `production-stores` environment | exists |
-| Required reviewer | set |
-| Deployment rule: `v*` tags | set |
-| `PRODUCTION_STORES_CONFIGURED` (environment scope) | set |
-| Six store credentials | repository scope, **by decision** — see step 2 |
-| `v*` tag ruleset | optional, see step 4 |
+| Item                                               | Status                                         |
+| -------------------------------------------------- | ---------------------------------------------- |
+| `production-stores` environment                    | exists                                         |
+| Required reviewer                                  | set                                            |
+| Deployment rule: `v*` tags                         | set                                            |
+| `PRODUCTION_STORES_CONFIGURED` (environment scope) | set                                            |
+| Six store credentials                              | repository scope, **by decision** — see step 2 |
+| `v*` tag ruleset                                   | optional, see step 4                           |
 
 Nothing on this page blocks a release.
 
-> **Why it fails closed.** GitHub *auto-creates* an environment the first time a
+> **Why it fails closed.** GitHub _auto-creates_ an environment the first time a
 > workflow names one, with no protection rules — no reviewers, no secrets. A
 > repository that skipped this setup would therefore look identical to one that
 > did it, and would publish on the first stable tag with nobody asked. The canary
@@ -438,28 +439,28 @@ Nothing on this page blocks a release.
 - For **Deployment branches and tags**, choose **Selected branches and tags** and
   add a **tag** rule matching `v*`.
 
-  Do **not** choose *Protected branches only*. It excludes tags entirely, and
+  Do **not** choose _Protected branches only_. It excludes tags entirely, and
   every release here is tag-triggered, so that setting makes all store
-  publishing fail permanently. There is no "protected branches *and tags*"
-  option; the three choices are *All branches*, *Protected branches only*, and
-  *Selected branches and tags*.
+  publishing fail permanently. There is no "protected branches _and tags_"
+  option; the three choices are _All branches_, _Protected branches only_, and
+  _Selected branches and tags_.
 
 ### 2. The six store credentials stay at **repository** scope
 
 These already exist as **repository** secrets and are deliberately left there.
 Names are unchanged from the previous workflow:
 
-| Secret                  | Used for                     | Scope      |
-| ----------------------- | ---------------------------- | ---------- |
-| `CHROME_EXTENSION_ID`   | Chrome Web Store             | repository |
-| `CHROME_CLIENT_ID`      | Chrome Web Store             | repository |
-| `CHROME_CLIENT_SECRET`  | Chrome Web Store             | repository |
-| `CHROME_REFRESH_TOKEN`  | Chrome Web Store             | repository |
-| `AMO_JWT_ISSUER`        | Firefox AMO                  | repository |
-| `AMO_JWT_SECRET`        | Firefox AMO                  | repository |
+| Secret                 | Used for         | Scope      |
+| ---------------------- | ---------------- | ---------- |
+| `CHROME_EXTENSION_ID`  | Chrome Web Store | repository |
+| `CHROME_CLIENT_ID`     | Chrome Web Store | repository |
+| `CHROME_CLIENT_SECRET` | Chrome Web Store | repository |
+| `CHROME_REFRESH_TOKEN` | Chrome Web Store | repository |
+| `AMO_JWT_ISSUER`       | Firefox AMO      | repository |
+| `AMO_JWT_SECRET`       | Firefox AMO      | repository |
 
 Nothing needs doing here before a release. An environment job reads repository
-secrets perfectly well — environment secrets merely *shadow* same-named
+secrets perfectly well — environment secrets merely _shadow_ same-named
 repository ones — so the pipeline works as it stands.
 
 **Why they were not moved.** GitHub never returns a stored secret's value, not
@@ -468,8 +469,8 @@ scope to another. Moving these would mean regenerating each one at its source �
 and generating a new AMO API key **revokes the live one**. That is a real risk to
 a working release path in exchange for no change to the approval gate.
 
-**This does not weaken the gate.** Approval is enforced by the *environment
-attached to the job*, not by where the secrets are stored. `publish-stores` names
+**This does not weaken the gate.** Approval is enforced by the _environment
+attached to the job_, not by where the secrets are stored. `publish-stores` names
 `production-stores`, so GitHub holds the whole job — every step, before any of
 them runs — until a required reviewer approves it. That is true regardless of
 which scope the credentials come from.
@@ -487,13 +488,13 @@ decide to take it on later.
 
 One **environment** secret on `production-stores`:
 
-| Secret                          | Value                           | Scope                |
-| ------------------------------- | ------------------------------- | -------------------- |
-| `PRODUCTION_STORES_CONFIGURED`  | any non-empty value, e.g. `yes` | **environment only** |
+| Secret                         | Value                           | Scope                |
+| ------------------------------ | ------------------------------- | -------------------- |
+| `PRODUCTION_STORES_CONFIGURED` | any non-empty value, e.g. `yes` | **environment only** |
 
 The value is never read, logged, or compared — only its existence is. It is the
 signal that this page was filled in by a person rather than conjured by GitHub,
-which is why it is a *different name* from the six credentials: those are
+which is why it is a _different name_ from the six credentials: those are
 expected at repository scope, and this one must never be.
 
 > **Rule: `PRODUCTION_STORES_CONFIGURED` must never exist at repository scope.**
@@ -513,7 +514,7 @@ placement.
 
 There is a second guard in the job that checks all six credential names resolve
 to a non-empty value. It is a **partial-publish** guard, not a configuration
-check: Chrome is submitted before Firefox, so a credential missing from *every*
+check: Chrome is submitted before Firefox, so a credential missing from _every_
 scope would publish to one store and strand the other. It says nothing about
 which scope supplied a value, and does not need to.
 
@@ -564,7 +565,7 @@ Required — all done:
 
 - [x] `production-stores` environment exists
 - [x] Required reviewer added
-- [x] Deployment rule is *Selected branches and tags* with a `v*` **tag** rule
+- [x] Deployment rule is _Selected branches and tags_ with a `v*` **tag** rule
 - [x] `PRODUCTION_STORES_CONFIGURED` added, **environment scope only**
 - [x] Six store credentials present at repository scope (deliberate; step 2)
 

--- a/manifests/manifest.chrome.json
+++ b/manifests/manifest.chrome.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Bookmarks But Better",
   "description": "A clean, beautiful bookmarks dashboard for your new tab with themes, dark mode, and full bookmark management.",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "chrome_url_overrides": {
     "newtab": "index.html"
   },

--- a/manifests/manifest.firefox.json
+++ b/manifests/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Bookmarks But Better",
   "description": "A clean, beautiful bookmarks dashboard for your new tab with themes, dark mode, and full bookmark management.",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "browser_specific_settings": {
     "gecko": {
       "id": "bookmarks@farhadeidi.com",

--- a/manifests/manifest.safari.json
+++ b/manifests/manifest.safari.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Bookmarks But Better",
   "description": "A clean, beautiful bookmarks dashboard backed by a local daemon, with themes, dark mode, and full bookmark management.",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "action": {
     "default_popup": "popup.html",
     "default_title": "Save bookmark"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmarks-but-better",
   "private": true,
-  "version": "4.0.0",
+  "version": "4.1.0",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump the product version to `4.1.0` across package, Chrome/Firefox/Safari manifests, Cargo workspace dependencies and lockfile.
- Promote the completed Source Configuration work from `Unreleased` into the `4.1.0` changelog with the final migration and UI behavior.
- Update release documentation for `v4.1.0-beta.1` and include Safari in version validation, build verification and prerelease artifacts.

## Validation

- `bun run check`: 632 tests passed; formatting, lint, typecheck and Chrome/Firefox/daemon/Safari builds passed.
- Focused upgrade/migration suite: 52 tests passed.
- Local packaging smoke test produced Chrome, Firefox and Safari archives whose manifests all report `4.1.0`.

## Release behavior

After this PR merges, tag `v4.1.0-beta.1` will create a GitHub prerelease. Extension stores are not contacted and `/releases/latest` remains on the latest stable release.