### PR TITLE
feat: add a search palette to the bookmarks dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Search palette** — start typing anywhere on the dashboard and a palette
+  opens on the first character, matching bookmark titles and URLs and folder
+  names across the whole Active Source. There is no shortcut to learn, and a
+  Search action in the toolbar covers pointer and touch. Results carry their
+  folder path, and any result can be revealed in the Bookmark Organizer —
+  including one outside the dashboard's root folder, which widens the
+  organizer for that visit without changing the saved root
+
 ### Changed
 
 - **The omnibox keyword is now `bb`.** Address-bar search previously required

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,16 @@ import {
   TooltipContent,
 } from "@/components/ui/tooltip"
 import { HugeiconsIcon } from "@hugeicons/react"
-import { Settings03Icon, FolderTreeIcon } from "@hugeicons/core-free-icons"
+import {
+  Settings03Icon,
+  FolderTreeIcon,
+  Search01Icon,
+} from "@hugeicons/core-free-icons"
 import { useAppBootstrap } from "@/hooks/use-app-bootstrap"
+// Imported past the feature's barrel on purpose: the listener has to be
+// mounted before the palette exists, and the barrel would defeat the lazy
+// chunk below.
+import { useSearchTypeAhead } from "@/features/search-palette/use-search-type-ahead"
 
 const SettingsDialog = React.lazy(() =>
   import("@/features/settings").then((m) => ({ default: m.SettingsDialog }))
@@ -53,9 +61,15 @@ const OnboardingWizard = React.lazy(() =>
     default: m.OnboardingWizard,
   }))
 )
