### PR TITLE
chore: ignore agent worktrees in git and eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ dist-safari
 *.sw?
 .superpowers/
 .worktrees/
+# Agent worktrees, created inside the repo by Claude Code's `isolation: worktree`.
+# Untracked they are merely noise; unignored by ESLint they are a second copy of
+# the whole tree, which the root config then lints as if it were source.
+.claude/worktrees/
 
 # Marketing automation — videos and tmp dirs (large binary files)
 marketing/output/videos/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,12 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'dist-*', 'target']),
+  // `.claude/worktrees` and `.worktrees` hold agent worktrees: whole checkouts
+  // of this repo nested inside it. Linting them means linting a second copy of
+  // every file, under the root config rather than the config that copy would
+  // use — `website/src/entries/**` overrides, for one, are relative and stop
+  // matching once the path is prefixed.
+  globalIgnores(['dist', 'dist-*', 'target', '.claude', '.worktrees']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [


### PR DESCRIPTION
## Summary

- Add `.claude/worktrees/` to `.gitignore`.
- Add `.claude` and `.worktrees` to ESLint's `globalIgnores`.

## Why

Claude Code's `isolation: worktree` creates a worktree at `.claude/worktrees/<id>` — a whole checkout of this repo, nested inside it. Neither `.gitignore` nor `eslint.config.js` excluded that path, so `eslint .` walked into the copies and linted them a second time under the **root** config.

That is not merely slow; it is wrong. Overrides in `eslint.config.js` are relative:

```js
files: ['website/src/entries/**/*.tsx']
```

Once the path is prefixed with `.claude/worktrees/agent-xxxx/`, the override stops matching, and files that are green in their own tree fail in this one. It produced exactly that failure while #50 and #51 were in flight:

```
.claude/worktrees/agent-.../website/src/entries/app-preview.tsx
  35:10  error  Fast refresh only works when a file has exports  react-refresh/only-export-components
```

`.worktrees/` was already gitignored but never eslint-ignored, so it had the same latent problem; both are covered now.

## Verification

- `bun run lint` — pass.
- The rest of `bun run check` is unaffected: this changes no source file, and CI runs the whole gate on this PR anyway (`.github/workflows/ci.yml` is outside both new ignores, and `check` is unfiltered regardless).
