### PR TITLE
feat: add keyboard navigation to the bookmark organizer tree

### DIFF
--- a/src/features/bookmark-organizer/__tests__/bookmark-organizer-keyboard.test.tsx
+++ b/src/features/bookmark-organizer/__tests__/bookmark-organizer-keyboard.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import { BookmarkOrganizerTree } from "../bookmark-organizer-tree"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+import { useUIStore } from "@/stores/ui-store"
+import type { BookmarkNode } from "@/browser"
+
+/**
+ * Drives the organizer the way a keyboard user does — real key events into
+ * the rendered tree, no direct calls into `@headless-tree/core`. The features
+ * that provide this are configuration, not code we wrote, so the only thing
+ * worth asserting is what the configuration lets through: which row holds the
+ * tab stop, which rows the arrows are allowed to visit, and which drop
+ * positions a keyboard drag may propose.
+ */
+
+/**
+ * `hotkeysCoreFeature` matches on the *set* of keys currently held, and
+ * clears that set from a document-level keyup — so a press that is not
+ * released stays in the set and blocks every hotkey after it.
+ */
+function press(element: Element, ...codes: string[]) {
+  for (const code of codes) {
+    fireEvent.keyDown(element, { code })
+  }
+  for (const code of codes) {
+    fireEvent.keyUp(document, { code })
+  }
+}
+
+const VAULT: Record<string, BookmarkNode> = {
+  "root-1": {
+    id: "root-1",
+    title: "Bookmarks Bar",
+    children: [
+      { id: "folder-1", title: "Folder One", parentId: "root-1", children: [] },
+      {
+        id: "bookmark-1",
+        title: "Bookmark One",
+        parentId: "root-1",
+        url: "https://example.com/one",
+      },
+      { id: "folder-2", title: "Folder Two", parentId: "root-1", children: [] },
+    ],
+  },
+  "folder-1": {
+    id: "folder-1",
+    title: "Folder One",
+    parentId: "root-1",
+    children: [
+      {
+        id: "bookmark-2",
+        title: "Nested Bookmark",
+        parentId: "folder-1",
+        url: "https://example.com/two",
+      },
+    ],
+  },
+  "folder-2": {
+    id: "folder-2",
+    title: "Folder Two",
+    parentId: "root-1",
+    children: [],
+  },
+  "bookmark-1": {
+    id: "bookmark-1",
+    title: "Bookmark One",
+    parentId: "root-1",
+    url: "https://example.com/one",
+  },
+  "bookmark-2": {
+    id: "bookmark-2",
+    title: "Nested Bookmark",
+    parentId: "folder-1",
+    url: "https://example.com/two",
+  },
+}
+
+function mountStore(
+  capabilities: { move: boolean; reorder: boolean; setChildOrder: boolean },
+  readOnlyIds: string[] = []
+) {
+  useUIStore.setState({
+    settingsOpen: false,
+    bookmarkOrganizerOpen: true,
+    editingBookmark: null,
+    deletingItem: null,
+    creatingItem: null,
+  })
+
+  useBookmarkStore.setState({
+    tree: [{ id: "root-1", title: "Bookmarks Bar", children: [] }],
+    rootFolderId: "root-1",
+    isLoading: false,
+    adapter: {
+      bookmarks: {
+        getTree: vi.fn().mockResolvedValue([]),
+        getSubTree: vi.fn().mockImplementation(async (id: string) => {
+          const node = VAULT[id]
+          if (!node) return []
+          return [
+            {
+              ...node,
+              readOnly: readOnlyIds.includes(node.id) || undefined,
+              children: node.children?.map((child) => ({
+                ...child,
+                readOnly: readOnlyIds.includes(child.id) || undefined,
+              })),
+            },
+          ]
+        }),
+        create: vi.fn(),
+        update: vi.fn(),
+        remove: vi.fn(),
+        removeTree: vi.fn(),
+        move: vi.fn(),
+        onChanged: vi.fn(() => () => {}),
+        onCreated: vi.fn(() => () => {}),
+        onRemoved: vi.fn(() => () => {}),
+        onMoved: vi.fn(() => () => {}),
+        openInManager: vi.fn(),
+      },
+      storage: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+      favicon: { getUrl: vi.fn(() => ""), isAvailable: vi.fn(() => false) },
+      capabilities: { openInManager: false, ...capabilities },
+    },
+    rootFolder: { id: "root-1", title: "Bookmarks Bar", children: [] },
+    init: vi.fn(),
+    setRootFolderId: vi.fn(),
+    refresh: vi.fn(),
+    createBookmark: vi.fn(),
+    updateBookmark: vi.fn(),
+    deleteBookmark: vi.fn(),
+    deleteFolder: vi.fn(),
+    createFolder: vi.fn(),
+    moveBookmark: vi.fn(),
+  })
+}
+
+function renderTree(showBookmarks = true) {
+  return render(
+    <BookmarkOrganizerTree
+      rootFolderId="root-1"
+      showBookmarks={showBookmarks}
+      treeRef={{ current: null }}
+    />
+  )
+}
+
+function row(name: string) {
+  return screen.getByRole("treeitem", { name })
+}
+
+const FULL_ORDERING = { move: true, reorder: true, setChildOrder: false }
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("BookmarkOrganizerTree keyboard navigation", () => {
+  beforeEach(() => {
+    mountStore(FULL_ORDERING)
+  })
+
+  it("gives the first row the tab stop and moves it with the arrow keys", async () => {
+    renderTree()
+
+    await waitFor(() => expect(row("Nested Bookmark")).toBeTruthy())
+    expect(row("Folder One").tabIndex).toBe(0)
+
+    press(row("Folder One"), "ArrowDown")
+
+    expect(row("Nested Bookmark").tabIndex).toBe(0)
+    expect(row("Folder One").tabIndex).toBe(-1)
+
+    press(row("Nested Bookmark"), "ArrowUp")
+
+    expect(row("Folder One").tabIndex).toBe(0)
+  })
+
+  it("collapses and expands the focused folder with left and right", async () => {
+    renderTree()
+
+    await waitFor(() => expect(row("Nested Bookmark")).toBeTruthy())
+    expect(row("Folder One").getAttribute("aria-expanded")).toBe("true")
+
+    press(row("Folder One"), "ArrowLeft")
+
+    expect(row("Folder One").getAttribute("aria-expanded")).toBe("false")
+    expect(
+      screen.queryByRole("treeitem", { name: "Nested Bookmark" })
+    ).toBeNull()
+
+    press(row("Folder One"), "ArrowRight")
+
+    await waitFor(() => expect(row("Nested Bookmark")).toBeTruthy())
+  })
+
+  it("selects the focused row so a keyboard drag has something to carry", async () => {
+    renderTree()
+
+    await waitFor(() => expect(row("Nested Bookmark")).toBeTruthy())
+
+    fireEvent.click(row("Bookmark One"))
+
+    expect(row("Bookmark One").getAttribute("aria-selected")).toBe("true")
+    expect(row("Folder One").getAttribute("aria-selected")).toBe("false")
+  })
+
+  it("steps over the rows Folders Only hides", async () => {
+    renderTree(false)
+
+    await waitFor(() => expect(row("Folder Two")).toBeTruthy())
+    expect(screen.queryByRole("treeitem", { name: "Bookmark One" })).toBeNull()
+    expect(row("Folder One").tabIndex).toBe(0)
+
+    // Two bookmark rows sit between the folders in the flattened tree; without
+    // the correction the tab stop would land on one of them and disappear.
+    press(row("Folder One"), "ArrowDown")
+
+    expect(row("Folder Two").tabIndex).toBe(0)
+    expect(row("Folder One").tabIndex).toBe(-1)
+  })
+})
+
+describe("BookmarkOrganizerTree keyboard drag", () => {
+  function assistiveText(container: HTMLElement) {
+    return container.querySelector('[aria-live="assertive"]')?.textContent ?? ""
+  }
+
+  function startDragOn(name: string) {
+    press(row(name), "ControlLeft", "ShiftLeft", "KeyD")
+  }
+
+  it("offers an ordered position when the source can express an order", async () => {
+    mountStore(FULL_ORDERING)
+    const { container } = renderTree()
+
+    await waitFor(() => expect(row("Nested Bookmark")).toBeTruthy())
+    fireEvent.click(row("Bookmark One"))
+    startDragOn("Bookmark One")
+
+    // "<index> of <count> in <folder>" is the library's own wording for a drop
+    // between two rows, which is exactly the gesture `reorder` pays for.
+    expect(assistiveText(container)).toMatch(/\d+ of \d+ in /)
+  })
+
+  it("never offers one when the source can only reparent", async () => {
+    mountStore({ move: true, reorder: false, setChildOrder: false })
+    const { container } = renderTree()
+
+    await waitFor(() => expect(row("Nested Bookmark")).toBeTruthy())
+    fireEvent.click(row("Bookmark One"))
+    startDragOn("Bookmark One")
+
+    expect(assistiveText(container)).toContain("Dragging Bookmark One")
+
+    // Every position the drag can reach has to be a plain drop *onto* a
+    // folder; an ordered one would be a reorder the adapter cannot persist.
+    for (let i = 0; i < 4; i++) {
+      expect(assistiveText(container)).not.toMatch(/\d+ of \d+ in /)
+      press(document.body, "ArrowDown")
+    }
+  })
+
+  it("refuses to pick up a read-only row", async () => {
+    mountStore(FULL_ORDERING, ["bookmark-1"])
+    const { container } = renderTree()
+
+    await waitFor(() => expect(row("Nested Bookmark")).toBeTruthy())
+    fireEvent.click(row("Bookmark One"))
+    startDragOn("Bookmark One")
+
+    expect(assistiveText(container)).not.toContain("Dragging")
+  })
+})