+const SearchPaletteDialog = React.lazy(() =>
+  import("@/features/search-palette").then((m) => ({
+    default: m.SearchPaletteDialog,
+  }))
+)
 
 export function App() {
   const { onboardingChecked } = useAppBootstrap()
+  useSearchTypeAhead()
   const onboardingOpen = useUIStore((s) => s.onboardingOpen)
   const closeOnboarding = useUIStore((s) => s.closeOnboarding)
   const openSettings = useUIStore((s) => s.openSettings)
@@ -67,6 +81,7 @@ export function App() {
   const loadError = useBookmarkStore((s) => s.loadError)
   const retry = useBookmarkStore((s) => s.retry)
   const openBookmarkOrganizer = useUIStore((s) => s.openBookmarkOrganizer)
+  const openSearchPalette = useUIStore((s) => s.openSearchPalette)
 
   return (
     <ScrollArea className="h-svh bg-background text-foreground">
@@ -128,7 +143,7 @@ export function App() {
         )}
       </main>
 
-      {/* The two global actions. Appearance and product information live in
+      {/* The three global actions. Appearance and product information live in
           their corresponding Settings categories instead of being duplicated
           here. */}
       <div
@@ -136,6 +151,23 @@ export function App() {
         aria-label="App actions"
         className="fixed right-4 bottom-4 z-10 flex w-fit items-center gap-2 rounded-2xl border border-border/60 bg-background/90 px-2 py-1.5 shadow-sm backdrop-blur-sm sm:right-6 sm:bottom-6 max-sm:[&_button]:size-12"
       >
+        {/* Typing anywhere on the page opens the same palette; this is the
+            way in for a pointer, and the only one on a touch screen. */}
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => openSearchPalette()}
+                aria-label="Search bookmarks"
+              />
+            }
+          >
+            <HugeiconsIcon icon={Search01Icon} />
+          </TooltipTrigger>
+          <TooltipContent side="top">Search bookmarks</TooltipContent>
+        </Tooltip>
         <Tooltip>
           <TooltipTrigger
             render={
@@ -182,6 +214,7 @@ export function App() {
       {/* Dialogs */}
       <React.Suspense fallback={null}>
         <SettingsDialog />
+        <SearchPaletteDialog />
         <BookmarkEditorDialog />
         <DeleteConfirmDialog />
         <BookmarkOrganizerSheet />

--- a/src/features/bookmark-organizer/__tests__/bookmark-organizer-reveal.test.tsx
+++ b/src/features/bookmark-organizer/__tests__/bookmark-organizer-reveal.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import type { BookmarkNode } from "@/browser"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+import { useUIStore } from "@/stores/ui-store"
+import { usePreferencesStore } from "@/stores/preferences-store"
+import { BookmarkOrganizerSheet } from "../bookmark-organizer-sheet"
+
+/**
+ * Reveal is the search palette's answer to a hit the dashboard is not
+ * showing, so what matters is that the organizer reaches items it would
+ * normally hide: a different branch than the pinned root, and a bookmark
+ * while "Folders Only" is on.
+ */
+
+const STORE_TREE: BookmarkNode[] = [
+  {
+    id: "vault",
+    title: "Vault",
+    children: [
+      {
+        id: "work",
+        title: "Work",
+        parentId: "vault",
+        children: [
+          {
+            id: "deep",
+            title: "Deep",
+            parentId: "work",
+            children: [
+              {
+                id: "target",
+                title: "Target Bookmark",
+                parentId: "deep",
+                url: "https://example.com/target",
+              },
+            ],
+          },
+        ],
+      },
+      { id: "other", title: "Other", parentId: "vault", children: [] },
+    ],
+  },
+]
+
+function nodesById(
+  nodes: BookmarkNode[],
+  into: Map<string, BookmarkNode> = new Map()
+): Map<string, BookmarkNode> {
+  for (const node of nodes) {
+    into.set(node.id, node)
+    if (node.children) nodesById(node.children, into)
+  }
+  return into
+}
+
+const BY_ID = nodesById(STORE_TREE)
+
+function mountStore(rootFolderId: string | null) {
+  const rootFolder = rootFolderId ? (BY_ID.get(rootFolderId) ?? null) : null
+
+  useUIStore.setState({
+    settingsOpen: false,
+    bookmarkOrganizerOpen: true,
+    organizerRevealId: null,
+    editingBookmark: null,
+    deletingItem: null,
+    creatingItem: null,
+  })
+
+  useBookmarkStore.setState({
+    tree: STORE_TREE,
+    rootFolderId,
+    rootFolder,
+    isLoading: false,
+    adapter: {
+      bookmarks: {
+        getTree: vi.fn().mockResolvedValue(STORE_TREE),
+        getSubTree: vi.fn().mockImplementation(async (id: string) => {
+          const node = BY_ID.get(id)
+          return node ? [node] : []
+        }),
+        create: vi.fn(),
+        update: vi.fn(),
+        remove: vi.fn(),
+        removeTree: vi.fn(),
+        move: vi.fn(),
+        onChanged: vi.fn(() => () => {}),
+        onCreated: vi.fn(() => () => {}),
+        onRemoved: vi.fn(() => () => {}),
+        onMoved: vi.fn(() => () => {}),
+        openInManager: vi.fn(),
+      },
+      storage: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+      favicon: { getUrl: vi.fn(() => ""), isAvailable: vi.fn(() => false) },
+      capabilities: {
+        openInManager: false,
+        move: true,
+        reorder: false,
+        setChildOrder: false,
+        rootIsCreatable: true,
+      },
+    },
+  })
+}
+
+describe("Bookmark Organizer reveal", () => {
+  beforeEach(() => {
+    usePreferencesStore.setState({ isFoldersOnlyEnabledInTreeEditor: true })
+  })
+
+  afterEach(() => {
+    cleanup()
+    useUIStore.setState({ organizerRevealId: null })
+  })
+
+  it("expands its way down to the revealed item and selects it", async () => {
+    mountStore(null)
+    useUIStore.setState({ organizerRevealId: "target" })
+    render(<BookmarkOrganizerSheet />)
+
+    // Two folders deep, and hidden by "Folders Only" until the reveal.
+    expect(await screen.findByText("Target Bookmark")).toBeTruthy()
+    await waitFor(() => {
+      const selected = document.querySelector(
+        "[role='treeitem'][aria-selected='true']"
+      )
+      expect(selected?.textContent).toContain("Target Bookmark")
+    })
+  })
+
+  it("widens past a pinned root folder without changing the saved one", async () => {
+    mountStore("other")
+    useUIStore.setState({ organizerRevealId: "target" })
+    render(<BookmarkOrganizerSheet />)
+
+    expect(await screen.findByText("Target Bookmark")).toBeTruthy()
+    expect(
+      screen.getByText(
+        "Widened to the whole source to show a search result. Your saved root folder is unchanged."
+      )
+    ).toBeTruthy()
+    // The dashboard's root is a saved preference: revealing must not write it.
+    expect(useBookmarkStore.getState().rootFolderId).toBe("other")
+  })
+
+  it("leaves the pinned root alone when the item is already inside it", async () => {
+    mountStore("work")
+    useUIStore.setState({ organizerRevealId: "target" })
+    render(<BookmarkOrganizerSheet />)
+
+    expect(await screen.findByText("Target Bookmark")).toBeTruthy()
+    expect(
+      screen.getByText("Changes apply to the selected root subtree.")
+    ).toBeTruthy()
+  })
+
+  it("shows only folders again on a plain visit", async () => {
+    mountStore(null)
+    render(<BookmarkOrganizerSheet />)
+
+    expect(await screen.findByText("Work")).toBeTruthy()
+    expect(screen.queryByText("Target Bookmark")).toBeNull()
+  })
+})

--- a/src/features/bookmark-organizer/bookmark-organizer-sheet.tsx
+++ b/src/features/bookmark-organizer/bookmark-organizer-sheet.tsx
@@ -40,22 +40,20 @@ import {
 import { useBookmarkStore } from "@/stores/bookmark-store"
 import { useUIStore } from "@/stores/ui-store"
 import { usePreferencesStore } from "@/stores/preferences-store"
+import { findNodePath } from "@/lib/bookmark-utils"
 
 export function BookmarkOrganizerSheet() {
   const bookmarkOrganizerOpen = useUIStore((s) => s.bookmarkOrganizerOpen)
   const closeBookmarkOrganizer = useUIStore((s) => s.closeBookmarkOrganizer)
+  const organizerRevealId = useUIStore((s) => s.organizerRevealId)
+  const clearOrganizerReveal = useUIStore((s) => s.clearOrganizerReveal)
   const rootFolderId = useBookmarkStore((s) => s.rootFolderId)
   const setRootFolderId = useBookmarkStore((s) => s.setRootFolderId)
+  const rootFolder = useBookmarkStore((s) => s.rootFolder)
   const tree = useBookmarkStore((s) => s.tree)
   const adapter = useBookmarkStore((s) => s.adapter)
   const mutationError = useBookmarkStore((s) => s.mutationError)
   const clearMutationError = useBookmarkStore((s) => s.clearMutationError)
-
-  const createParentId = resolveCreateParentId(
-    tree,
-    rootFolderId,
-    adapter?.capabilities.rootIsCreatable ?? false
-  )
 
   const creatingItem = useUIStore((s) => s.creatingItem)
   const openCreateItem = useUIStore((s) => s.openCreateItem)
@@ -65,6 +63,29 @@ export function BookmarkOrganizerSheet() {
   )
   const setFoldersOnly = usePreferencesStore(
     (s) => s.setIsFoldersOnlyEnabledInTreeEditor
+  )
+
+  // Search covers the whole Active Source, so a revealed item can sit outside
+  // the pinned root, or be a bookmark while "Folders Only" is on. Both are
+  // relaxed for the visit rather than written back: the root folder is a
+  // saved preference that also drives the dashboard, and a reveal is not the
+  // user asking to change it.
+  const revealPath = organizerRevealId
+    ? findNodePath(tree, organizerRevealId)
+    : null
+  const revealTarget = revealPath?.[revealPath.length - 1] ?? null
+  const revealNeedsWholeSource =
+    revealPath !== null &&
+    rootFolder !== null &&
+    !revealPath.some((node) => node.id === rootFolder.id)
+  const showBookmarks = !foldersOnly || revealTarget?.url != null
+  // Every header control describes the tree actually on screen, so a widened
+  // visit creates where it is showing rather than where the saved root points.
+  const shownRootFolderId = revealNeedsWholeSource ? null : rootFolderId
+  const createParentId = resolveCreateParentId(
+    tree,
+    shownRootFolderId,
+    adapter?.capabilities.rootIsCreatable ?? false
   )
 
   const treeRef = React.useRef<BookmarkOrganizerTreeHandle>(null)
@@ -112,9 +133,16 @@ export function BookmarkOrganizerSheet() {
             <div className="flex flex-col gap-4 border-b border-border/70 px-6 py-4">
               <RootFolderSelect
                 label="Root folder"
-                description="Changes apply to the selected root subtree."
-                value={rootFolderId}
-                onChange={setRootFolderId}
+                description={
+                  revealNeedsWholeSource
+                    ? "Widened to the whole source to show a search result. Your saved root folder is unchanged."
+                    : "Changes apply to the selected root subtree."
+                }
+                value={shownRootFolderId}
+                onChange={(id) => {
+                  clearOrganizerReveal()
+                  setRootFolderId(id)
+                }}
               />
 
               <div className="flex items-center gap-2">
@@ -123,7 +151,10 @@ export function BookmarkOrganizerSheet() {
                     id="folders-only"
                     size="sm"
                     checked={foldersOnly}
-                    onCheckedChange={setFoldersOnly}
+                    onCheckedChange={(checked) => {
+                      clearOrganizerReveal()
+                      setFoldersOnly(checked)
+                    }}
                   />
                   <Label
                     htmlFor="folders-only"
@@ -228,8 +259,9 @@ export function BookmarkOrganizerSheet() {
 
             <ScrollArea className="min-h-0 flex-1 px-6 py-4">
               <BookmarkOrganizerTree
-                rootFolderId={rootFolderId}
-                showBookmarks={!foldersOnly}
+                rootFolderId={shownRootFolderId}
+                showBookmarks={showBookmarks}
+                revealId={organizerRevealId}
                 treeRef={treeRef}
               />
             </ScrollArea>

--- a/src/features/bookmark-organizer/bookmark-organizer-tree.tsx
+++ b/src/features/bookmark-organizer/bookmark-organizer-tree.tsx
@@ -19,6 +19,7 @@ import type { BookmarkAdapter, BookmarkNode } from "@/browser"
 import { useBookmarkStore } from "@/stores/bookmark-store"
 import { useUIStore } from "@/stores/ui-store"
 import { resolveCreateParentId } from "@/features/root-folder-select"
+import { findNodePath } from "@/lib/bookmark-utils"
 import {
   loadOrganizerChildren,
   loadOrganizerItem,
@@ -210,6 +211,8 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
     rootOrderReadOnly?: boolean
     bookmarks: Pick<BookmarkAdapter, "getSubTree">
     showBookmarks: boolean
+    /** An item to expand down to and focus, with the folders above it, outermost first. */
+    reveal?: { id: string; ancestorIds: string[] } | null
     moveEnabled: boolean
     reorderEnabled: boolean
     setChildOrderEnabled: boolean
@@ -221,6 +224,7 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
     rootOrderReadOnly,
     bookmarks,
     showBookmarks,
+    reveal,
     moveEnabled,
     reorderEnabled,
     setChildOrderEnabled,
@@ -236,6 +240,9 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
   const reorderAllowed = reorderEnabled || setChildOrderEnabled
 
   const hasAutoExpanded = React.useRef(false)
+  // Which item the reveal below has already delivered focus to. Without it,
+  // every later render would drag focus back to the revealed row.
+  const revealedIdRef = React.useRef<string | null>(null)
   // `createOnDropHandler` invokes its callback twice per drop — once with the
   // source parent's children minus the dragged ids, once with the destination
   // parent's children plus them — and neither call says which pass it is.
@@ -393,6 +400,43 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
     }
   }, [items])
 
+  /**
+   * Walks the tree open one level per render until the revealed item exists,
+   * then focuses and selects it.
+   *
+   * A folder's children only load once it is expanded, so the item to focus
+   * does not exist yet when the reveal arrives. Expanding the outermost
+   * unexpanded ancestor and stopping is what lets the load's own re-render
+   * bring the effect back for the next level — rather than this reaching into
+   * the loader and re-implementing it. Ancestors above the organizer's own
+   * root are not rows at all and are simply skipped.
+   */
+  React.useEffect(() => {
+    if (!reveal) {
+      revealedIdRef.current = null
+      return
+    }
+    if (revealedIdRef.current === reveal.id) return
+
+    const rendered = new Map(items.map((item) => [item.getId(), item]))
+
+    for (const ancestorId of reveal.ancestorIds) {
+      const ancestor = rendered.get(ancestorId)
+      if (ancestor && !ancestor.isExpanded()) {
+        ancestor.expand()
+        return
+      }
+    }
+
+    const target = rendered.get(reveal.id)
+    if (!target) return
+
+    revealedIdRef.current = reveal.id
+    target.select()
+    target.setFocused()
+    tree.updateDomFocus()
+  }, [items, reveal, tree])
+
   const draggedItemIds = new Set(
     tree.getState().dnd?.draggedItems?.map((i) => i.getId()) ?? []
   )
@@ -493,21 +537,40 @@ const BookmarkOrganizerTreeImpl = React.forwardRef<
 export function BookmarkOrganizerTree({
   rootFolderId,
   showBookmarks,
+  revealId,
   treeRef,
 }: {
   rootFolderId: string | null
   showBookmarks: boolean
+  /** An item somewhere in the source to expand down to and focus, if any. */
+  revealId?: string | null
   treeRef: React.Ref<BookmarkOrganizerTreeHandle>
 }) {
   const adapter = useBookmarkStore((s) => s.adapter)
   const tree = useBookmarkStore((s) => s.tree)
   const rootFolder = useBookmarkStore((s) => s.rootFolder)
+
+  // The store's tree already holds every ancestor, so the path costs one walk
+  // here instead of a request per level from the organizer's own loader.
+  const reveal = React.useMemo(() => {
+    if (!revealId) return null
+    const path = findNodePath(tree, revealId)
+    if (!path) return null
+    return {
+      id: revealId,
+      ancestorIds: path.slice(0, -1).map((node) => node.id),
+    }
+  }, [tree, revealId])
+
   // `rootFolder` is the store's own resolution of `rootFolderId` against the
   // tree, so going through it means a saved id whose folder has since been
   // deleted falls back to the tree root instead of asking for a subtree that
   // no longer exists and rendering an empty organizer — which is what the
-  // create actions and import already do.
-  const effectiveRootNode = rootFolder ?? tree[0]
+  // create actions and import already do. The prop still decides which
+  // question is being asked: a caller passing `null` wants the whole source,
+  // and the saved resolution must not put the pinned root back.
+  const effectiveRootNode =
+    (rootFolderId === null ? null : rootFolder) ?? tree[0]
   const effectiveRootId = effectiveRootNode?.id ?? null
 
   if (!adapter) {
@@ -537,6 +600,7 @@ export function BookmarkOrganizerTree({
       }
       bookmarks={adapter.bookmarks}
       showBookmarks={showBookmarks}
+      reveal={reveal}
       moveEnabled={adapter.capabilities.move}
       reorderEnabled={adapter.capabilities.reorder}
       setChildOrderEnabled={setChildOrderEnabled}

--- a/src/features/search-palette/__tests__/search-palette-dialog.test.tsx
+++ b/src/features/search-palette/__tests__/search-palette-dialog.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import type { BookmarkNode } from "@/browser"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+import { useUIStore } from "@/stores/ui-store"
+import { SearchPaletteDialog } from "../search-palette-dialog"
+import { openResultUrl } from "../open-result"
+
+// Only the navigation itself is stubbed: which URLs may be followed is a rule
+// worth exercising through the real thing.
+vi.mock("../open-result", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../open-result")>()),
+  openResultUrl: vi.fn(),
+}))
+
+const TREE: BookmarkNode[] = [
+  {
+    id: "0",
+    title: "",
+    children: [
+      {
+        id: "bar",
+        title: "Bookmarks Bar",
+        children: [
+          {
+            id: "dev",
+            title: "Dev",
+            children: [
+              { id: "github", title: "GitHub", url: "https://github.com" },
+            ],
+          },
+          {
+            id: "scripts",
+            title: "Scripts",
+            children: [
+              { id: "legacy", title: "Legacy tool", url: "javascript:void 0" },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+
+function openPalette(seedQuery = "") {
+  useUIStore.setState({ searchPalette: { seedQuery }, organizerRevealId: null })
+}
+
+function searchInput(): HTMLInputElement {
+  return screen.getByRole("combobox", { name: "Search bookmarks" })
+}
+
+function highlightedOption(): HTMLElement | undefined {
+  return screen
+    .getAllByRole("option")
+    .find((option) => option.getAttribute("aria-selected") === "true")
+}
+
+describe("SearchPaletteDialog", () => {
+  beforeEach(() => {
+    vi.mocked(openResultUrl).mockClear()
+    useBookmarkStore.setState({ tree: TREE })
+    openPalette()
+    render(<SearchPaletteDialog />)
+  })
+
+  afterEach(() => {
+    cleanup()
+    useUIStore.setState({ searchPalette: null, organizerRevealId: null })
+  })
+
+  it("starts from the character that opened it", () => {
+    cleanup()
+    openPalette("g")
+    render(<SearchPaletteDialog />)
+
+    expect(searchInput().value).toBe("g")
+    expect(screen.getAllByRole("option")[0].textContent).toContain("GitHub")
+  })
+
+  it("puts focus in the search box, since the next character is the query", async () => {
+    await waitFor(() => expect(document.activeElement).toBe(searchInput()))
+  })
+
+  it("says where each hit lives, since the scope is the whole source", () => {
+    fireEvent.change(searchInput(), { target: { value: "github" } })
+
+    expect(screen.getByRole("option").textContent).toContain(
+      "Bookmarks Bar > Dev"
+    )
+  })
+
+  it("moves the highlight with the arrow keys, staying in the input", () => {
+    fireEvent.change(searchInput(), { target: { value: "e" } })
+    const options = screen.getAllByRole("option")
+    expect(options.length).toBeGreaterThan(1)
+    expect(highlightedOption()).toBe(options[0])
+
+    fireEvent.keyDown(searchInput(), { key: "ArrowDown" })
+    expect(highlightedOption()).toBe(screen.getAllByRole("option")[1])
+    expect(searchInput().getAttribute("aria-activedescendant")).toBe(
+      screen.getAllByRole("option")[1].id
+    )
+
+    fireEvent.keyDown(searchInput(), { key: "ArrowUp" })
+    expect(highlightedOption()).toBe(screen.getAllByRole("option")[0])
+  })
+
+  it("opens the highlighted result in this tab on Enter, and closes", () => {
+    fireEvent.change(searchInput(), { target: { value: "github" } })
+    fireEvent.keyDown(searchInput(), { key: "Enter" })
+
+    expect(openResultUrl).toHaveBeenCalledWith("https://github.com/", {
+      background: false,
+    })
+    expect(useUIStore.getState().searchPalette).toBeNull()
+  })
+
+  it("opens in a background tab on Ctrl or Command Enter, and stays open", () => {
+    fireEvent.change(searchInput(), { target: { value: "github" } })
+    fireEvent.keyDown(searchInput(), { key: "Enter", metaKey: true })
+
+    expect(openResultUrl).toHaveBeenCalledWith("https://github.com/", {
+      background: true,
+    })
+    // The user is still here: opening several in a row is the point.
+    expect(useUIStore.getState().searchPalette).not.toBeNull()
+  })
+
+  it("reveals a folder instead of navigating, since it has nowhere to go", () => {
+    fireEvent.change(searchInput(), { target: { value: "scripts" } })
+    fireEvent.keyDown(searchInput(), { key: "Enter" })
+
+    expect(openResultUrl).not.toHaveBeenCalled()
+    expect(useUIStore.getState().organizerRevealId).toBe("scripts")
+    expect(useUIStore.getState().bookmarkOrganizerOpen).toBe(true)
+  })
+
+  it("reveals a bookmark whose URL this page must not follow", () => {
+    fireEvent.change(searchInput(), { target: { value: "legacy" } })
+    fireEvent.keyDown(searchInput(), { key: "Enter" })
+
+    expect(openResultUrl).not.toHaveBeenCalled()
+    expect(useUIStore.getState().organizerRevealId).toBe("legacy")
+  })
+
+  it("reveals the highlighted result from the footer action", () => {
+    fireEvent.change(searchInput(), { target: { value: "github" } })
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Reveal GitHub in Bookmark Organizer",
+      })
+    )
+
+    expect(useUIStore.getState().organizerRevealId).toBe("github")
+    expect(useUIStore.getState().searchPalette).toBeNull()
+  })
+
+  it("says so when nothing matches, and offers nothing to open", () => {
+    fireEvent.change(searchInput(), { target: { value: "nothing here" } })
+
+    expect(screen.queryAllByRole("option")).toHaveLength(0)
+    expect(screen.getByText("Nothing in this source matches.")).toBeTruthy()
+
+    fireEvent.keyDown(searchInput(), { key: "Enter" })
+    expect(openResultUrl).not.toHaveBeenCalled()
+  })
+
+  it("shows nothing at all for an empty query", () => {
+    expect(screen.queryAllByRole("option")).toHaveLength(0)
+    expect(screen.getByText("Type to search this source.")).toBeTruthy()
+  })
+})

--- a/src/features/search-palette/__tests__/use-search-type-ahead.test.tsx
+++ b/src/features/search-palette/__tests__/use-search-type-ahead.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { useSearchTypeAhead } from "../use-search-type-ahead"
+import { useUIStore } from "@/stores/ui-store"
+
+/**
+ * The palette has no shortcut, so this listener is the whole keyboard
+ * entrance: what it opens on, and — the part that would be felt first if it
+ * were wrong — everything it must keep its hands off.
+ */
+function TypeAheadHost() {
+  useSearchTypeAhead()
+
+  return (
+    <div>
+      <button type="button">Plain button</button>
+      <input aria-label="A field" />
+      <textarea aria-label="A note" />
+      <div contentEditable aria-label="A rich field" />
+      <div role="dialog" aria-label="Another dialog">
+        <button type="button">Button in a dialog</button>
+      </div>
+    </div>
+  )
+}
+
+function seedQuery(): string | null {
+  return useUIStore.getState().searchPalette?.seedQuery ?? null
+}
+
+describe("useSearchTypeAhead", () => {
+  beforeEach(() => {
+    useUIStore.setState({ searchPalette: null })
+    render(<TypeAheadHost />)
+  })
+
+  afterEach(() => {
+    cleanup()
+    useUIStore.setState({ searchPalette: null })
+  })
+
+  it("opens the palette on a printable character, seeded with it", () => {
+    fireEvent.keyDown(document.body, { key: "g" })
+
+    expect(seedQuery()).toBe("g")
+  })
+
+  it("keeps the character out of the page, so quick-find never starts", () => {
+    const notPrevented = fireEvent.keyDown(document.body, { key: "g" })
+
+    expect(notPrevented).toBe(false)
+  })
+
+  it("treats Shift as part of typing", () => {
+    fireEvent.keyDown(document.body, { key: "G", shiftKey: true })
+
+    expect(seedQuery()).toBe("G")
+  })
+
+  it("opens from a focusable element that is not a text field", () => {
+    fireEvent.keyDown(screen.getByRole("button", { name: "Plain button" }), {
+      key: "b",
+    })
+
+    expect(seedQuery()).toBe("b")
+  })
+
+  it("leaves typing in an input alone", () => {
+    fireEvent.keyDown(screen.getByLabelText("A field"), { key: "g" })
+
+    expect(seedQuery()).toBeNull()
+  })
+
+  it("leaves typing in a textarea alone", () => {
+    fireEvent.keyDown(screen.getByLabelText("A note"), { key: "g" })
+
+    expect(seedQuery()).toBeNull()
+  })
+
+  it("leaves typing in a contenteditable alone", () => {
+    fireEvent.keyDown(screen.getByLabelText("A rich field"), { key: "g" })
+
+    expect(seedQuery()).toBeNull()
+  })
+
+  it("leaves a character typed inside another dialog to that dialog", () => {
+    fireEvent.keyDown(
+      screen.getByRole("button", { name: "Button in a dialog" }),
+      { key: "g" }
+    )
+
+    expect(seedQuery()).toBeNull()
+  })
+
+  it("ignores a character carrying Ctrl or Command, which belongs to a shortcut", () => {
+    fireEvent.keyDown(document.body, { key: "k", metaKey: true })
+    expect(seedQuery()).toBeNull()
+
+    fireEvent.keyDown(document.body, { key: "k", ctrlKey: true })
+    expect(seedQuery()).toBeNull()
+
+    fireEvent.keyDown(document.body, { key: "k", altKey: true })
+    expect(seedQuery()).toBeNull()
+  })
+
+  it("ignores keys that are not a typed character", () => {
+    for (const key of ["Enter", "Tab", "ArrowDown", "Escape", "F5", " "]) {
+      fireEvent.keyDown(document.body, { key })
+      expect(seedQuery()).toBeNull()
+    }
+  })
+
+  it("ignores a keystroke another handler already claimed", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "g",
+      bubbles: true,
+      cancelable: true,
+    })
+    event.preventDefault()
+    document.body.dispatchEvent(event)
+
+    expect(seedQuery()).toBeNull()
+  })
+
+  it("stops listening once the dashboard unmounts", () => {
+    cleanup()
+
+    fireEvent.keyDown(document.body, { key: "g" })
+
+    expect(seedQuery()).toBeNull()
+  })
+})

--- a/src/features/search-palette/index.ts
+++ b/src/features/search-palette/index.ts
@@ -1,0 +1,4 @@
+// The type-ahead hook is deliberately not re-exported here: it has to be
+// mounted eagerly, and importing it through this barrel would pull the
+// palette's chunk into the initial bundle it is lazily split out of.
+export { SearchPaletteDialog } from "./search-palette-dialog"

--- a/src/features/search-palette/open-result.ts
+++ b/src/features/search-palette/open-result.ts
@@ -1,0 +1,39 @@
+/**
+ * Where a chosen result is opened, and the two limits on that.
+ *
+ * A bookmark's URL is user data that ends up in `location`, so only http(s)
+ * is followed: a `javascript:` bookmark would otherwise run in the extension
+ * page's own origin. A *background* tab is only expressible through the
+ * extension tabs API, so a plain web client (the daemon web app) gets a
+ * foreground tab rather than nothing at all.
+ */
+
+export function navigableUrl(url: string | undefined): string | null {
+  if (!url) return null
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+      ? parsed.href
+      : null
+  } catch {
+    return null
+  }
+}
+
+export function openResultUrl(
+  url: string,
+  options: { background: boolean }
+): void {
+  if (!options.background) {
+    window.location.assign(url)
+    return
+  }
+
+  const tabs = typeof chrome === "undefined" ? undefined : chrome.tabs
+  if (tabs?.create) {
+    void tabs.create({ url, active: false })
+    return
+  }
+
+  window.open(url, "_blank", "noopener,noreferrer")
+}

--- a/src/features/search-palette/search-palette-dialog.tsx
+++ b/src/features/search-palette/search-palette-dialog.tsx
@@ -1,0 +1,262 @@
+import * as React from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Bookmark02Icon,
+  Folder01Icon,
+  FolderTreeIcon,
+  Search01Icon,
+} from "@hugeicons/core-free-icons"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { cn } from "@/lib/utils"
+import { searchBookmarks, type BookmarkSearchHit } from "@/lib/bookmark-search"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+import { useUIStore } from "@/stores/ui-store"
+import { navigableUrl, openResultUrl } from "./open-result"
+
+/**
+ * Enough rows to make refining the query unnecessary at the collection sizes
+ * this product is built for, and few enough that the list stays scannable
+ * rather than becoming a second thing to search.
+ */
+const RESULT_LIMIT = 25
+
+const LIST_ID = "search-palette-results"
+
+function optionId(index: number): string {
+  return `search-palette-option-${index}`
+}
+
+function describeLocation(hit: BookmarkSearchHit): string {
+  // The path first: the search covers the whole Active Source, so where a hit
+  // lives is the thing the dashboard cannot already tell the user.
+  return [hit.folderPath.join(" > "), hit.url].filter(Boolean).join(" · ")
+}
+
+export function SearchPaletteDialog() {
+  const palette = useUIStore((s) => s.searchPalette)
+  const closeSearchPalette = useUIStore((s) => s.closeSearchPalette)
+  const revealInBookmarkOrganizer = useUIStore(
+    (s) => s.revealInBookmarkOrganizer
+  )
+  // The whole Active Source, not the dashboard's root subtree — and never
+  // more than one source, since the store only ever holds the active one.
+  const tree = useBookmarkStore((s) => s.tree)
+
+  const [query, setQuery] = React.useState("")
+  const [highlighted, setHighlighted] = React.useState(0)
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const activeRowRef = React.useRef<HTMLDivElement>(null)
+
+  // A fresh request object per open, so the character that opened the palette
+  // seeds it every time — including opening it again on the same character.
+  React.useEffect(() => {
+    if (!palette) return
+    setQuery(palette.seedQuery)
+    setHighlighted(0)
+  }, [palette])
+
+  const results = React.useMemo(
+    () => searchBookmarks(tree, query, { limit: RESULT_LIMIT }),
+    [tree, query]
+  )
+
+  // Clamped rather than stored back: results change on every keystroke, and a
+  // highlight that outlives its row would open something the user can't see.
+  const activeIndex =
+    results.length === 0 ? -1 : Math.min(highlighted, results.length - 1)
+  const activeHit = activeIndex === -1 ? undefined : results[activeIndex]
+
+  React.useEffect(() => {
+    activeRowRef.current?.scrollIntoView?.({ block: "nearest" })
+  }, [activeIndex, results])
+
+  function openHit(hit: BookmarkSearchHit, background: boolean) {
+    const url = navigableUrl(hit.url)
+    // Folders have nowhere to navigate to, and neither does a bookmark whose
+    // URL this page may not follow — revealing it is the honest answer to
+    // "open" for both, rather than doing nothing.
+    if (!url) {
+      revealInBookmarkOrganizer(hit.id)
+      return
+    }
+
+    // A background tab means the user is still here: leaving the palette open
+    // is what lets them open several in a row.
+    if (!background) closeSearchPalette()
+    openResultUrl(url, { background })
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (results.length === 0 || activeIndex === -1) return
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      setHighlighted((activeIndex + 1) % results.length)
+      return
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault()
+      setHighlighted((activeIndex - 1 + results.length) % results.length)
+      return
+    }
+    if (event.key === "Enter") {
+      event.preventDefault()
+      openHit(results[activeIndex], event.metaKey || event.ctrlKey)
+    }
+  }
+
+  const trimmedQuery = query.trim()
+
+  return (
+    <Dialog
+      open={palette !== null}
+      onOpenChange={(open) => {
+        if (!open) closeSearchPalette()
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        // Focus belongs in the search box, not on the popup: the palette is
+        // opened by typing, and the next character has to land in the query.
+        initialFocus={inputRef}
+        className="top-[12vh] translate-y-0 gap-0 rounded-3xl p-0 sm:max-w-xl"
+      >
+        <DialogTitle className="sr-only">Search bookmarks</DialogTitle>
+        <DialogDescription className="sr-only">
+          Searches the whole active source. Use the up and down arrows to move
+          between results, Enter to open one in this tab, Command or Control
+          with Enter to open it in a background tab, and Escape to close.
+        </DialogDescription>
+
+        <div className="flex items-center gap-2.5 border-b border-border/70 px-4 py-3">
+          <HugeiconsIcon
+            icon={Search01Icon}
+            size={16}
+            className="shrink-0 text-muted-foreground"
+          />
+          <Input
+            ref={inputRef}
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value)
+              setHighlighted(0)
+            }}
+            onKeyDown={handleKeyDown}
+            role="combobox"
+            aria-label="Search bookmarks"
+            aria-autocomplete="list"
+            aria-expanded={results.length > 0}
+            aria-controls={LIST_ID}
+            aria-activedescendant={
+              activeIndex === -1 ? undefined : optionId(activeIndex)
+            }
+            placeholder="Search this source…"
+            className="h-7 rounded-none border-0 bg-transparent px-0 focus-visible:border-0 focus-visible:ring-0"
+          />
+        </div>
+
+        {/* Announced instead of counted on screen: a sighted user can see how
+            many rows there are, and a live count would read out on every
+            keystroke otherwise. */}
+        <div role="status" aria-live="polite" className="sr-only">
+          {trimmedQuery === ""
+            ? ""
+            : `${results.length} ${results.length === 1 ? "result" : "results"}`}
+        </div>
+
+        {results.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+            {trimmedQuery === ""
+              ? "Type to search this source."
+              : tree.length === 0
+                ? // The dashboard says why; repeating its error here would put
+                  // two explanations of one problem on screen at once.
+                  "No bookmarks are loaded."
+                : "Nothing in this source matches."}
+          </p>
+        ) : (
+          <ScrollArea className="max-h-[min(24rem,50vh)]">
+            <div
+              id={LIST_ID}
+              role="listbox"
+              aria-label="Search results"
+              className="flex flex-col gap-0.5 p-1.5"
+            >
+              {results.map((hit, index) => (
+                <div
+                  key={hit.id}
+                  id={optionId(index)}
+                  role="option"
+                  aria-selected={index === activeIndex}
+                  ref={index === activeIndex ? activeRowRef : undefined}
+                  onMouseMove={() => setHighlighted(index)}
+                  onClick={(event) =>
+                    openHit(hit, event.metaKey || event.ctrlKey)
+                  }
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2.5 rounded-2xl px-2.5 py-2",
+                    index === activeIndex && "bg-muted"
+                  )}
+                >
+                  <HugeiconsIcon
+                    icon={hit.kind === "folder" ? Folder01Icon : Bookmark02Icon}
+                    size={16}
+                    className={cn(
+                      "shrink-0",
+                      hit.kind === "folder"
+                        ? "text-primary"
+                        : "text-muted-foreground"
+                    )}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm">
+                      {hit.title ||
+                        (hit.kind === "folder"
+                          ? "Untitled Folder"
+                          : "Untitled Bookmark")}
+                    </span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {describeLocation(hit)}
+                    </span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+        )}
+
+        <div className="flex items-center justify-between gap-3 border-t border-border/70 px-3 py-2">
+          <p className="hidden text-xs text-muted-foreground sm:block">
+            ↑↓ move · ↵ open · ⌘/Ctrl ↵ background tab · Esc close
+          </p>
+          <Button
+            variant="outline"
+            size="xs"
+            disabled={activeHit === undefined}
+            // Named after the highlighted row so that what it will reveal is
+            // legible before it is pressed — the highlight follows the mouse.
+            aria-label={
+              activeHit
+                ? `Reveal ${activeHit.title} in Bookmark Organizer`
+                : "Reveal in Bookmark Organizer"
+            }
+            onClick={() => {
+              if (activeHit) revealInBookmarkOrganizer(activeHit.id)
+            }}
+          >
+            <HugeiconsIcon icon={FolderTreeIcon} size={14} />
+            Reveal in organizer
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/search-palette/use-search-type-ahead.ts
+++ b/src/features/search-palette/use-search-type-ahead.ts
@@ -1,0 +1,62 @@
+import * as React from "react"
+import { useUIStore } from "@/stores/ui-store"
+
+/**
+ * Type-ahead is the palette's only way in from the keyboard: there is no
+ * shortcut to remember, and no manifest key to keep in step across three
+ * browsers. Whatever the page's focus is on, the first character typed goes
+ * into the search box.
+ */
+
+function ownsTypedCharacter(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false
+
+  if (target.closest("input, textarea, select")) return true
+  if (target instanceof HTMLElement && target.isContentEditable) return true
+  if (target.closest("[contenteditable]:not([contenteditable='false'])"))
+    return true
+
+  // A character typed inside another dialog belongs to that dialog — and to
+  // the palette itself, whose input is already focused when it is open.
+  return target.closest("[role='dialog'], [role='alertdialog']") !== null
+}
+
+/**
+ * The character a keydown should open the palette with, or `null` when the
+ * keystroke is not the user starting to type.
+ *
+ * `key.length === 1` is what separates "a" from "Enter" and "ArrowDown"
+ * without listing every named key. Shift is the one modifier a typed
+ * character legitimately carries; anything else is a shortcut the browser,
+ * the page or an assistive technology owns. Space is excluded on its own: it
+ * scrolls, and it would seed a query that trims away to nothing.
+ */
+export function typeAheadCharacter(event: KeyboardEvent): string | null {
+  if (event.defaultPrevented) return null
+  if (event.ctrlKey || event.metaKey || event.altKey) return null
+  if (event.isComposing) return null
+  if (event.key.length !== 1 || event.key === " ") return null
+  if (ownsTypedCharacter(event.target)) return null
+
+  return event.key
+}
+
+/** Installs the type-ahead listener for as long as the dashboard is mounted. */
+export function useSearchTypeAhead(): void {
+  const openSearchPalette = useUIStore((s) => s.openSearchPalette)
+
+  React.useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      const character = typeAheadCharacter(event)
+      if (character === null) return
+
+      // The keystroke seeds the palette instead of reaching the page —
+      // Firefox's quick-find would otherwise start on the same character.
+      event.preventDefault()
+      openSearchPalette(character)
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [openSearchPalette])
+}

--- a/src/lib/bookmark-search.test.ts
+++ b/src/lib/bookmark-search.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest"
+import type { BookmarkNode } from "@/browser"
+import { searchBookmarks } from "./bookmark-search"
+
+const TREE: BookmarkNode[] = [
+  {
+    id: "0",
+    title: "",
+    children: [
+      {
+        id: "bar",
+        title: "Bookmarks Bar",
+        children: [
+          {
+            id: "dev",
+            title: "Dev",
+            children: [
+              {
+                id: "github",
+                title: "GitHub",
+                url: "https://github.com",
+              },
+              {
+                id: "legit",
+                title: "Legit Blog",
+                url: "https://blog.example.com/legit",
+              },
+            ],
+          },
+          {
+            id: "reading",
+            title: "Reading",
+            children: [
+              {
+                id: "docs",
+                title: "MDN",
+                url: "https://developer.mozilla.org/docs",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+
+function ids(query: string): string[] {
+  return searchBookmarks(TREE, query).map((hit) => hit.id)
+}
+
+describe("searchBookmarks", () => {
+  it("finds nothing for an empty or whitespace-only query", () => {
+    expect(searchBookmarks(TREE, "")).toEqual([])
+    expect(searchBookmarks(TREE, "   ")).toEqual([])
+  })
+
+  it("matches bookmark titles regardless of case", () => {
+    expect(ids("github")).toContain("github")
+    expect(ids("GITHUB")).toContain("github")
+    expect(ids("GiThUb")).toContain("github")
+  })
+
+  it("matches folder titles too, so a folder can be found and revealed", () => {
+    const hits = searchBookmarks(TREE, "reading")
+    expect(hits).toHaveLength(1)
+    expect(hits[0]).toMatchObject({ id: "reading", kind: "folder" })
+    expect(hits[0].url).toBeUndefined()
+  })
+
+  it("matches a URL nothing in the title matches", () => {
+    const hits = searchBookmarks(TREE, "mozilla")
+    expect(hits.map((hit) => hit.id)).toEqual(["docs"])
+    expect(hits[0].kind).toBe("bookmark")
+  })
+
+  it("ranks a title prefix above a title substring", () => {
+    // "GitHub" starts with the query; "Legit Blog" merely contains it.
+    expect(ids("git")).toEqual(["github", "legit"])
+  })
+
+  it("ranks a URL prefix above a title substring", () => {
+    const hits = searchBookmarks(
+      [
+        { id: "substring", title: "My Example Notes" },
+        { id: "prefix", title: "Notes", url: "https://example.com/notes" },
+      ],
+      "example"
+    )
+    expect(hits.map((hit) => hit.id)).toEqual(["prefix", "substring"])
+  })
+
+  it("treats the host as the start of a URL, not the scheme", () => {
+    const [hit] = searchBookmarks(TREE, "developer.mozilla")
+    // A substring match would still find it; only a prefix match outranks
+    // unrelated title hits, which is the point of ignoring "https://".
+    expect(hit.score).toBeGreaterThan(searchBookmarks(TREE, "mozilla")[0].score)
+  })
+
+  it("ignores a leading www. the way a user typing a host does", () => {
+    const hits = searchBookmarks(
+      [{ id: "site", title: "Untitled", url: "https://www.example.com" }],
+      "example.com"
+    )
+    expect(hits).toHaveLength(1)
+    expect(hits[0].score).toBe(
+      searchBookmarks(
+        [{ id: "site", title: "Untitled", url: "https://example.com" }],
+        "example.com"
+      )[0].score
+    )
+  })
+
+  it("keeps tree order between equally scored hits", () => {
+    // Both are title prefix matches: the one written first stays first.
+    const hits = searchBookmarks(
+      [
+        { id: "first", title: "Alpha One", url: "https://one.example.com" },
+        { id: "second", title: "Alpha Two", url: "https://two.example.com" },
+      ],
+      "alpha"
+    )
+    expect(hits.map((hit) => hit.id)).toEqual(["first", "second"])
+  })
+
+  it("reports the folder path, since a hit can sit outside the shown root", () => {
+    const [hit] = searchBookmarks(TREE, "github")
+    expect(hit.folderPath).toEqual(["Bookmarks Bar", "Dev"])
+  })
+
+  it("leaves an untitled synthetic root out of the folder path", () => {
+    const [hit] = searchBookmarks(TREE, "reading")
+    expect(hit.folderPath).toEqual(["Bookmarks Bar"])
+  })
+
+  it("searches the whole forest it is handed, at any depth", () => {
+    expect(ids("legit")).toEqual(["legit"])
+  })
+
+  it("keeps only the best hits when a limit is given", () => {
+    expect(searchBookmarks(TREE, "git", { limit: 1 }).map((h) => h.id)).toEqual(
+      ["github"]
+    )
+  })
+
+  it("finds nothing in an empty tree", () => {
+    expect(searchBookmarks([], "anything")).toEqual([])
+  })
+})

--- a/src/lib/bookmark-search.ts
+++ b/src/lib/bookmark-search.ts
@@ -1,0 +1,129 @@
+import type { BookmarkNode } from "@/browser"
+
+/**
+ * Matching a typed query against one source's bookmarks.
+ *
+ * Deliberately free of React, DOM and adapter concerns: the in-page palette
+ * runs this over the store's tree, and the omnibox runs the same function in
+ * a service worker over whatever tree the Active Source hands it. The caller
+ * passes the one tree it means — nothing here reaches for a source, so
+ * sources can never be merged by searching.
+ */
+
+export type BookmarkSearchKind = "bookmark" | "folder"
+
+export interface BookmarkSearchHit {
+  id: string
+  title: string
+  /** Absent for folders. */
+  url?: string
+  kind: BookmarkSearchKind
+  /**
+   * Titles of the folders containing the hit, outermost first. The scope is a
+   * whole source rather than whatever subtree a client happens to be showing,
+   * so a hit has to be able to say where it lives.
+   */
+  folderPath: string[]
+  /** Higher is a better match. Exposed so a caller can re-rank or explain. */
+  score: number
+}
+
+export interface BookmarkSearchOptions {
+  /** Keep only the best `limit` hits. Unset returns every match. */
+  limit?: number
+}
+
+/**
+ * The four ways a node can match, ranked. Every prefix match outranks every
+ * substring match: a query is nearly always the start of the thing being
+ * looked for, so "git" wanting GitHub above "Legit blog" matters more than
+ * whether the match landed on a title or on a URL.
+ */
+const TITLE_PREFIX = 4
+const URL_PREFIX = 3
+const TITLE_SUBSTRING = 2
+const URL_SUBSTRING = 1
+
+/**
+ * The parts of a URL a user could plausibly be typing the start of. Nobody
+ * searches for "https://", so without this every URL prefix match would
+ * degrade into a substring match and rank below unrelated title hits.
+ */
+function urlPrefixes(url: string): string[] {
+  const withoutScheme = url.replace(/^[a-z][a-z0-9+.-]*:\/\//, "")
+  return [url, withoutScheme, withoutScheme.replace(/^www\./, "")]
+}
+
+function scoreNode(node: BookmarkNode, needle: string): number {
+  const title = node.title.toLowerCase()
+  if (title.startsWith(needle)) return TITLE_PREFIX
+
+  const url = node.url?.toLowerCase()
+  if (url && urlPrefixes(url).some((candidate) => candidate.startsWith(needle)))
+    return URL_PREFIX
+  if (title.includes(needle)) return TITLE_SUBSTRING
+  if (url?.includes(needle)) return URL_SUBSTRING
+
+  return 0
+}
+
+function collect(
+  nodes: readonly BookmarkNode[],
+  folderPath: string[],
+  needle: string,
+  hits: BookmarkSearchHit[]
+): void {
+  for (const node of nodes) {
+    const kind: BookmarkSearchKind = node.url == null ? "folder" : "bookmark"
+    const score = scoreNode(node, needle)
+
+    if (score > 0) {
+      hits.push({
+        id: node.id,
+        title: node.title,
+        url: node.url,
+        kind,
+        folderPath,
+        score,
+      })
+    }
+
+    if (node.children) {
+      // A browser's tree is rooted in a synthetic folder with no title, and
+      // naming it in a path would print a separator with nothing before it.
+      collect(
+        node.children,
+        node.title ? [...folderPath, node.title] : folderPath,
+        needle,
+        hits
+      )
+    }
+  }
+}
+
+/**
+ * Every bookmark and folder in `roots` whose title or URL matches `query`,
+ * best first.
+ *
+ * The query is one needle, not a set of terms: at the collection sizes this
+ * product is built for the extra recall buys nothing, and a single needle is
+ * a rule a user can predict from one result list.
+ */
+export function searchBookmarks(
+  roots: readonly BookmarkNode[],
+  query: string,
+  options: BookmarkSearchOptions = {}
+): BookmarkSearchHit[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === "") return []
+
+  const hits: BookmarkSearchHit[] = []
+  collect(roots, [], needle, hits)
+
+  // Sorting is stable in every engine these builds target, so equally scored
+  // hits keep tree order: refining a query never reshuffles the rows the user
+  // is already reading past.
+  hits.sort((a, b) => b.score - a.score)
+
+  return options.limit === undefined ? hits : hits.slice(0, options.limit)
+}

--- a/src/lib/bookmark-utils.ts
+++ b/src/lib/bookmark-utils.ts
@@ -28,6 +28,23 @@ export function findNodeById(
   return null
 }
 
+/**
+ * The chain of nodes from a root down to `id`, the node itself last, or
+ * `null` when no tree holds it. Revealing an item needs the folders above it,
+ * not just the item: each one has to be expanded before the next exists.
+ */
+export function findNodePath(
+  nodes: BookmarkNode[],
+  id: string
+): BookmarkNode[] | null {
+  for (const node of nodes) {
+    if (node.id === id) return [node]
+    const found = node.children ? findNodePath(node.children, id) : null
+    if (found) return [node, ...found]
+  }
+  return null
+}
+
 export function getDisplayRoot(
   rootFolder: BookmarkNode | null,
   tree: BookmarkNode[]

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -13,6 +13,15 @@ interface CreateItemRequest {
   parentId: string
 }
 
+interface SearchPaletteRequest {
+  /**
+   * What the palette starts with — the character that opened it by
+   * type-ahead, or nothing when it was opened from the toolbar. A fresh
+   * object per open is what re-seeds the input on every visit.
+   */
+  seedQuery: string
+}
+
 interface UIState {
   settingsOpen: boolean
   bookmarkOrganizerOpen: boolean
@@ -20,12 +29,30 @@ interface UIState {
   editingBookmark: BookmarkNode | null
   deletingItem: DeletingItem | null
   creatingItem: CreateItemRequest | null
+  searchPalette: SearchPaletteRequest | null
+  /**
+   * The item the organizer should expand to and focus, for as long as this
+   * visit lasts. It outlives the focus itself: the organizer widens its root
+   * and unhides bookmarks to reach the item, and undoing that the moment
+   * focus lands would hide the row the user was sent to look at.
+   */
+  organizerRevealId: string | null
 
   // Actions
   openSettings(): void
   closeSettings(): void
   openBookmarkOrganizer(): void
   closeBookmarkOrganizer(): void
+  /** Opens the organizer pointed at one item, wherever in the source it sits. */
+  revealInBookmarkOrganizer(id: string): void
+  /**
+   * Ends the reveal without closing the organizer — what the organizer's own
+   * root and visibility controls do, so that touching one of them hands the
+   * view back to the user instead of fighting the reveal that widened it.
+   */
+  clearOrganizerReveal(): void
+  openSearchPalette(seedQuery?: string): void
+  closeSearchPalette(): void
   openOnboarding(): void
   closeOnboarding(): void
   openEditor(bookmark: BookmarkNode): void
@@ -43,11 +70,26 @@ export const useUIStore = create<UIState>((set) => ({
   editingBookmark: null,
   deletingItem: null,
   creatingItem: null,
+  searchPalette: null,
+  organizerRevealId: null,
 
   openSettings: () => set({ settingsOpen: true }),
   closeSettings: () => set({ settingsOpen: false }),
-  openBookmarkOrganizer: () => set({ bookmarkOrganizerOpen: true }),
-  closeBookmarkOrganizer: () => set({ bookmarkOrganizerOpen: false }),
+  openBookmarkOrganizer: () =>
+    set({ bookmarkOrganizerOpen: true, organizerRevealId: null }),
+  closeBookmarkOrganizer: () =>
+    set({ bookmarkOrganizerOpen: false, organizerRevealId: null }),
+  revealInBookmarkOrganizer: (id) =>
+    set({
+      bookmarkOrganizerOpen: true,
+      organizerRevealId: id,
+      // The palette is the only way to reach this, and leaving it stacked
+      // over the organizer would hide the item it just went to find.
+      searchPalette: null,
+    }),
+  clearOrganizerReveal: () => set({ organizerRevealId: null }),
+  openSearchPalette: (seedQuery = "") => set({ searchPalette: { seedQuery } }),
+  closeSearchPalette: () => set({ searchPalette: null }),
   openOnboarding: () => set({ onboardingOpen: true }),
   closeOnboarding: () => set({ onboardingOpen: false }),
   openEditor: (bookmark) => set({ editingBookmark: bookmark }),

--- a/tests/ui/default-scenario.spec.ts
+++ b/tests/ui/default-scenario.spec.ts
@@ -94,7 +94,10 @@ test("mobile source and action controls stay contained without overlapping", asy
   await expect(tabs).toBeVisible()
   await expect(toolbar).toBeVisible()
   await expect(workbench).toBeVisible()
-  await expect(toolbar.getByRole("button")).toHaveCount(2)
+  await expect(toolbar.getByRole("button")).toHaveCount(3)
+  await expect(
+    toolbar.getByRole("button", { name: "Search bookmarks" })
+  ).toBeVisible()
   await expect(
     toolbar.getByRole("button", { name: "Bookmark tree" })
   ).toBeVisible()


### PR DESCRIPTION
Closes #45.

## Summary

- A pure matcher, `searchBookmarks(roots, query, { limit })` in `src/lib/bookmark-search.ts`, over one source's tree.
- A search palette under `src/features/search-palette/`, lazy-loaded alongside the other dialogs.
- Type-ahead: with the page focused, the first character typed opens the palette seeded with it.
- A Search action in the floating toolbar, so the palette is reachable by pointer and touch.
- "Reveal in Bookmark Organizer" for a result, including results outside the dashboard's pinned root.

## Decisions this implements

Recorded on #45 and deliberately narrow:

- **Scope is the whole Active Source**, never across sources. A hit can therefore sit outside the dashboard's root, so results carry their folder path.
- **No keyboard shortcut.** No `/`, no `Cmd/Ctrl+K`, no `chrome.commands` entry. Type-ahead is the only keyboard entry point — nothing to remember, and no manifest key to keep in step across three browsers.
- Search from a *freshly opened* tab is out of scope here and belongs to the omnibox: Chrome gives a new tab's keyboard focus to the address bar. That is #55.

## Type-ahead gate

A `document` keydown opens the palette only when all hold: not `defaultPrevented`; no `ctrl`/`meta`/`alt` (Shift allowed); not `isComposing`; `key.length === 1` and not a space; and the target does not own the character — not inside `input`/`textarea`/`select`, not contenteditable, and not inside another `[role=dialog]`. The event is then `preventDefault`ed so Firefox's quick-find does not start on the same character.

`isComposing` matters: without it the palette would interrupt IME composition for anyone typing a non-Latin script.

The organizer sheet renders through Base UI's dialog primitive, so its own keyboard navigation (#51) is untouched by this listener.

## Reveal

The organizer only renders its pinned root's subtree, so a hit outside it was unreachable. Reveal widens the organizer to the whole source **for that visit**, says so in the root-select description, and never writes `rootFolderId` — touching the root select or the Folders Only switch ends it. "Folders Only" is likewise relaxed when the revealed item is a bookmark.

Making that possible needed one semantic change in shared code: `rootFolderId === null` from the caller now beats the store's resolved `rootFolder`. This is equivalent for every pre-existing path — `BookmarkOrganizerSheet` is the only caller and previously always passed the store's own `rootFolderId`, and in the store `rootFolderId === null` always implies `rootFolder === null`.

The reveal effect expands one ancestor level per render, letting the loader's own re-render bring it back for the next level rather than re-implementing loading. It gives up quietly if the row never renders, and cannot loop.

## Known follow-ups

- `navigableUrl` in `open-result.ts` duplicates an identical helper in `src/extension/omnibox.ts`. That file was off-limits here; #55 should unify them next to the matcher.
- Opening in a background tab needs `chrome.tabs`; the daemon web app falls back to a foreground `window.open`. This is an API-presence check rather than a browser-name branch, but it is not expressed as a `PlatformCapabilities` field.
- Reveal acts on the highlighted row via a footer button, not per row: a button inside `role="option"` would break the listbox contract and DOM focus must stay in the input.
- Folders and non-`http(s)` URLs reveal rather than open. A `javascript:` bookmark must never be navigated to from an extension page.

## Verification

- `bun run check` — pass (77 test files, 695 tests; 654 before).
- `bun run test:ui` — 20 passed.
- 41 new tests: the matcher (ranking, case, URL prefixes with scheme and `www.` stripped, empty query), the type-ahead gate (12 cases, including Ctrl/Cmd, other dialogs, and cleanup on unmount), the palette, and reveal.

The second commit fixes a guard the feature broke: `tests/ui/default-scenario.spec.ts` pinned the toolbar at **two** buttons. Its geometric assertions — contained within a 320px viewport, 48px touch targets, Dev Workbench button clear of the toolbar — are unchanged and still pass with three, so only the count was stale.
