### PR TITLE
feat: search every source from the omnibox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Address-bar search covers whichever source is active**, not only a
+  connected daemon vault. Typing `bb` then Tab searches the Active Source's
+  bookmarks, and the suggestion line names the source being searched. The
+  retiring Standalone Source is the exception — its profiles search from the
+  dashboard palette instead
 - **The omnibox keyword is now `bb`.** Address-bar search previously required
   typing `bookmarks-but-better` before Tab, which was long enough that the one
   search path reachable from a fresh tab went unused. Existing users need to

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 - **Import and export** — Standard HTML bookmark files
 - **Smart favicons** — Sharp, high-quality site icons with a clean letter fallback when a site has none
 - **Quick capture** — Save the active tab from the extension popup
-- **Address-bar search** — Search a connected daemon vault with the `bb` omnibox keyword
+- **Address-bar search** — Search the active source with the `bb` omnibox keyword
 - **Three bookmark sources** — Browser bookmarks, a browser-local standalone collection, or an optional Markdown vault daemon
 - **Private by design** — No account, analytics, tracking, ads, or bookmark-content collection
 

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -2,8 +2,8 @@ import { platformCapabilities } from "@/sources/platform"
 import { createBrowserOmniboxFacade, registerOmniboxListeners } from "./omnibox"
 
 // MV3 workers can be stopped between any two events. Listener registration is
-// therefore synchronous, while every event reconstructs its daemon client
-// state from persistence and owns only the request it is currently handling.
+// therefore synchronous, while every event re-reads the Active Source from
+// persistence and owns only the request it is currently handling.
 //
 // The omnibox is a capability, not a given: Safari's WebExtensions
 // implementation has none, so its background worker simply registers nothing

--- a/src/extension/omnibox.test.ts
+++ b/src/extension/omnibox.test.ts
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { installFakeIndexedDB } from "@/browser/__tests__/fake-indexeddb"
 import { saveSourceConfig } from "@/sources/persistence"
 import { daemonSourceId } from "@/sources/config"
