### PR TITLE
fix: balance grid columns from measured card heights

### DIFF
--- a/src/features/bookmark-grid/__tests__/bookmark-grid-measurement.test.tsx
+++ b/src/features/bookmark-grid/__tests__/bookmark-grid-measurement.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, cleanup, render } from "@testing-library/react"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+import { usePreferencesStore } from "@/stores/preferences-store"
+import { BookmarkGrid } from "../bookmark-grid"
+
+/**
+ * The grid balances columns from measured card heights, which is a loop —
+ * measure, re-balance, measure again. These cases pin the rules that stop it
+ * spinning: a change under the threshold is ignored, and within one set of
+ * distribution inputs a card is only ever allowed to grow.
+ */
+
+class StubResizeObserver {
+  static instances: StubResizeObserver[] = []
+
+  targets = new Set<Element>()
+  callback: ResizeObserverCallback
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    StubResizeObserver.instances.push(this)
+  }
+
+  observe(target: Element) {
+    this.targets.add(target)
+  }
+
+  unobserve(target: Element) {
+    this.targets.delete(target)
+  }
+
+  disconnect() {
+    this.targets.clear()
+  }
+
+  report(heights: Map<Element, number>) {
+    const entries = Array.from(this.targets)
+      .filter((target) => heights.has(target))
+      .map(
+        (target) =>
+          ({
+            target,
+            borderBoxSize: [{ blockSize: heights.get(target), inlineSize: 0 }],
+            contentRect: { height: heights.get(target) },
+          }) as unknown as ResizeObserverEntry
+      )
+
+    if (entries.length > 0) {
+      this.callback(entries, this as unknown as ResizeObserver)
+    }
+  }
+}
+
+const TREE = [
+  {
+    id: "root",
+    title: "Root",
+    children: ["one", "two", "three"].map((id) => ({
+      id,
+      title: id,
+      children: [
+        { id: `${id}-b`, title: "Bookmark", url: "https://e.example" },
+      ],
+    })),
+  },
+]
+
+function mount() {
+  useBookmarkStore.setState({
+    adapter: {
+      bookmarks: {} as never,
+      storage: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+      favicon: { getUrl: () => "", isAvailable: () => false },
+      capabilities: {
+        openInManager: false,
+        move: true,
+        reorder: true,
+        setChildOrder: false,
+      },
+    },
+    tree: TREE,
+    rootFolder: TREE[0],
+    isLoading: false,
+  })
+  usePreferencesStore.setState({
+    experimentalCardDrag: false,
+    nestedFolders: true,
+    folderOrder: [],
+    cardLayouts: {},
+    maxColumns: 2,
+    containerMode: "fluid",
+  })
+  return render(<BookmarkGrid />)
+}
+
+/** The folder titles in each rendered column, in visual order. */
+function columns(container: HTMLElement): string[][] {
+  const grid = container.querySelector(".grid")
+  return Array.from(grid?.children ?? []).map((column) =>
+    Array.from(column.querySelectorAll("h3")).map((h) => h.textContent ?? "")
+  )
+}
+
+/** Cards, keyed by the element the grid asked the observer to watch. */
+function cardsByTitle(container: HTMLElement): Map<string, Element> {
+  const cards = new Map<string, Element>()
+  for (const card of container.querySelectorAll(
+    '[data-testid="bookmark-card"]'
+  )) {
+    const title = card.querySelector("h3")?.textContent ?? ""
+    if (card.parentElement) cards.set(title, card.parentElement)
+  }
+  return cards
+}
+
+function report(container: HTMLElement, heights: Record<string, number>) {
+  const cards = cardsByTitle(container)
+  const byElement = new Map<Element, number>()
+  for (const [title, height] of Object.entries(heights)) {
+    const element = cards.get(title)
+    if (element) byElement.set(element, height)
+  }
+
+  act(() => {
+    for (const instance of StubResizeObserver.instances) {
+      instance.report(byElement)
+    }
+  })
+}
+
+beforeEach(() => {
+  StubResizeObserver.instances = []
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+  )
+  vi.stubGlobal("ResizeObserver", StubResizeObserver)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe("BookmarkGrid card measurement", () => {
+  it("balances on estimates until a card has been measured", () => {
+    const { container } = mount()
+
+    // Equal estimates alternate, so the third card returns to the first column.
+    expect(columns(container)).toEqual([["one", "three"], ["two"]])
+  })
+
+  it("re-balances once a measured card turns out to be taller than its estimate", () => {
+    const { container } = mount()
+
+    report(container, { one: 400, two: 100, three: 100 })
+
+    expect(columns(container)).toEqual([["one"], ["two", "three"]])
+  })
+
+  it("ignores a change smaller than the threshold", () => {
+    const { container } = mount()
+    // The two columns are 2px apart, so a card taking 4px of sub-pixel churn at
+    // face value would be enough to send the third card the other way.
+    report(container, { one: 100, two: 102, three: 100 })
+    expect(columns(container)).toEqual([["one", "three"], ["two"]])
+
+    report(container, { one: 104 })
+
+    expect(columns(container)).toEqual([["one", "three"], ["two"]])
+  })
+
+  it("does not let a measured card shrink again under the same inputs", () => {
+    const { container } = mount()
+    report(container, { one: 400, two: 100, three: 100 })
+
+    // A card reporting a smaller height after it has already been placed is how
+    // the loop would oscillate: the re-balance would make it tall again.
+    report(container, { one: 100 })
+
+    expect(columns(container)).toEqual([["one"], ["two", "three"]])
+  })
+
+  it("re-balances again when a measured card grows past the threshold", () => {
+    const { container } = mount()
+    report(container, { one: 400, two: 100, three: 100 })
+
+    report(container, { two: 500 })
+
+    expect(columns(container)).toEqual([["one", "three"], ["two"]])
+  })
+
+  it("takes a fresh measurement in either direction once the inputs change", () => {
+    const { container } = mount()
+    report(container, { one: 400, two: 100, three: 100 })
+
+    // Switching a card's layout is a new generation, so the card is allowed to
+    // report the shorter height that layout actually produces.
+    act(() => {
+      usePreferencesStore.setState({ cardLayouts: { one: "grid" } })
+    })
+    report(container, { one: 100, two: 100, three: 100 })
+
+    expect(columns(container)).toEqual([["one", "three"], ["two"]])
+  })
+})

--- a/src/features/bookmark-grid/__tests__/card-heights.test.ts
+++ b/src/features/bookmark-grid/__tests__/card-heights.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest"
+import type { BookmarkNode } from "@/browser"
+import { distributeToColumns } from "../card-heights"
+
+function folder(id: string, bookmarkCount: number): BookmarkNode {
+  return {
+    id,
+    title: id.toUpperCase(),
+    children: Array.from({ length: bookmarkCount }, (_, i) => ({
+      id: `${id}-${i}`,
+      title: `Bookmark ${i}`,
+      url: `https://${id}-${i}.example`,
+    })),
+  }
+}
+
+const NO_HEIGHTS = new Map<string, number>()
+
+function ids(columns: BookmarkNode[][]): string[][] {
+  return columns.map((column) => column.map((f) => f.id))
+}
+
+describe("distributeToColumns", () => {
+  it("fills the shortest column first from the estimates", () => {
+    const folders = [folder("a", 10), folder("b", 1), folder("c", 1)]
+
+    expect(ids(distributeToColumns(folders, 2, {}, NO_HEIGHTS))).toEqual([
+      ["a"],
+      ["b", "c"],
+    ])
+  })
+
+  it("charges a taller card to the grid estimate when the layout says grid", () => {
+    const folders = [folder("a", 10), folder("b", 10), folder("c", 1)]
+
+    // "a" as a grid is 168px against "b"'s 384px as a list, so the third card
+    // stacks on "a" rather than alternating.
+    expect(
+      ids(distributeToColumns(folders, 2, { a: "grid" }, NO_HEIGHTS))
+    ).toEqual([["a", "c"], ["b"]])
+  })
+
+  it("prefers a measured height over the card's estimate", () => {
+    const folders = [folder("a", 1), folder("b", 1), folder("c", 1)]
+
+    // On estimates alone all three cards are 96px and "c" would alternate back
+    // to the first column; measuring "a" as the tall card it really is moves it.
+    expect(
+      ids(distributeToColumns(folders, 2, {}, new Map([["a", 400]])))
+    ).toEqual([["a"], ["b", "c"]])
+  })
+
+  it("falls back to the estimate for cards that have not been measured yet", () => {
+    const folders = [folder("a", 1), folder("b", 20), folder("c", 1)]
+
+    // "b" has no measurement, so its 704px estimate still has to hold the
+    // second column open for "c".
+    expect(
+      ids(distributeToColumns(folders, 2, {}, new Map([["a", 96]])))
+    ).toEqual([["a", "c"], ["b"]])
+  })
+
+  it("keeps the gap between stacked cards in the running column height", () => {
+    const folders = [
+      folder("a", 1),
+      folder("b", 1),
+      folder("c", 1),
+      folder("d", 1),
+    ]
+    const measured = new Map([
+      ["a", 30],
+      ["b", 70],
+      ["c", 30],
+      ["d", 40],
+    ])
+
+    // Two short cards plus their gaps stand taller than one 70px card, which is
+    // what sends the last card to the second column.
+    expect(ids(distributeToColumns(folders, 2, {}, measured))).toEqual([
+      ["a", "c"],
+      ["b", "d"],
+    ])
+  })
+
+  it("returns the requested number of columns even when there is nothing to place", () => {
+    expect(ids(distributeToColumns([], 3, {}, NO_HEIGHTS))).toEqual([
+      [],
+      [],
+      [],
+    ])
+  })
+})

--- a/src/features/bookmark-grid/bookmark-grid.tsx
+++ b/src/features/bookmark-grid/bookmark-grid.tsx
@@ -6,6 +6,7 @@ import { useSortableFolder, DropIndicator } from "@/features/dnd"
 import type { BookmarkNode } from "@/browser"
 import { cn } from "@/lib/utils"
 import { getVisibleFolders } from "./folder-collection"
+import { distributeToColumns, useMeasuredCardHeights } from "./card-heights"
 import { BookmarkGridEmpty } from "./bookmark-grid-empty"
 
 function getColumnCountForWidth(): number {
@@ -41,58 +42,6 @@ function useColumnCount(maxColumns: number): number {
   }, [maxColumns])
 
   return columnCount
-}
-
-/** Estimate card height based on layout mode and bookmark count */
-function estimateCardHeight(
-  folder: BookmarkNode,
-  cardLayouts: Record<string, string>
-): number {
-  const bookmarks = (folder.children ?? []).filter((c) => c.url !== undefined)
-  const count = bookmarks.length
-  const layout = cardLayouts[folder.id] ?? "list"
-
-  // Header (~40px) + padding (~24px)
-  const chrome = 64
-
-  if (layout === "grid") {
-    // Grid: ~48px cells, ~5 per row in a typical column width, ~52px per row
-    const cols = 5
-    const rows = Math.ceil(count / cols)
-    return chrome + rows * 52
-  }
-
-  // List: ~32px per item
-  return chrome + count * 32
-}
-
-/** Distribute folders into the shortest column based on estimated height */
-function distributeToColumns(
-  folders: BookmarkNode[],
-  columnCount: number,
-  cardLayouts: Record<string, string>
-): BookmarkNode[][] {
-  const columns: BookmarkNode[][] = Array.from(
-    { length: columnCount },
-    () => []
-  )
-  const heights = new Array(columnCount).fill(0)
-
-  for (const folder of folders) {
-    const estimatedHeight = estimateCardHeight(folder, cardLayouts)
-
-    // Find the shortest column
-    let shortest = 0
-    for (let i = 1; i < columnCount; i++) {
-      if (heights[i] < heights[shortest]) shortest = i
-    }
-
-    columns[shortest].push(folder)
-    // Add card height + gap between cards (16px)
-    heights[shortest] += estimatedHeight + 16
-  }
-
-  return columns
 }
 
 function SortableFolderCard({
@@ -158,9 +107,15 @@ export function BookmarkGrid() {
     return map
   }, [folders])
 
+  const { heights, measureRefs } = useMeasuredCardHeights(
+    folders,
+    columnCount,
+    cardLayouts
+  )
+
   const columns = React.useMemo(
-    () => distributeToColumns(folders, columnCount, cardLayouts),
-    [folders, columnCount, cardLayouts]
+    () => distributeToColumns(folders, columnCount, cardLayouts, heights),
+    [folders, columnCount, cardLayouts, heights]
   )
 
   if (isLoading) {
@@ -190,17 +145,24 @@ export function BookmarkGrid() {
       >
         {columns.map((columnFolders, colIndex) => (
           <div key={colIndex} className="flex min-w-0 flex-col gap-4">
-            {columnFolders.map((folder) =>
-              experimentalCardDrag ? (
-                <SortableFolderCard
-                  key={folder.id}
-                  folder={folder}
-                  sortableIndex={folderIndexMap.get(folder.id) ?? 0}
-                />
-              ) : (
-                <BookmarkCard key={folder.id} folder={folder} />
-              )
-            )}
+            {columnFolders.map((folder) => (
+              // The wrapper is what the ResizeObserver watches: it is the only
+              // element that exists in both the draggable and plain variants.
+              <div
+                key={folder.id}
+                ref={measureRefs.get(folder.id)}
+                className="min-w-0"
+              >
+                {experimentalCardDrag ? (
+                  <SortableFolderCard
+                    folder={folder}
+                    sortableIndex={folderIndexMap.get(folder.id) ?? 0}
+                  />
+                ) : (
+                  <BookmarkCard folder={folder} />
+                )}
+              </div>
+            ))}
           </div>
         ))}
       </div>

--- a/src/features/bookmark-grid/card-heights.ts
+++ b/src/features/bookmark-grid/card-heights.ts
@@ -1,0 +1,216 @@
+import * as React from "react"
+import type { BookmarkNode } from "@/browser"
+
+/** Vertical gap between stacked cards, matching the column's `gap-4`. */
+const CARD_GAP = 16
+
+/**
+ * A measurement only counts once it moves a card by this much. Cards are
+ * discrete — a bookmark row, a grid cell — so anything smaller is sub-pixel
+ * churn from font metrics or scrollbars, and re-balancing on it would trade a
+ * reflow for a distribution that looks identical.
+ */
+const HEIGHT_CHANGE_THRESHOLD = 8
+
+/**
+ * Guess a card's height before it has ever been rendered.
+ *
+ * The constants come from one theme at one font size, so they drift with card
+ * padding, row height, font stack and icon size — and `cols` cannot know how
+ * wide the column actually is. They are only ever the first paint's answer:
+ * `useMeasuredCardHeights` replaces each card's guess with its real height.
+ */
+function estimateCardHeight(
+  folder: BookmarkNode,
+  cardLayouts: Record<string, string>
+): number {
+  const bookmarks = (folder.children ?? []).filter((c) => c.url !== undefined)
+  const count = bookmarks.length
+  const layout = cardLayouts[folder.id] ?? "list"
+
+  // Header (~40px) + padding (~24px)
+  const chrome = 64
+
+  if (layout === "grid") {
+    // Grid: ~48px cells, ~5 per row in a typical column width, ~52px per row
+    const cols = 5
+    const rows = Math.ceil(count / cols)
+    return chrome + rows * 52
+  }
+
+  // List: ~32px per item
+  return chrome + count * 32
+}
+
+/**
+ * Distribute folders into the shortest column, using each card's measured
+ * height where one exists and its estimate until then.
+ */
+export function distributeToColumns(
+  folders: BookmarkNode[],
+  columnCount: number,
+  cardLayouts: Record<string, string>,
+  measuredHeights: ReadonlyMap<string, number>
+): BookmarkNode[][] {
+  const columns: BookmarkNode[][] = Array.from(
+    { length: columnCount },
+    () => []
+  )
+  const heights = new Array(columnCount).fill(0)
+
+  for (const folder of folders) {
+    const height =
+      measuredHeights.get(folder.id) ?? estimateCardHeight(folder, cardLayouts)
+
+    // Find the shortest column
+    let shortest = 0
+    for (let i = 1; i < columnCount; i++) {
+      if (heights[i] < heights[shortest]) shortest = i
+    }
+
+    columns[shortest].push(folder)
+    heights[shortest] += height + CARD_GAP
+  }
+
+  return columns
+}
+
+interface HeightRecord {
+  height: number
+  /** The distribution inputs this height was measured under. */
+  generation: object
+}
+
+const NO_HEIGHTS: ReadonlyMap<string, number> = new Map()
+
+/**
+ * Observe the rendered cards and report their real heights.
+ *
+ * Feeding measurements back into a layout that then re-measures is where this
+ * would normally oscillate, so acceptance is deliberately one-way. A card's
+ * height may move freely once per *generation* — the identity of the inputs
+ * that decide the distribution — and after that only upwards, and only by more
+ * than the threshold. Each card therefore causes a bounded number of
+ * re-balances per generation, and a generation only turns over when the
+ * folders, the column count or the card layouts change: never in response to
+ * our own re-balance. Once no card crosses the threshold there is no state
+ * write, so nothing re-renders and the observer falls silent.
+ */
+export function useMeasuredCardHeights(
+  folders: BookmarkNode[],
+  columnCount: number,
+  cardLayouts: Record<string, string>
+) {
+  const [heights, setHeights] =
+    React.useState<ReadonlyMap<string, number>>(NO_HEIGHTS)
+
+  const records = React.useRef(new Map<string, HeightRecord>())
+  const observedIds = React.useRef(new Map<Element, string>())
+  const observedElements = React.useRef(new Map<string, Element>())
+  const observer = React.useRef<ResizeObserver | null>(null)
+
+  const generation = React.useMemo(
+    () => ({ folders, columnCount, cardLayouts }),
+    [folders, columnCount, cardLayouts]
+  )
+  const currentGeneration = React.useRef(generation)
+  // A layout effect lands in the commit, before the browser can deliver a
+  // resize notification for the layout it just produced; a passive effect
+  // could arrive after it and mistake new content for a card that grew.
+  React.useLayoutEffect(() => {
+    currentGeneration.current = generation
+  }, [generation])
+
+  const getObserver = React.useCallback(() => {
+    // jsdom and older Safari have no ResizeObserver; there the estimates stand.
+    if (typeof ResizeObserver === "undefined") return null
+
+    observer.current ??= new ResizeObserver((entries) => {
+      let changed = false
+
+      for (const entry of entries) {
+        const folderId = observedIds.current.get(entry.target)
+        if (folderId === undefined) continue
+
+        const height = Math.round(
+          entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height
+        )
+        // A hidden or detached card measures zero, which is not its height.
+        if (height <= 0) continue
+
+        const previous = records.current.get(folderId)
+        if (previous !== undefined) {
+          const seenThisGeneration =
+            previous.generation === currentGeneration.current
+          const accepted = seenThisGeneration
+            ? height >= previous.height + HEIGHT_CHANGE_THRESHOLD
+            : Math.abs(height - previous.height) >= HEIGHT_CHANGE_THRESHOLD
+
+          if (!accepted) {
+            // Still worth recording: the card has now been seen under this
+            // generation, so from here on it may only grow.
+            records.current.set(folderId, {
+              height: previous.height,
+              generation: currentGeneration.current,
+            })
+            continue
+          }
+        }
+
+        records.current.set(folderId, {
+          height,
+          generation: currentGeneration.current,
+        })
+        changed = true
+      }
+
+      if (!changed) return
+      setHeights(
+        new Map(
+          Array.from(records.current, ([id, record]) => [id, record.height])
+        )
+      )
+    })
+
+    return observer.current
+  }, [])
+
+  const observeCard = React.useCallback(
+    (folderId: string, element: HTMLElement | null) => {
+      const previous = observedElements.current.get(folderId)
+      if (previous) {
+        getObserver()?.unobserve(previous)
+        observedIds.current.delete(previous)
+        observedElements.current.delete(folderId)
+      }
+      if (!element) return
+
+      observedIds.current.set(element, folderId)
+      observedElements.current.set(folderId, element)
+      getObserver()?.observe(element)
+    },
+    [getObserver]
+  )
+
+  // One stable callback per card, so an unrelated re-render does not detach
+  // and re-observe every card in the grid.
+  const measureRefs = React.useMemo(() => {
+    const callbacks = new Map<string, (element: HTMLElement | null) => void>()
+    for (const folder of folders) {
+      callbacks.set(folder.id, (element) => observeCard(folder.id, element))
+    }
+    return callbacks
+  }, [folders, observeCard])
+
+  React.useEffect(
+    () => () => {
+      observer.current?.disconnect()
+      observer.current = null
+      observedIds.current.clear()
+      observedElements.current.clear()
+    },
+    []
+  )
+
+  return { heights, measureRefs }
+}


### PR DESCRIPTION
Closes #48

## Summary

- Replace `estimateCardHeight`'s hardcoded constants (64 chrome, 32/list row, 52/grid row, `cols = 5`) with real `ResizeObserver` measurements as the input to masonry column distribution. The constants survive only as the first-paint guess, before any card has been measured.
- Move `distributeToColumns` and the new `useMeasuredCardHeights` hook into `src/features/bookmark-grid/card-heights.ts`. They could not stay in `bookmark-grid.tsx`: exporting non-components from a component module trips `react-refresh/only-export-components`, and lint runs at `--max-warnings=0`.
- `distributeToColumns` stays pure — it now takes a `ReadonlyMap` of measured heights and falls back to the estimate per card.
- Each card gains one `min-w-0` wrapper div carrying the measure ref; it is the only element common to the draggable and plain card variants.

## Why this was wrong before

The constants were measured against one theme at one font size. Card padding, row height, font stack, icon size and the user's own browser font size all move them, and `cols = 5` cannot know how wide the column actually is. The symptom was not a crash but lopsided columns — one column running far past its neighbours with visible empty space beside it.

## How the measure/re-balance loop settles

Feeding measurements back into a layout that then re-measures is the obvious oscillation risk, so acceptance is one-way inside a *generation* — the identity of `{folders, columnCount, cardLayouts}`, published to a ref in a `useLayoutEffect` so it lands in the commit before the browser can deliver a resize notification for that layout.

- A card's first measurement in a generation may move in either direction, but only registers at ≥ 8px (`HEIGHT_CHANGE_THRESHOLD`). A rejected measurement still marks the card as seen.
- After that, only growth of ≥ 8px is accepted.
- So each card causes at most `1 + (max height / 8)` state writes per generation — finite. Heights are not part of the generation, so a re-balance can never turn one over.
- When nothing crosses the threshold there is no `setState`: the fixed point is silent.

## Known limitation

Acceptance being monotone within a generation means a card that genuinely shrinks without `folders`, `columnCount` or `cardLayouts` changing — a viewport resize that stays inside one breakpoint band — keeps its taller height until the next generation. That degrades balance quality in the same direction the old estimates already erred; it never affects correctness. Resetting on container width instead reopens a real oscillation path through the page scrollbar.

Height records are not pruned, so a number per folder id seen in the session is retained.

## Verification

- `bun run check` — pass (73 test files, 652 tests)
- `bun run test:ui` — 20 passed
- New: `card-heights.test.ts` (6 pure-function cases) and `bookmark-grid-measurement.test.tsx` (6 jsdom cases driving a stub `ResizeObserver` through `BookmarkGrid`, pinning the threshold and monotonicity rules). No existing test modified.
- jsdom has no `ResizeObserver`; the hook no-ops there and estimates stand, so the new test supplies its own stub.
