### PR TITLE
refactor: fold the ordered-drop rule back into canDropOnTarget

### DIFF
--- a/src/features/bookmark-organizer/__tests__/bookmark-organizer-drop.test.ts
+++ b/src/features/bookmark-organizer/__tests__/bookmark-organizer-drop.test.ts
@@ -287,6 +287,7 @@ describe("canDropOnTarget", () => {
     isFolder: true,
     orderReadOnly: true,
     isOrderedTarget: true,
+    reorderAllowed: true,
     setChildOrderEnabled: true,
   }
 
@@ -309,14 +310,18 @@ describe("canDropOnTarget", () => {
     ).toBe(true)
   })
 
-  it("never allows a drop onto a bookmark, matching headless-tree's built-in rule", () => {
+  // headless-tree's own `canReorder` covers the pointer path only, so this
+  // rule is the sole thing standing between a keyboard drag and an ordered
+  // position the source cannot persist.
+  it("refuses an ordered drop when the source cannot express an order", () => {
     for (const setChildOrderEnabled of [true, false]) {
-      for (const isOrderedTarget of [true, false]) {
+      for (const orderReadOnly of [true, false, undefined]) {
         expect(
           canDropOnTarget({
-            isFolder: false,
-            orderReadOnly: undefined,
-            isOrderedTarget,
+            isFolder: true,
+            orderReadOnly,
+            isOrderedTarget: true,
+            reorderAllowed: false,
             setChildOrderEnabled,
           })
         ).toBe(false)
@@ -324,9 +329,39 @@ describe("canDropOnTarget", () => {
     }
   })
 
+  it("still allows a reparent ONTO a folder when the source cannot order", () => {
+    expect(
+      canDropOnTarget({
+        ...orderedIntoFrozen,
+        isOrderedTarget: false,
+        reorderAllowed: false,
+      })
+    ).toBe(true)
+  })
+
+  it("never allows a drop onto a bookmark, matching headless-tree's built-in rule", () => {
+    for (const setChildOrderEnabled of [true, false]) {
+      for (const isOrderedTarget of [true, false]) {
+        for (const reorderAllowed of [true, false]) {
+          expect(
+            canDropOnTarget({
+              isFolder: false,
+              orderReadOnly: undefined,
+              isOrderedTarget,
+              reorderAllowed,
+              setChildOrderEnabled,
+            })
+          ).toBe(false)
+        }
+      }
+    }
+  })
+
   it("is exactly headless-tree's default (isFolder) for every extension build", () => {
     // The override replaces the built-in, so extension parity has to be
-    // asserted rather than assumed: with ordering off, only isFolder matters.
+    // asserted rather than assumed: Chrome, Firefox and Standalone all report
+    // `reorder: true` and `setChildOrder: false`, and there only isFolder
+    // matters.
     for (const orderReadOnly of [true, false, undefined]) {
       for (const isOrderedTarget of [true, false]) {
         expect(
@@ -334,6 +369,7 @@ describe("canDropOnTarget", () => {
             isFolder: true,
             orderReadOnly,
             isOrderedTarget,
+            reorderAllowed: true,
             setChildOrderEnabled: false,
           })
         ).toBe(true)

--- a/src/features/bookmark-organizer/bookmark-organizer-drop.ts
+++ b/src/features/bookmark-organizer/bookmark-organizer-drop.ts
@@ -55,19 +55,31 @@ export interface ChildrenChangeDeps {
  *
  * Replaces headless-tree's built-in `canDrop` (which is just
  * `target.item.isFolder()`), so it has to re-assert that rule or drops onto
- * bookmarks become legal. The only thing it adds is the daemon's own: a folder
- * whose child order is frozen refuses a drop *between* its children, while a
- * drop *onto* it — a plain reparent, which needs no order file — stays fine.
+ * bookmarks become legal. It adds two more:
+ *
+ * - The source has to be able to express an order at all. headless-tree has
+ *   its own `canReorder` for this, but consults it only while resolving a
+ *   *pointer* target — `getNextDragTarget`, which the keyboard uses, proposes
+ *   between-row positions regardless. Stating the rule here is what covers
+ *   both paths, rather than leaving the keyboard offering a gesture whose
+ *   ordering half would be dropped on the floor.
+ * - The daemon's own: a folder whose child order is frozen refuses a drop
+ *   *between* its children, while a drop *onto* it — a plain reparent, which
+ *   needs no order file — stays fine.
  */
 export function canDropOnTarget(params: {
   isFolder: boolean
   orderReadOnly: boolean | undefined
   /** True for a drop between children, false for a drop onto the folder. */
   isOrderedTarget: boolean
+  /** `capabilities.reorder || capabilities.setChildOrder`. */
+  reorderAllowed: boolean
   setChildOrderEnabled: boolean
 }): boolean {
   if (!params.isFolder) return false
-  if (!params.setChildOrderEnabled || !params.isOrderedTarget) return true
+  if (!params.isOrderedTarget) return true
+  if (!params.reorderAllowed) return false
+  if (!params.setChildOrderEnabled) return true
   return !params.orderReadOnly
 }
 

--- a/src/features/bookmark-organizer/bookmark-organizer-tree.tsx
+++ b/src/features/bookmark-organizer/bookmark-organizer-tree.tsx
@@ -257,29 +257,17 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
     // same rule has to be stated as configuration or the drag hotkey would
     // pick up a row the source refuses to move.
     canDrag: (items) => items.every((item) => !item.getItemData()?.readOnly),
-    // Mirrors headless-tree's own default (`target.item.isFolder()`), plus one
-    // rule the daemon enforces anyway: a folder whose child order is frozen
-    // refuses a drop *between* its children, while a drop *onto* it — a plain
-    // reparent, which needs no order file — stays allowed.
-    canDrop: (_items, target) => {
-      const isOrderedTarget = isOrderedDragTarget(target)
-
-      // headless-tree consults `canReorder` only while resolving a *pointer*
-      // target; the keyboard path proposes between-row positions regardless
-      // of it. Restating it here is what keeps an adapter that can reparent
-      // but not order from offering a gesture whose ordering half would be
-      // dropped on the floor.
-      if (isOrderedTarget && !reorderAllowed) {
-        return false
-      }
-
-      return canDropOnTarget({
+    // Every rule about where a drop may land lives in `canDropOnTarget`, for
+    // both the pointer and the keyboard. This stays a thin adapter from
+    // headless-tree's target shape to that function's parameters.
+    canDrop: (_items, target) =>
+      canDropOnTarget({
         isFolder: target.item.isFolder(),
         orderReadOnly: target.item.getItemData()?.orderReadOnly,
-        isOrderedTarget,
+        isOrderedTarget: isOrderedDragTarget(target),
+        reorderAllowed,
         setChildOrderEnabled,
-      })
-    },
+      }),
     indent: 16,
     seperateDragHandle: true,
     // `hotkeysCoreFeature` is what binds any key at all; `selectionFeature`


### PR DESCRIPTION
Follow-up to #51, which flagged this in its own description.

## Summary

- `canDropOnTarget` takes a `reorderAllowed` parameter and owns the "source must be able to express an order" rule.
- The tree's `canDrop` goes back to being a thin adapter from headless-tree's target shape to that function's parameters.
- No behaviour change.

## Why

#51 had to state that rule somewhere: headless-tree consults its own `canReorder` only while resolving a **pointer** target, so `getNextDragTarget` — the keyboard path — proposes between-row positions regardless of it. Without the rule, a keyboard drag on an adapter that can reparent but not order offers a gesture whose ordering half is silently dropped.

It landed inline in the tree rather than in `canDropOnTarget` only because folding it in meant adding a required parameter and editing `bookmark-organizer-drop.test.ts`, and that PR deliberately changed no existing test. The cost was one rule about where a drop may land living in two places — the exact cohesion loss called out in #51's "Known follow-ups".

## Verification

- `bun run typecheck`, `bun run lint`, `bun run test` — pass (73 files, 654 tests; 652 before, 2 new).
- The regression guard that matters is unmodified: `bookmark-organizer-keyboard.test.tsx`'s "never offers one when the source can only reparent" still passes with the rule moved, which is what shows the fold preserved behaviour rather than merely relocating code.
- `canDropOnTarget`'s existing cases keep their assertions; `reorderAllowed: true` is added to the shared fixture (the value every shipping adapter reports), and two new cases cover the gate itself — ordered drops refused when the source cannot order, reparents onto a folder still allowed.