--- a/src/features/bookmark-organizer/bookmark-organizer-row.tsx
+++ b/src/features/bookmark-organizer/bookmark-organizer-row.tsx
@@ -57,6 +57,10 @@ export const BookmarkOrganizerRow = React.memo(function BookmarkOrganizerRow({
   const title = itemData?.title ?? item.getItemName()
   const level = item.getItemMeta().level
   const itemProps = item.getProps()
+  // Read back off the props rather than asking the item, so the row styles
+  // exactly the state it announces — and so it keeps rendering when the
+  // selection feature isn't registered at all.
+  const isSelected = itemProps["aria-selected"] === "true"
   const isReadOnly = itemData?.readOnly ?? false
   const canDrag = dragEnabled && !isReadOnly
   // The folder itself stays draggable, renameable and deletable — only the
@@ -67,8 +71,11 @@ export const BookmarkOrganizerRow = React.memo(function BookmarkOrganizerRow({
     <div
       {...itemProps}
       className={cn(
-        "group group/row flex items-center gap-1.5 rounded-md border border-transparent px-1.5 py-1 transition-colors hover:bg-muted/70",
+        "group group/row flex items-center gap-1.5 rounded-md border border-transparent px-1.5 py-1 transition-colors outline-none hover:bg-muted/70 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
         isDragging && "opacity-40",
+        // Selection is what the arrow keys carry and what a keyboard drag
+        // picks up, so it needs a mark of its own that survives losing focus.
+        isSelected && "bg-muted",
         isFolderDropTarget && "border-primary/40 bg-primary/5",
         itemProps.className
       )}

--- a/src/features/bookmark-organizer/bookmark-organizer-tree.tsx
+++ b/src/features/bookmark-organizer/bookmark-organizer-tree.tsx
@@ -1,11 +1,16 @@
 import * as React from "react"
-import { useTree } from "@headless-tree/react"
+import { AssistiveTreeDescription, useTree } from "@headless-tree/react"
 import {
   asyncDataLoaderFeature,
   createOnDropHandler,
   dragAndDropFeature,
+  hotkeysCoreFeature,
   isOrderedDragTarget,
+  keyboardDragAndDropFeature,
   propMemoizationFeature,
+  selectionFeature,
+  type ItemInstance,
+  type TreeInstance,
 } from "@headless-tree/core"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { Bookmark02Icon, Folder01Icon } from "@hugeicons/core-free-icons"
@@ -49,6 +54,68 @@ function createMissingOrganizerItem(
     index: 0,
     childCount: 0,
   }
+}
+
+/**
+ * The hotkeys that move focus towards the top of the list. Everything else
+ * that moves focus moves it downwards, so naming these is enough to keep the
+ * hidden-row correction below travelling the same way the user asked to.
+ */
+const UPWARD_HOTKEYS = new Set([
+  "focusPreviousItem",
+  "focusLastItem",
+  "selectUpwards",
+])
+
+function findFolderFrom(
+  items: ItemInstance<OrganizerItemData>[],
+  start: number,
+  step: number
+): ItemInstance<OrganizerItemData> | undefined {
+  for (let i = start; i >= 0 && i < items.length; i += step) {
+    if (items[i].isFolder()) {
+      return items[i]
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Pulls focus off a row that "Folders Only" is hiding.
+ *
+ * The toggle hides bookmark rows at render time but leaves them in the
+ * flattened tree, so every focus-moving hotkey can land on a row that draws
+ * nothing: `updateDomFocus` then polls half a second for an element that
+ * never appears and resets focus to the top of the tree. Correcting after the
+ * fact covers the arrows, Home/End and the selection pair in one place,
+ * rather than re-implementing each of the library's handlers.
+ */
+function skipHiddenRows(
+  tree: TreeInstance<OrganizerItemData>,
+  hotkeyName: string
+) {
+  const focused = tree.getFocusedItem()
+  if (!focused || focused.isFolder()) {
+    return
+  }
+
+  const items = tree.getItems()
+  const from = focused.getItemMeta().index
+  const step = UPWARD_HOTKEYS.has(hotkeyName) ? -1 : 1
+  // Falling back to the opposite direction is what keeps the last folder in
+  // the list reachable: pressing Down past it has nowhere else to go, and
+  // leaving focus on the hidden row below would strand it.
+  const next =
+    findFolderFrom(items, from + step, step) ??
+    findFolderFrom(items, from - step, -step)
+
+  if (!next) {
+    return
+  }
+
+  next.setFocused()
+  tree.updateDomFocus()
 }
 
 function toBookmarkNode(node: BookmarkNode) {
@@ -166,6 +233,7 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
   const moveBookmark = useBookmarkStore((s) => s.moveBookmark)
   const setChildOrder = useBookmarkStore((s) => s.setChildOrder)
   const dragEnabled = moveEnabled || reorderEnabled || setChildOrderEnabled
+  const reorderAllowed = reorderEnabled || setChildOrderEnabled
 
   const hasAutoExpanded = React.useRef(false)
   // `createOnDropHandler` invokes its callback twice per drop — once with the
@@ -183,25 +251,52 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
     // `canReorder` controls only same-parent sibling repositioning; a drag
     // that reparents onto a different folder is still allowed when it's
     // false, since that's gated separately by `moveEnabled` below.
-    canReorder: reorderEnabled || setChildOrderEnabled,
+    canReorder: reorderAllowed,
+    // The pointer path withholds a drag from a read-only row simply by not
+    // rendering its handle. A keyboard drag has no handle to withhold, so the
+    // same rule has to be stated as configuration or the drag hotkey would
+    // pick up a row the source refuses to move.
+    canDrag: (items) => items.every((item) => !item.getItemData()?.readOnly),
     // Mirrors headless-tree's own default (`target.item.isFolder()`), plus one
     // rule the daemon enforces anyway: a folder whose child order is frozen
     // refuses a drop *between* its children, while a drop *onto* it — a plain
     // reparent, which needs no order file — stays allowed.
-    canDrop: (_items, target) =>
-      canDropOnTarget({
+    canDrop: (_items, target) => {
+      const isOrderedTarget = isOrderedDragTarget(target)
+
+      // headless-tree consults `canReorder` only while resolving a *pointer*
+      // target; the keyboard path proposes between-row positions regardless
+      // of it. Restating it here is what keeps an adapter that can reparent
+      // but not order from offering a gesture whose ordering half would be
+      // dropped on the floor.
+      if (isOrderedTarget && !reorderAllowed) {
+        return false
+      }
+
+      return canDropOnTarget({
         isFolder: target.item.isFolder(),
         orderReadOnly: target.item.getItemData()?.orderReadOnly,
-        isOrderedTarget: isOrderedDragTarget(target),
+        isOrderedTarget,
         setChildOrderEnabled,
-      }),
+      })
+    },
     indent: 16,
     seperateDragHandle: true,
+    // `hotkeysCoreFeature` is what binds any key at all; `selectionFeature`
+    // gives the arrow keys something to carry and supplies the multi-item
+    // set the drag hotkey reads. `keyboardDragAndDropFeature` rides on the
+    // same `canDrag`/`canDrop`/`onDrop` config as the pointer path, so it
+    // stays gated behind the same capabilities.
     features: [
       asyncDataLoaderFeature,
-      ...(dragEnabled ? [dragAndDropFeature] : []),
+      hotkeysCoreFeature,
+      selectionFeature,
+      ...(dragEnabled ? [dragAndDropFeature, keyboardDragAndDropFeature] : []),
       propMemoizationFeature,
     ],
+    onTreeHotkey: showBookmarks
+      ? undefined
+      : (name) => skipHiddenRows(tree, name),
     dataLoader: {
       getItem: async (id) => {
         if (id === BOOKMARK_ORGANIZER_ROOT_ID) {
@@ -320,6 +415,23 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
     return true
   })
 
+  // headless-tree hands `tabIndex: 0` to the focused row and -1 to every
+  // other, treating the first row as focused while the state is still null.
+  // That first row can be one "Folders Only" hides, or one a refresh has
+  // since removed — either leaves the tree with no tab stop at all. Seeding
+  // focus onto a row that is actually rendered is what keeps Tab able to
+  // reach the tree, and where focus lands after a mutation.
+  React.useEffect(() => {
+    if (visibleItems.length === 0) return
+
+    const focusedId = tree.getState().focusedItem
+    if (focusedId && visibleItems.some((item) => item.getId() === focusedId)) {
+      return
+    }
+
+    visibleItems[0].setFocused()
+  }, [visibleItems, tree])
+
   if (visibleItems.length === 0) {
     return <BookmarkOrganizerEmpty createParentId={createParentId} />
   }
@@ -329,6 +441,11 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
       {...tree.getContainerProps("Bookmark Organizer")}
       className="relative space-y-1"
     >
+      {/* A keyboard drag has no drag image and no cursor to follow, so the
+          only feedback a screen reader gets is this live region — the
+          library's own, which names the position the next Enter would drop
+          into. */}
+      {dragEnabled && <AssistiveTreeDescription tree={tree} />}
       <div
         className="h-0.5 rounded-full bg-primary"
         style={tree.getDragLineStyle()}


### PR DESCRIPTION
Part of #46 — step 1 (organizer) only. The dashboard grid, keyboard reordering across cards, focus-after-mutation and the focus-visible theme audit stay open on that issue.

## Summary

- Register `hotkeysCoreFeature` and `selectionFeature` on the organizer tree, plus `keyboardDragAndDropFeature` inside the existing `dragEnabled` branch. Before this the tree had no arrow-key navigation at all: only `asyncDataLoaderFeature`, `dragAndDropFeature` and `propMemoizationFeature` were registered.
- Focus-visible ring on rows, and a `bg-muted` mark for selected rows so selection survives losing focus.
- Render the library's `AssistiveTreeDescription` live region when drag is on — a keyboard drag has no drag image or cursor, so it is the only feedback a screen reader gets.

## Two rules the library does not enforce for us

**`canReorder` is pointer-only.** It is consulted by `getDragTarget` (pointer) but not by `getNextDragTarget` (keyboard), so the keyboard path proposed ordered between-row targets regardless of the adapter's capabilities. The rule is restated inside `canDrop`: an ordered target is refused when neither `reorder` nor `setChildOrder` is available.

**Read-only rows had no keyboard equivalent of a withheld drag handle.** The pointer path blocks a read-only row simply by not rendering its handle; a keyboard drag has none to withhold. Added `canDrag: (items) => items.every((item) => !item.getItemData()?.readOnly)`.

Everything else is honoured natively: `getNextValidDragTarget` and `completeDrag` both route through the same internal `canDrop` the pointer path uses, so `canDropOnTarget` — including the frozen-order rule — already gates every keyboard target and the final drop. Reordering still goes through the unchanged `onDrop` → `createChildrenChangeHandler`, so store actions and Platform Capabilities are untouched.

## Pre-existing bug fixed along the way

"Folders Only" hides bookmark rows at render time but leaves them in the flattened tree. Every focus-moving hotkey could therefore land on a row that draws nothing, after which `updateDomFocus` polls for half a second for an element that never appears and resets focus to the top of the tree. `skipHiddenRows` corrects focus after the fact, which covers the arrows, Home/End and the selection pair in one place instead of re-implementing each handler.

Separately, headless-tree treats row 0 as focused while focus state is still `null`, and row 0 can be one "Folders Only" hides or one a refresh has removed — leaving the tree with no tab stop. An effect seeds focus onto a row that is actually rendered.

## Known follow-ups

- The ordered-target rule now lives in two places: inline in `canDrop` and in `canDropOnTarget`. Folding it back into `canDropOnTarget` means adding a required parameter and updating `bookmark-organizer-drop.test.ts`; kept separate here so no existing test changed.
- Selection styling reads `itemProps["aria-selected"]` rather than `item.isSelected()`, because the existing `bookmark-organizer-row-readonly.test.tsx` fake `ItemInstance` has no `isSelected`.
- Inner row buttons (drag handle, expand, add, rename, delete) remain native tab stops, so Tab moves within a row rather than out of the tree. Making them `tabIndex={-1}` would remove keyboard access to rename/delete without replacement hotkeys — that belongs with #46 step 4.
- No shipping adapter can reach the `canReorder: false` path today (Chrome/Firefox/Standalone are `reorder: true`, daemon is `setChildOrder: true`). The guard is defensive and its test constructs the capability combination synthetically.

## Verification

- `bun run check` — pass (73 test files, 652 tests)
- `bun run test:ui` — 20 passed
- New: `bookmark-organizer-keyboard.test.tsx`, 7 cases driving real key events — arrow movement and the tab stop, collapse/expand, selection, stepping over "Folders Only" rows, and the three capability gates (ordered position offered, refused when the source can only reparent, read-only row refused). No existing test modified.