-import type { DaemonSearchResponse } from "@/browser/daemon/client"
 import type { BookmarkNode } from "@/browser/types"
 import {
   decodeOpaqueSuggestion,
@@ -14,6 +13,8 @@ import {
   registerOmniboxListeners,
   type OmniboxDisposition,
   type OmniboxFacade,
+  type OmniboxResult,
+  type OmniboxSearchScope,
   type OmniboxSuggestion,
 } from "./omnibox"
 
@@ -36,7 +37,21 @@ function flush() {
   return new Promise((resolve) => setTimeout(resolve, 0))
 }
 
-function fakeFacade() {
+/**
+ * A scope standing in for whichever source is active: the listener logic is
+ * the same code for a Daemon Source and a Browser Source, so the tests below
+ * exercise it once through this and pin the per-source wiring separately
+ * against the real facade.
+ */
+function fakeScope(label = "Browser bookmarks") {
+  return {
+    label,
+    search: vi.fn<OmniboxSearchScope["search"]>().mockResolvedValue([]),
+    lookupUrl: vi.fn<OmniboxSearchScope["lookupUrl"]>(),
+  }
+}
+
+function fakeFacade(scope: OmniboxSearchScope | null = fakeScope()) {
   let changed:
     | ((text: string, suggest: (items: OmniboxSuggestion[]) => void) => void)
     | undefined
@@ -51,13 +66,7 @@ function fakeFacade() {
       entered = listener
     }),
     setDefaultSuggestion: vi.fn(),
-    getDaemonSelection: vi.fn().mockResolvedValue({
-      config: { origin: "http://127.0.0.1:52222" },
-      vaultId: "main",
-    }),
-    hasHostPermission: vi.fn().mockResolvedValue(true),
-    search: vi.fn().mockResolvedValue({ results: [] }),
-    fetchNode: vi.fn(),
+    resolveActiveScope: vi.fn().mockResolvedValue(scope),
     navigate: vi.fn(),
   }
   return {
@@ -77,26 +86,46 @@ describe("omnibox listener registration", () => {
     expect(fake.facade.setDefaultSuggestion).toHaveBeenCalledOnce()
   })
 
-  it("does nothing unless an active daemon source and permission are both present", async () => {
-    const fake = fakeFacade()
-    vi.mocked(fake.facade.getDaemonSelection).mockResolvedValue(null)
+  it("does nothing unless a searchable active source is present", async () => {
+    const fake = fakeFacade(null)
     registerOmniboxListeners(fake.facade)
     const suggest = vi.fn()
 
     fake.changed()("rust", suggest)
     await flush()
 
-    expect(fake.facade.search).not.toHaveBeenCalled()
     expect(suggest).toHaveBeenCalledWith([])
   })
 
+  it("names the source being searched once one resolves", async () => {
+    const scope = fakeScope("Kitchen & <sink>")
+    const fake = fakeFacade(scope)
+    registerOmniboxListeners(fake.facade)
+
+    expect(fake.facade.setDefaultSuggestion).toHaveBeenLastCalledWith(
+      "Search your bookmarks"
+    )
+
+    fake.changed()("rust", vi.fn())
+    await flush()
+    fake.changed()("rustup", vi.fn())
+    await flush()
+
+    // Escaped like any other description, and set once rather than per
+    // keystroke: the source only changes when the user switches it.
+    expect(fake.facade.setDefaultSuggestion).toHaveBeenLastCalledWith(
+      "Search Kitchen &amp; &lt;sink&gt;"
+    )
+    expect(fake.facade.setDefaultSuggestion).toHaveBeenCalledTimes(2)
+  })
+
   it("ignores stale asynchronous results and escapes description text", async () => {
-    const fake = fakeFacade()
-    const first = deferred<DaemonSearchResponse>()
-    const second = deferred<DaemonSearchResponse>()
-    vi.mocked(fake.facade.search)
-      .mockReturnValueOnce(first.promise)
-      .mockReturnValueOnce(second.promise)
+    const scope = fakeScope()
+    const fake = fakeFacade(scope)
+    const first = deferred<OmniboxResult[]>()
+    const second = deferred<OmniboxResult[]>()
+    scope.search.mockReturnValueOnce(first.promise)
+    scope.search.mockReturnValueOnce(second.promise)
     registerOmniboxListeners(fake.facade)
     const oldSuggest = vi.fn()
     const newSuggest = vi.fn()
@@ -105,19 +134,15 @@ describe("omnibox listener registration", () => {
     await flush()
     fake.changed()("new", newSuggest)
     await flush()
-    second.resolve({
-      results: [
-        {
-          id: "opaque/id",
-          title: "<script>& title",
-          url: "https://example.com/?a=<b>",
-        },
-      ],
-    })
+    second.resolve([
+      {
+        id: "opaque/id",
+        title: "<script>& title",
+        url: "https://example.com/?a=<b>",
+      },
+    ])
     await flush()
-    first.resolve({
-      results: [{ id: "old", title: "Old", url: "https://old.example" }],
-    })
+    first.resolve([{ id: "old", title: "Old", url: "https://old.example" }])
     await flush()
 
     expect(oldSuggest).not.toHaveBeenCalled()
@@ -135,54 +160,48 @@ describe("omnibox selection", () => {
   it.each(["currentTab", "newForegroundTab", "newBackgroundTab"] as const)(
     "re-fetches the opaque id before %s navigation",
     async (disposition) => {
-      const fake = fakeFacade()
-      const node: BookmarkNode = {
-        id: "bookmark-1",
-        title: "Example",
-        url: "https://example.com",
-      }
-      vi.mocked(fake.facade.fetchNode).mockResolvedValue(node)
+      const scope = fakeScope()
+      const fake = fakeFacade(scope)
+      scope.lookupUrl.mockResolvedValue("https://example.com")
       registerOmniboxListeners(fake.facade)
 
-      fake.entered()(opaqueSuggestionContent(node.id), disposition)
+      fake.entered()(opaqueSuggestionContent("bookmark-1"), disposition)
       await flush()
 
-      expect(fake.facade.fetchNode).toHaveBeenCalledWith(
-        {
-          config: { origin: "http://127.0.0.1:52222" },
-          vaultId: "main",
-        },
-        node.id
-      )
+      expect(scope.lookupUrl).toHaveBeenCalledWith("bookmark-1")
       expect(fake.facade.navigate).toHaveBeenCalledWith(
-        node.url + "/",
+        "https://example.com/",
         disposition
       )
     }
   )
 
   it("does nothing for free-form unselected input", async () => {
-    const fake = fakeFacade()
+    const scope = fakeScope()
+    const fake = fakeFacade(scope)
     registerOmniboxListeners(fake.facade)
 
     fake.entered()("just some words", "currentTab")
     await flush()
 
-    expect(fake.facade.getDaemonSelection).not.toHaveBeenCalled()
-    expect(fake.facade.fetchNode).not.toHaveBeenCalled()
+    expect(fake.facade.resolveActiveScope).not.toHaveBeenCalled()
+    expect(scope.lookupUrl).not.toHaveBeenCalled()
     expect(fake.facade.navigate).not.toHaveBeenCalled()
   })
 
   it("does not navigate when the selected node became a folder or unsafe URL", async () => {
-    const fake = fakeFacade()
-    vi.mocked(fake.facade.fetchNode).mockResolvedValue({
-      id: "bookmark-1",
-      title: "Changed",
-      url: "javascript:alert(1)",
-    })
+    const scope = fakeScope()
+    const fake = fakeFacade(scope)
+    scope.lookupUrl.mockResolvedValue("javascript:alert(1)")
     registerOmniboxListeners(fake.facade)
 
     fake.entered()(opaqueSuggestionContent("bookmark-1"), "currentTab")
+    await flush()
+
+    expect(fake.facade.navigate).not.toHaveBeenCalled()
+
+    scope.lookupUrl.mockResolvedValue(undefined)
+    fake.entered()(opaqueSuggestionContent("folder-1"), "currentTab")
     await flush()
 
     expect(fake.facade.navigate).not.toHaveBeenCalled()
@@ -203,22 +222,90 @@ describe("omnibox encoding", () => {
   })
 })
 
+const BROWSER_TREE: BookmarkNode[] = [
+  {
+    id: "0",
+    title: "",
+    children: [
+      {
+        id: "bar",
+        title: "Rust things",
+        children: [
+          {
+            id: "book",
+            title: "The Rust Book",
+            url: "https://doc.rust-lang.org",
+          },
+          { id: "crates", title: "Crates", url: "https://crates.io" },
+        ],
+      },
+    ],
+  },
+]
+
+function stubBookmarksApi() {
+  return {
+    getTree: vi.fn().mockResolvedValue(BROWSER_TREE),
+    getSubTree: vi.fn().mockResolvedValue([
+      {
+        id: "book",
+        title: "The Rust Book",
+        url: "https://doc.rust-lang.org",
+      },
+    ]),
+  }
+}
+
 describe("browser omnibox facade", () => {
+  it("searches the Browser Source's own tree when it is active", async () => {
+    const bookmarks = stubBookmarksApi()
+    // `storage` too: the Browser Source only exists where both APIs do.
+    vi.stubGlobal("chrome", { bookmarks, storage: {}, omnibox: {}, tabs: {} })
+    await saveSourceConfig({
+      version: 2,
+      connections: {},
+      sources: { browser: { enabled: true, label: "My bookmarks" } },
+      activeSourceId: "browser",
+    })
+
+    const scope = await createBrowserOmniboxFacade().resolveActiveScope()
+
+    expect(scope?.label).toBe("My bookmarks")
+    // "Rust things" is a folder and matches too; only openable rows survive.
+    await expect(scope?.search("rust", 8)).resolves.toEqual([
+      {
+        id: "book",
+        title: "The Rust Book",
+        url: "https://doc.rust-lang.org",
+      },
+    ])
+    await expect(scope?.lookupUrl("book")).resolves.toBe(
+      "https://doc.rust-lang.org"
+    )
+    expect(bookmarks.getSubTree).toHaveBeenCalledWith("book")
+  })
+
   it("reads the active daemon source from the shared Source Configuration", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ results: [] }),
+    })
+    vi.stubGlobal("fetch", fetchImpl)
     const facade = createBrowserOmniboxFacade()
     const origin = "http://localhost:52222"
 
-    // Browser active: nothing for the omnibox to search.
+    // No source at all: nothing for the omnibox to search.
     await saveSourceConfig({
       version: 2,
       connections: { [origin]: { bearerToken: "secret" } },
-      sources: { browser: { enabled: true } },
-      activeSourceId: "browser",
+      sources: {},
+      activeSourceId: null,
     })
-    await expect(facade.getDaemonSelection()).resolves.toBeNull()
+    await expect(facade.resolveActiveScope()).resolves.toBeNull()
 
-    // The daemon vault active: the selection carries the connection and the
-    // vault scope, canonicalized the same way everywhere.
+    // The daemon vault active: every request carries that connection's
+    // credentials and is scoped to that vault, never another source's.
     const id = daemonSourceId(origin, "reading")
     await saveSourceConfig({
       version: 2,
@@ -229,28 +316,45 @@ describe("browser omnibox facade", () => {
       },
       activeSourceId: id,
     })
-    await expect(facade.getDaemonSelection()).resolves.toEqual({
-      config: { origin, bearerToken: "secret" },
-      vaultId: "reading",
-    })
+
+    const scope = await facade.resolveActiveScope()
+    expect(scope?.label).toBe("reading · localhost:52222")
+    await expect(scope?.search("rust", 8)).resolves.toEqual([])
+
+    const [url, init] = fetchImpl.mock.calls[0] as [
+      string,
+      { headers: Record<string, string> },
+    ]
+    expect(url).toBe(
+      "http://localhost:52222/api/v1/vaults/reading/search?q=rust&limit=8"
+    )
+    expect(init.headers.Authorization).toBe("Bearer secret")
   })
 
-  it("reuses the daemon permission check for both allowed loopback hosts", async () => {
+  it("resolves no scope while the daemon host permission is missing", async () => {
     const contains = vi.fn(
       (
         _permissions: chrome.permissions.Permissions,
         callback: (granted: boolean) => void
-      ) => callback(true)
+      ) => callback(false)
     )
     vi.stubGlobal("chrome", {
       permissions: { contains },
       omnibox: {},
       tabs: {},
     })
+    const origin = "http://127.0.0.1:52222"
+    const id = daemonSourceId(origin, "main")
+    await saveSourceConfig({
+      version: 2,
+      connections: { [origin]: {} },
+      sources: { [id]: { enabled: true, origin, vaultId: "main" } },
+      activeSourceId: id,
+    })
 
     await expect(
-      createBrowserOmniboxFacade().hasHostPermission()
-    ).resolves.toBe(true)
+      createBrowserOmniboxFacade().resolveActiveScope()
+    ).resolves.toBeNull()
     expect(contains).toHaveBeenCalledWith(
       { origins: ["http://127.0.0.1/*", "http://localhost/*"] },
       expect.any(Function)

--- a/src/extension/omnibox.ts
+++ b/src/extension/omnibox.ts
@@ -1,12 +1,12 @@
-import type {
-  DaemonSearchResponse,
-  DaemonSearchResult,
-} from "@/browser/daemon/client"
 import { DaemonClient } from "@/browser/daemon/client"
-import type { DaemonConnectionConfig } from "@/browser/types"
 import { hasDaemonHostPermission } from "@/browser/daemon/permissions"
+import { ChromeBookmarkAdapter } from "@/browser/chrome/bookmarks"
+import type { BookmarkAdapter } from "@/browser/types"
+import { searchBookmarks } from "@/lib/bookmark-search"
+import { navigableUrl } from "@/lib/navigable-url"
 import { loadSourceConfig } from "@/sources/persistence"
-import type { BookmarkNode } from "@/browser/types"
+import { platformCapabilities } from "@/sources/platform"
+import { describeSource, type SourceDescriptor } from "@/sources/descriptors"
 
 export type OmniboxDisposition =
   | "currentTab"
@@ -18,12 +18,32 @@ export interface OmniboxSuggestion {
   description: string
 }
 
-/** What the omnibox needs to search one daemon Vault: where, and which. */
-export interface PersistedDaemonSelection {
-  config: DaemonConnectionConfig
-  /** The vault to scope every search and fetch to; `null` is the legacy
-   * single-vault spelling. */
-  vaultId: string | null
+/** One row the omnibox can show and open: never a folder, so never unopenable. */
+export interface OmniboxResult {
+  id: string
+  title: string
+  url: string
+}
+
+/**
+ * The Active Source as the omnibox needs it: what to call it, how to search
+ * it, and how to resolve a chosen row back to a URL.
+ *
+ * This is the whole reason the listener logic below names no source kind. A
+ * Daemon Source searches server-side because it has an endpoint for it; a
+ * source without one hands over its tree and is matched here. Which of those
+ * a scope is stays behind this interface, and a scope is bound to exactly one
+ * source, so nothing here can merge two.
+ */
+export interface OmniboxSearchScope {
+  /** The source's label, shown so the user knows what is being searched. */
+  label: string
+  search(query: string, limit: number): Promise<OmniboxResult[]>
+  /**
+   * The current URL of `id` in this source, re-read at selection time.
+   * `undefined` when it is gone, or turned out to be a folder.
+   */
+  lookupUrl(id: string): Promise<string | undefined>
 }
 
 export interface OmniboxFacade {
@@ -37,22 +57,21 @@ export interface OmniboxFacade {
     listener: (text: string, disposition: OmniboxDisposition) => void
   ): void
   setDefaultSuggestion(description: string): void
-  getDaemonSelection(): Promise<PersistedDaemonSelection | null>
-  hasHostPermission(): Promise<boolean>
-  search(
-    selection: PersistedDaemonSelection,
-    query: string,
-    limit: number
-  ): Promise<DaemonSearchResponse>
-  fetchNode(
-    selection: PersistedDaemonSelection,
-    id: string
-  ): Promise<BookmarkNode>
+  /**
+   * The Active Source, resolved per event: an MV3 worker is stopped between
+   * events, and the user can switch sources between two keystrokes. `null`
+   * when nothing is searchable from here — no active source, or a daemon
+   * whose host permission was never granted.
+   */
+  resolveActiveScope(): Promise<OmniboxSearchScope | null>
   navigate(url: string, disposition: OmniboxDisposition): Promise<void>
 }
 
 const SEARCH_LIMIT = 8
 const OPAQUE_PREFIX = "bookmarks-but-better:"
+
+/** Shown before any query has resolved a source to name. */
+const DEFAULT_DESCRIPTION = "Search your bookmarks"
 
 export function escapeSuggestionDescription(value: string): string {
   return value
@@ -98,29 +117,35 @@ export function decodeOpaqueSuggestion(content: string): string | null {
   }
 }
 
-function suggestion(result: DaemonSearchResult): OmniboxSuggestion {
+function suggestion(result: OmniboxResult): OmniboxSuggestion {
   return {
     content: opaqueSuggestionContent(result.id),
     description: `${escapeSuggestionDescription(result.title)} — <dim>${escapeSuggestionDescription(result.url)}</dim>`,
   }
 }
 
-function navigableUrl(value: string | undefined): string | null {
-  if (!value) return null
-  try {
-    const url = new URL(value)
-    return url.protocol === "http:" || url.protocol === "https:"
-      ? url.href
-      : null
-  } catch {
-    return null
-  }
-}
-
 export function registerOmniboxListeners(facade: OmniboxFacade): void {
   let inputRevision = 0
+  let description = DEFAULT_DESCRIPTION
 
-  facade.setDefaultSuggestion("Search bookmarks in your local daemon")
+  facade.setDefaultSuggestion(description)
+
+  /**
+   * Names the source the next Enter would search. The Active Source is
+   * profile-wide and another surface can switch it between two keystrokes, so
+   * this follows whatever the current query resolved rather than being read
+   * once at registration. The description is markup, exactly like a
+   * suggestion's, so a source label carries no less escaping.
+   */
+  function describeScope(scope: OmniboxSearchScope | null): void {
+    const next = scope
+      ? `Search ${escapeSuggestionDescription(scope.label)}`
+      : DEFAULT_DESCRIPTION
+    if (next === description) return
+    description = next
+    facade.setDefaultSuggestion(next)
+  }
+
   facade.onInputChanged((text, suggestResults) => {
     const revision = ++inputRevision
     const query = text.trim()
@@ -131,19 +156,16 @@ export function registerOmniboxListeners(facade: OmniboxFacade): void {
 
     void (async () => {
       try {
-        const selection = await facade.getDaemonSelection()
-        if (!selection) {
-          if (revision === inputRevision) suggestResults([])
-          return
-        }
-        if (!(await facade.hasHostPermission())) {
+        const scope = await facade.resolveActiveScope()
+        describeScope(scope)
+        if (!scope) {
           if (revision === inputRevision) suggestResults([])
           return
         }
 
-        const response = await facade.search(selection, query, SEARCH_LIMIT)
+        const results = await scope.search(query, SEARCH_LIMIT)
         if (revision !== inputRevision) return
-        suggestResults(response.results.slice(0, SEARCH_LIMIT).map(suggestion))
+        suggestResults(results.slice(0, SEARCH_LIMIT).map(suggestion))
       } catch {
         if (revision === inputRevision) suggestResults([])
       }
@@ -156,11 +178,9 @@ export function registerOmniboxListeners(facade: OmniboxFacade): void {
 
     void (async () => {
       try {
-        const selection = await facade.getDaemonSelection()
-        if (!selection) return
-        if (!(await facade.hasHostPermission())) return
-        const node = await facade.fetchNode(selection, id)
-        const url = navigableUrl(node.url)
+        const scope = await facade.resolveActiveScope()
+        if (!scope) return
+        const url = navigableUrl(await scope.lookupUrl(id))
         if (!url) return
         await facade.navigate(url, disposition)
       } catch {
@@ -172,41 +192,105 @@ export function registerOmniboxListeners(facade: OmniboxFacade): void {
 }
 
 /**
- * The Active Source, read from the same persisted Source Configuration the
- * dashboard and popup use — that sharing is what makes the active source
- * profile-wide rather than per-surface. Only a Daemon Source is searchable
- * from the omnibox: the Browser Source has no search API to query here.
+ * A scope over a source that hands out its whole tree.
+ *
+ * The Browser Source has no search endpoint to ask, so matching happens here,
+ * over the same `searchBookmarks` the in-page palette uses — one ranking for
+ * both surfaces, and one place to change it. The tree is re-read per query
+ * because an MV3 worker owns nothing across events, and because a bookmark
+ * created since the last keystroke should still be findable.
  */
-async function getDaemonSelection(): Promise<PersistedDaemonSelection | null> {
-  const config = await loadSourceConfig(
-    (await import("@/sources/platform")).platformCapabilities()
-  )
-  const activeId = config.activeSourceId
-  if (!activeId || !activeId.startsWith("daemon:")) return null
-
-  const entry = config.sources[activeId]
-  const origin = entry?.origin
-  if (!origin) return null
-  const connection = config.connections[origin]
-  if (!connection) return null
-
+function treeScope(
+  label: string,
+  adapter: BookmarkAdapter
+): OmniboxSearchScope {
   return {
-    config: {
-      origin,
-      ...(connection.bearerToken
-        ? { bearerToken: connection.bearerToken }
-        : {}),
+    label,
+    async search(query, limit) {
+      const tree = await adapter.getTree()
+      return (
+        searchBookmarks(tree, query)
+          // Folders match too, and Enter has nowhere to take them. Dropping
+          // them before the limit keeps a folder-heavy match from filling all
+          // eight rows with things that cannot be opened.
+          .flatMap((hit) =>
+            hit.url ? [{ id: hit.id, title: hit.title, url: hit.url }] : []
+          )
+          .slice(0, limit)
+      )
     },
-    vaultId: entry.unscoped ? null : (entry.vaultId ?? null),
+    async lookupUrl(id) {
+      const [node] = await adapter.getSubTree(id)
+      return node?.url
+    },
   }
 }
 
-function daemonClientFor(selection: PersistedDaemonSelection): DaemonClient {
-  return new DaemonClient({
-    origin: selection.config.origin,
-    bearerToken: selection.config.bearerToken,
-    vaultId: selection.vaultId,
+/**
+ * A scope over one daemon Vault, or `null` when it cannot be reached.
+ *
+ * The daemon searches its own snapshot server-side, which beats pulling a
+ * whole vault over loopback on every keystroke. The host permission is
+ * optional and granted only at Connect, so a profile that never connected —
+ * or revoked it — resolves no scope rather than firing a blocked request.
+ */
+async function daemonScope(
+  source: SourceDescriptor,
+  connection: { bearerToken?: string } | undefined
+): Promise<OmniboxSearchScope | null> {
+  if (!source.origin || !connection) return null
+  if (!(await hasDaemonHostPermission())) return null
+
+  const client = new DaemonClient({
+    origin: source.origin,
+    bearerToken: connection.bearerToken,
+    // A daemon that predates Vault ids is reached unscoped: scoping would aim
+    // every request at a route it does not serve.
+    vaultId: source.unscoped ? null : (source.vaultId ?? null),
   })
+
+  return {
+    label: source.label,
+    async search(query, limit) {
+      const response = await client.search(query, limit)
+      return response.results
+    },
+    async lookupUrl(id) {
+      return (await client.fetchNode(id)).url
+    },
+  }
+}
+
+/**
+ * The Active Source, read from the same persisted Source Configuration the
+ * dashboard and popup use — that sharing is what makes the active source
+ * profile-wide rather than per-surface, and what keeps the omnibox pointed at
+ * exactly the source the rest of the profile is showing.
+ */
+async function resolveActiveScope(): Promise<OmniboxSearchScope | null> {
+  const config = await loadSourceConfig(platformCapabilities())
+  const activeId = config.activeSourceId
+  if (!activeId) return null
+  const entry = config.sources[activeId]
+  if (!entry?.enabled) return null
+
+  const source = describeSource(activeId, entry)
+  switch (source.kind) {
+    case "browser":
+      // Firefox's adapter differs from Chrome's only in `openInManager`,
+      // which no omnibox path calls, so the Chromium one serves both here and
+      // the worker bundle carries no adapter selection at all.
+      return treeScope(source.label, new ChromeBookmarkAdapter())
+    case "standalone":
+      // The retiring Standalone Source stays out of the worker: its adapter
+      // is the one that seeds itself from `src/dev/seed-bookmarks.json`, and
+      // the IIFE background bundle inlines that dynamic import whole — a
+      // 14 kB worker becoming 41 kB, permanently, for a source that is being
+      // removed. Its profiles still search from the in-page palette.
+      return null
+    case "daemon":
+      return daemonScope(source, config.connections[source.origin ?? ""])
+  }
 }
 
 export function createBrowserOmniboxFacade(): OmniboxFacade {
@@ -220,14 +304,7 @@ export function createBrowserOmniboxFacade(): OmniboxFacade {
     setDefaultSuggestion(description) {
       chrome.omnibox.setDefaultSuggestion({ description })
     },
-    getDaemonSelection,
-    hasHostPermission: hasDaemonHostPermission,
-    search(selection, query, limit) {
-      return daemonClientFor(selection).search(query, limit)
-    },
-    fetchNode(selection, id) {
-      return daemonClientFor(selection).fetchNode(id)
-    },
+    resolveActiveScope,
     async navigate(url, disposition) {
       if (disposition === "currentTab") {
         await chrome.tabs.update({ url })

--- a/src/features/search-palette/open-result.ts
+++ b/src/features/search-palette/open-result.ts
@@ -1,24 +1,11 @@
 /**
- * Where a chosen result is opened, and the two limits on that.
+ * Where a chosen result is opened, and the one limit on that.
  *
- * A bookmark's URL is user data that ends up in `location`, so only http(s)
- * is followed: a `javascript:` bookmark would otherwise run in the extension
- * page's own origin. A *background* tab is only expressible through the
- * extension tabs API, so a plain web client (the daemon web app) gets a
- * foreground tab rather than nothing at all.
+ * A *background* tab is only expressible through the extension tabs API, so a
+ * plain web client (the daemon web app) gets a foreground tab rather than
+ * nothing at all. Which URLs may be followed at all is `navigableUrl`'s rule,
+ * shared with the omnibox.
  */
-
-export function navigableUrl(url: string | undefined): string | null {
-  if (!url) return null
-  try {
-    const parsed = new URL(url)
-    return parsed.protocol === "http:" || parsed.protocol === "https:"
-      ? parsed.href
-      : null
-  } catch {
-    return null
-  }
-}
 
 export function openResultUrl(
   url: string,

--- a/src/features/search-palette/search-palette-dialog.tsx
+++ b/src/features/search-palette/search-palette-dialog.tsx
@@ -19,7 +19,8 @@ import { cn } from "@/lib/utils"
 import { searchBookmarks, type BookmarkSearchHit } from "@/lib/bookmark-search"
 import { useBookmarkStore } from "@/stores/bookmark-store"
 import { useUIStore } from "@/stores/ui-store"
-import { navigableUrl, openResultUrl } from "./open-result"
+import { navigableUrl } from "@/lib/navigable-url"
+import { openResultUrl } from "./open-result"
 
 /**
  * Enough rows to make refining the query unnecessary at the collection sizes

--- a/src/lib/navigable-url.ts
+++ b/src/lib/navigable-url.ts
@@ -1,0 +1,21 @@
+/**
+ * Which URLs a client may follow on the user's behalf.
+ *
+ * A bookmark's URL is user data that ends up in `location` or in a
+ * `tabs.create` call, so only http(s) is followed: a `javascript:` bookmark
+ * would otherwise run in the extension page's own origin. Both surfaces that
+ * open a bookmark from a search result — the in-page palette and the omnibox
+ * listener in the service worker — share this one rule, so neither can be the
+ * one that forgets it.
+ */
+export function navigableUrl(url: string | undefined): string | null {
+  if (!url) return null
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+      ? parsed.href
+      : null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
Closes #55 (step 1, the `bb` keyword, shipped in #56).

## Summary

- `OmniboxFacade`'s four daemon-shaped methods collapse into one `resolveActiveScope()`, so the listener logic names no source kind.
- A Browser Source is searched by reading its tree in the worker and running the same `searchBookmarks` the palette uses. A Daemon Source keeps its server-side `search`.
- The default suggestion names the source being searched.
- `navigableUrl` is unified in `src/lib/navigable-url.ts` — the duplication #57 had to leave behind.

## Why

A new tab gives keyboard focus to the address bar, so the omnibox is the only search path reachable from a fresh tab. It working only for a Daemon Source meant the most common configuration had none.

## The seam

```ts
export interface OmniboxSearchScope {
  label: string
  search(query: string, limit: number): Promise<OmniboxResult[]>
  lookupUrl(id: string): Promise<string | undefined>
}
```

A scope is bound to one source at construction, so the listener cannot pass the wrong selection to a search — sources are not merely un-merged there, they are not nameable. The daemon host-permission check moves *inside* daemon-scope resolution, where "permission never granted" and "no active source" are the same fact to the listener: nothing to search. `lookupUrl` returns a raw URL rather than a node, keeping the `javascript:` guard at one enforcement point no scope implementation can bypass.

The scope is resolved per event, not once at registration: an MV3 worker owns nothing between events, and another surface can switch the Active Source between two keystrokes.

Folders are dropped from tree-backed results *before* the eight-row limit — Enter has nowhere to take a folder, and a folder-heavy match would otherwise fill every row with things that cannot be opened.

## The Standalone Source is deliberately excluded

`StandaloneBookmarkAdapter.getTree()` carries a dev seed path, `await import("@/dev/seed-bookmarks.json")`. The background is an IIFE lib build, so Rollup inlines that import rather than dropping it: including the adapter takes `background.js` from **14.15 kB to 40.93 kB**, permanently, for a source being removed in v5. Carving a seed-free reader out of that adapter would be building something special for a retiring source. Those profiles search from the dashboard palette. The reason is recorded at the `case "standalone"` branch.

## Verification

- `bun run check` — pass (77 test files, 697 tests).
- `bun run test:ui` — 20 passed.
- `dist-chrome/background.js`: 11.55 kB → **14.15 kB** (gzip 4.32 → 5.08 kB), from `bookmark-search`, `navigable-url`, `chrome/bookmarks` and `sources/descriptors`.
- `src/extension/omnibox.test.ts` keeps every existing case — suggestion escaping, the opaque-id round trip, disposition handling — against the new seam, and adds Browser-Source, vault-scoping, permission and default-suggestion cases.

## Known gaps

- **No worker-level proof.** The Browser-Source path is tested against a stubbed `chrome.bookmarks`, not a loaded extension. `bookmarks` is a manifest permission in both targets and the API is worker-available, but nothing here proves `getTree()` from a real MV3 worker. This repo has no omnibox e2e harness, so it matches the existing level of proof rather than lowering it.
- **The tree is re-read per keystroke** for a Browser Source. No cache: an MV3 worker owns nothing across events, and a cache would need `bookmarks.onChanged` invalidation. Fine at this product's sizes.
- Repeated `setDefaultSuggestion` calls were checked against the API contract, not against real Firefox.
- `website/src/components/daemon-cta.tsx:23` and `docs/DEV_WORKBENCH.md:41` now understate what search covers. Both are true-but-narrow rather than wrong; left for a copy pass.
