### PR TITLE
feat: add keyboard navigation to the bookmarks dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The dashboard is operable from the keyboard.** The bookmark grid is a
+  single tab stop: arrow keys move through it in the order you see rather than
+  the order it is built in, Home and End reach a column's ends, Enter opens the
+  focused bookmark, and Alt with an arrow moves one inside its folder — only
+  where the source can express an order
 - **Search palette** — start typing anywhere on the dashboard and a palette
   opens on the first character, matching bookmark titles and URLs and folder
   names across the whole Active Source. There is no shortcut to learn, and a

--- a/src/features/bookmark-card/bookmark-card.tsx
+++ b/src/features/bookmark-card/bookmark-card.tsx
@@ -21,6 +21,9 @@ import {
 } from "@hugeicons/core-free-icons"
 import { BookmarkItem } from "@/features/bookmark-item"
 import { useFolderDropTarget } from "@/features/dnd"
+// Past the grid's barrel on purpose: importing it would pull `BookmarkGrid`,
+// which renders this card, back into the card's own module graph.
+import { useGridItem } from "@/features/bookmark-grid/use-grid-navigation"
 import { usePreferencesStore } from "@/stores/preferences-store"
 import { useBookmarkStore } from "@/stores/bookmark-store"
 import { useUIStore } from "@/stores/ui-store"
@@ -180,6 +183,11 @@ export const BookmarkCard = React.memo(function BookmarkCard({
     disabled: !moveEnabled,
   })
 
+  // The card's stop in the grid's roving tab order. The heading carries it
+  // rather than the card: it is the one element that exists whatever the
+  // card holds, and it already names the folder.
+  const gridItem = useGridItem(folder.id)
+
   const children = folder.children ?? []
 
   // Separate direct bookmarks from subfolders
@@ -235,8 +243,9 @@ export const BookmarkCard = React.memo(function BookmarkCard({
           </button>
         )}
         <h3
+          {...gridItem}
           className={cn(
-            "min-w-0 flex-1 truncate font-medium",
+            "min-w-0 flex-1 truncate rounded-md border border-transparent font-medium outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
             nested ? "text-base sm:text-xs" : "text-base sm:text-sm"
           )}
         >

--- a/src/features/bookmark-grid/__tests__/bookmark-grid-keyboard.test.tsx
+++ b/src/features/bookmark-grid/__tests__/bookmark-grid-keyboard.test.tsx
@@ -1,0 +1,398 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, cleanup, render, screen } from "@testing-library/react"
+import type { BookmarkNode, BrowserAdapter } from "@/browser"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+import { usePreferencesStore } from "@/stores/preferences-store"
+import { useUIStore } from "@/stores/ui-store"
+import { useSearchTypeAhead } from "@/features/search-palette/use-search-type-ahead"
+import { BookmarkGrid } from "../bookmark-grid"
+
+/**
+ * The dashboard grid as one composite widget: a single tab stop, arrow keys
+ * that follow the columns the masonry actually drew, and a focus that has to
+ * outlive the wholesale tree replacement every mutation ends in.
+ *
+ * Four equal cards over two columns put the second folder in the *second*
+ * column, so "the card below alpha" is gamma and "the card to the right of
+ * alpha" is beta — the two directions a model built on the folder list rather
+ * than the layout would get the wrong way round.
+ */
+
+function folder(id: string, bookmarks: string[]): BookmarkNode {
+  return {
+    id,
+    title: id,
+    children: bookmarks.map((title) => ({
+      id: title,
+      title,
+      url: `https://${title}.example`,
+    })),
+  }
+}
+
+function treeWith(folders: BookmarkNode[]): BookmarkNode[] {
+  return [{ id: "root", title: "Root", children: folders }]
+}
+
+const FOLDERS = [
+  folder("alpha", ["a one", "a two"]),
+  folder("beta", ["b one", "b two"]),
+  folder("gamma", ["g one", "g two"]),
+  folder("delta", ["d one", "d two"]),
+]
+
+type Capabilities = BrowserAdapter["capabilities"]
+
+const EXTENSION_CAPABILITIES: Capabilities = {
+  openInManager: true,
+  move: true,
+  reorder: true,
+  setChildOrder: false,
+}
+
+const DAEMON_CAPABILITIES: Capabilities = {
+  openInManager: false,
+  move: true,
+  reorder: false,
+  setChildOrder: true,
+}
+
+function adapterWith(capabilities: Capabilities): BrowserAdapter {
+  return {
+    bookmarks: { setChildOrder: vi.fn(), openInManager: vi.fn() },
+    storage: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+    favicon: { getUrl: () => "", isAvailable: () => false },
+    capabilities,
+  } as unknown as BrowserAdapter
+}
+
+function TypeAheadGrid() {
+  useSearchTypeAhead()
+  return <BookmarkGrid />
+}
+
+function mount(
+  options: {
+    capabilities?: Capabilities
+    folders?: BookmarkNode[]
+    withTypeAhead?: boolean
+  } = {}
+) {
+  const tree = treeWith(options.folders ?? FOLDERS)
+  useBookmarkStore.setState({
+    adapter: adapterWith(options.capabilities ?? EXTENSION_CAPABILITIES),
+    tree,
+    rootFolder: tree[0],
+    isLoading: false,
+    moveBookmark: vi.fn().mockResolvedValue(true),
+    setChildOrder: vi.fn().mockResolvedValue(true),
+  })
+  usePreferencesStore.setState({
+    experimentalCardDrag: false,
+    nestedFolders: true,
+    folderOrder: [],
+    cardLayouts: {},
+    // Two columns is what makes the layout order and the folder-list order
+    // disagree; the jsdom viewport would otherwise ask for four.
+    maxColumns: 2,
+    containerMode: "fluid",
+  })
+  render(options.withTypeAhead ? <TypeAheadGrid /> : <BookmarkGrid />)
+}
+
+function bookmark(title: string): HTMLElement {
+  return screen.getByRole("link", { name: new RegExp(`^${title}`) })
+}
+
+function heading(title: string): HTMLElement {
+  return screen.getByRole("heading", { name: title })
+}
+
+function press(key: string, modifier?: "alt") {
+  const element = document.activeElement as HTMLElement
+  act(() => {
+    element.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key,
+        altKey: modifier === "alt",
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+  })
+}
+
+describe("BookmarkGrid keyboard navigation", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })
+    )
+    useUIStore.setState({ searchPalette: null })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    useUIStore.setState({ searchPalette: null })
+  })
+
+  it("offers exactly one tab stop for the whole grid", () => {
+    mount()
+
+    const tabbable = document.querySelectorAll(
+      "a[tabindex='0'], h3[tabindex='0']"
+    )
+    expect(tabbable).toHaveLength(1)
+    expect(tabbable[0]).toBe(heading("alpha"))
+  })
+
+  it("moves down within a card and on across the card boundary below it", () => {
+    mount()
+    act(() => bookmark("a one").focus())
+
+    press("ArrowDown")
+    expect(document.activeElement).toBe(bookmark("a two"))
+
+    // gamma is the card underneath alpha; beta is the next folder in the
+    // list, and it is in the other column.
+    press("ArrowDown")
+    expect(document.activeElement).toBe(heading("gamma"))
+  })
+
+  it("moves between columns on left and right", () => {
+    mount()
+    act(() => heading("alpha").focus())
+
+    press("ArrowRight")
+    expect(document.activeElement).toBe(heading("beta"))
+
+    press("ArrowLeft")
+    expect(document.activeElement).toBe(heading("alpha"))
+  })
+
+  it("takes Home and End to the ends of the column", () => {
+    mount()
+    act(() => bookmark("a two").focus())
+
+    press("End")
+    expect(document.activeElement).toBe(bookmark("g two"))
+
+    press("Home")
+    expect(document.activeElement).toBe(heading("alpha"))
+  })
+
+  it("hands the single tab stop to whatever the arrows moved to", () => {
+    mount()
+    act(() => bookmark("a one").focus())
+    press("ArrowDown")
+
+    expect(bookmark("a two")).toHaveProperty("tabIndex", 0)
+    expect(bookmark("a one")).toHaveProperty("tabIndex", -1)
+  })
+
+  it("leaves Enter to the anchor, so a bookmark opens the way a link does", () => {
+    mount()
+    act(() => bookmark("a one").focus())
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    })
+    act(() => {
+      document.activeElement!.dispatchEvent(event)
+    })
+
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it("still lets a typed character reach the search palette", () => {
+    mount({ withTypeAhead: true })
+    act(() => bookmark("a one").focus())
+
+    act(() => {
+      document.activeElement!.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "g",
+          bubbles: true,
+          cancelable: true,
+        })
+      )
+    })
+
+    expect(useUIStore.getState().searchPalette?.seedQuery).toBe("g")
+  })
+
+  it("keeps the arrows out of the palette's way", () => {
+    mount({ withTypeAhead: true })
+    act(() => bookmark("a one").focus())
+
+    press("ArrowDown")
+    press("ArrowDown", "alt")
+
+    expect(useUIStore.getState().searchPalette).toBeNull()
+  })
+})
+
+describe("BookmarkGrid focus after a mutation", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it("lands on whatever took the deleted bookmark's place", () => {
+    mount()
+    act(() => bookmark("a one").focus())
+
+    const withoutFirst = [folder("alpha", ["a two"]), ...FOLDERS.slice(1)]
+    const tree = treeWith(withoutFirst)
+    act(() => {
+      useBookmarkStore.setState({ tree, rootFolder: tree[0] })
+    })
+
+    expect(document.activeElement).toBe(bookmark("a two"))
+  })
+
+  it("holds the visual position when the whole card goes and the masonry re-deals", () => {
+    mount()
+    act(() => bookmark("g one").focus())
+
+    const withoutGamma = FOLDERS.filter((f) => f.id !== "gamma")
+    const tree = treeWith(withoutGamma)
+    act(() => {
+      useBookmarkStore.setState({ tree, rootFolder: tree[0] })
+    })
+
+    // Three cards over two columns puts delta where gamma was, so the fifth
+    // stop down the first column is delta's first bookmark — the place on
+    // screen the focus was already looking at, rather than the document.
+    expect(document.activeElement).toBe(bookmark("d one"))
+  })
+
+  it("does not reach out and take back a focus the user moved away", () => {
+    mount()
+    act(() => bookmark("a one").focus())
+
+    const outside = document.createElement("button")
+    document.body.appendChild(outside)
+    act(() => outside.focus())
+
+    const withoutFirst = [folder("alpha", ["a two"]), ...FOLDERS.slice(1)]
+    const tree = treeWith(withoutFirst)
+    act(() => {
+      useBookmarkStore.setState({ tree, rootFolder: tree[0] })
+    })
+
+    expect(document.activeElement).toBe(outside)
+    // The tab stop still moved on, so Tab reaches the grid at a sane place.
+    expect(bookmark("a two")).toHaveProperty("tabIndex", 0)
+    outside.remove()
+  })
+})
+
+describe("BookmarkGrid keyboard reordering", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it("positions through move() when the adapter can reorder", () => {
+    mount({ capabilities: EXTENSION_CAPABILITIES })
+    act(() => bookmark("a one").focus())
+
+    press("ArrowDown", "alt")
+
+    const { moveBookmark, setChildOrder } = useBookmarkStore.getState()
+    expect(moveBookmark).toHaveBeenCalledWith("a one", {
+      parentId: "alpha",
+      index: 1,
+    })
+    expect(setChildOrder).not.toHaveBeenCalled()
+  })
+
+  it("writes a whole-folder order in daemon mode", () => {
+    mount({ capabilities: DAEMON_CAPABILITIES })
+    act(() => bookmark("a one").focus())
+
+    press("ArrowDown", "alt")
+
+    const { moveBookmark, setChildOrder } = useBookmarkStore.getState()
+    expect(setChildOrder).toHaveBeenCalledWith("alpha", ["a two", "a one"])
+    expect(moveBookmark).not.toHaveBeenCalled()
+  })
+
+  it("writes nothing when the adapter can express no order at all", () => {
+    mount({
+      capabilities: {
+        openInManager: false,
+        move: true,
+        reorder: false,
+        setChildOrder: false,
+      },
+    })
+    act(() => bookmark("a one").focus())
+
+    press("ArrowDown", "alt")
+
+    const { moveBookmark, setChildOrder } = useBookmarkStore.getState()
+    expect(moveBookmark).not.toHaveBeenCalled()
+    expect(setChildOrder).not.toHaveBeenCalled()
+  })
+
+  it("writes nothing in a folder whose child order is frozen", () => {
+    const frozen = {
+      ...folder("alpha", ["a one", "a two"]),
+      orderReadOnly: true,
+    }
+    mount({
+      capabilities: DAEMON_CAPABILITIES,
+      folders: [frozen, ...FOLDERS.slice(1)],
+    })
+    act(() => bookmark("a one").focus())
+
+    press("ArrowDown", "alt")
+
+    expect(useBookmarkStore.getState().setChildOrder).not.toHaveBeenCalled()
+  })
+
+  it("leaves folder cards alone: their order is a client-local preference", () => {
+    mount({ capabilities: EXTENSION_CAPABILITIES })
+    act(() => heading("alpha").focus())
+
+    press("ArrowDown", "alt")
+
+    expect(useBookmarkStore.getState().moveBookmark).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/bookmark-grid/__tests__/grid-navigation.test.ts
+++ b/src/features/bookmark-grid/__tests__/grid-navigation.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest"
+import type { BookmarkNode } from "@/browser"
+import {
+  buildNavigationColumns,
+  itemAtPosition,
+  planBookmarkReorder,
+  resolveNavigationTarget,
+  type GridNavigationItem,
+} from "../grid-navigation"
+
+/**
+ * The grid's keyboard model, away from the DOM.
+ *
+ * The thing worth pinning here is that the arrows travel the *layout*: a
+ * column of cards, not the folder list the cards were drawn from. The two
+ * disagree the moment `distributeToColumns` sends the second folder to the
+ * second column, which is the ordinary case.
+ */
+
+function folder(id: string, bookmarkIds: string[]): BookmarkNode {
+  return {
+    id,
+    title: id,
+    children: bookmarkIds.map((bookmarkId) => ({
+      id: bookmarkId,
+      title: bookmarkId,
+      url: `https://${bookmarkId}.example`,
+    })),
+  }
+}
+
+// Two columns, each holding two cards: [alpha, gamma] and [beta, delta].
+const COLUMNS: BookmarkNode[][] = [
+  [folder("alpha", ["a1", "a2"]), folder("gamma", ["g1", "g2"])],
+  [folder("beta", ["b1", "b2"]), folder("delta", ["d1", "d2"])],
+]
+
+function ids(columns: GridNavigationItem[][]): string[][] {
+  return columns.map((column) => column.map((item) => item.id))
+}
+
+function move(activeId: string, key: string): string | null {
+  return resolveNavigationTarget({
+    columns: buildNavigationColumns(COLUMNS, false),
+    activeId,
+    key,
+  })
+}
+
+describe("buildNavigationColumns", () => {
+  it("walks each column card by card, heading before its bookmarks", () => {
+    expect(ids(buildNavigationColumns(COLUMNS, false))).toEqual([
+      ["alpha", "a1", "a2", "gamma", "g1", "g2"],
+      ["beta", "b1", "b2", "delta", "d1", "d2"],
+    ])
+  })
+
+  it("includes a nested sub-folder's card, in nested mode only", () => {
+    const nested: BookmarkNode[][] = [
+      [
+        {
+          id: "parent",
+          title: "parent",
+          children: [
+            { id: "p1", title: "p1", url: "https://p1.example" },
+            folder("child", ["c1"]),
+          ],
+        },
+      ],
+    ]
+
+    expect(ids(buildNavigationColumns(nested, true))).toEqual([
+      ["parent", "p1", "child", "c1"],
+    ])
+    expect(ids(buildNavigationColumns(nested, false))).toEqual([
+      ["parent", "p1"],
+    ])
+  })
+})
+
+describe("resolveNavigationTarget", () => {
+  it("moves down within a card", () => {
+    expect(move("a1", "ArrowDown")).toBe("a2")
+  })
+
+  it("moves down across the card boundary inside the column, not to the next folder in the list", () => {
+    // `gamma` is the card *below* `alpha`; `beta` is the next folder in the
+    // source list, and sits in the other column.
+    expect(move("a2", "ArrowDown")).toBe("gamma")
+  })
+
+  it("moves up back into the card above", () => {
+    expect(move("gamma", "ArrowUp")).toBe("a2")
+  })
+
+  it("moves between columns, not between cards, on left and right", () => {
+    expect(move("alpha", "ArrowRight")).toBe("beta")
+    expect(move("beta", "ArrowLeft")).toBe("alpha")
+    expect(move("a2", "ArrowRight")).toBe("b2")
+  })
+
+  it("keeps the row as close as a shorter neighbouring column allows", () => {
+    const ragged: BookmarkNode[][] = [
+      [folder("alpha", ["a1", "a2"])],
+      [folder("beta", [])],
+    ]
+
+    expect(
+      resolveNavigationTarget({
+        columns: buildNavigationColumns(ragged, false),
+        activeId: "a2",
+        key: "ArrowRight",
+      })
+    ).toBe("beta")
+  })
+
+  it("skips a column the masonry left empty", () => {
+    const withGap: BookmarkNode[][] = [
+      [folder("alpha", ["a1"])],
+      [],
+      [folder("beta", ["b1"])],
+    ]
+
+    expect(
+      resolveNavigationTarget({
+        columns: buildNavigationColumns(withGap, false),
+        activeId: "alpha",
+        key: "ArrowRight",
+      })
+    ).toBe("beta")
+  })
+
+  it("takes Home and End to the ends of the column, across cards", () => {
+    expect(move("g1", "Home")).toBe("alpha")
+    expect(move("a1", "End")).toBe("g2")
+  })
+
+  it("stays put at the edges rather than wrapping", () => {
+    expect(move("alpha", "ArrowUp")).toBeNull()
+    expect(move("g2", "ArrowDown")).toBeNull()
+    expect(move("alpha", "ArrowLeft")).toBeNull()
+    expect(move("beta", "ArrowRight")).toBeNull()
+    expect(move("alpha", "Home")).toBeNull()
+    expect(move("g2", "End")).toBeNull()
+  })
+
+  it("claims neither Enter nor a printable character", () => {
+    // Enter is the anchor's own default, and a character belongs to the
+    // search palette's type-ahead.
+    expect(move("a1", "Enter")).toBeNull()
+    expect(move("a1", "g")).toBeNull()
+  })
+})
+
+describe("itemAtPosition", () => {
+  const columns = buildNavigationColumns(COLUMNS, false)
+
+  it("clamps a row past the end of its column", () => {
+    expect(itemAtPosition(columns, { column: 0, row: 99 })?.id).toBe("g2")
+  })
+
+  it("falls back to the nearest column that still holds something", () => {
+    const withEmptyFirst = [[], columns[1]]
+
+    expect(itemAtPosition(withEmptyFirst, { column: 0, row: 1 })?.id).toBe("b1")
+  })
+
+  it("has nothing to offer once the grid is empty", () => {
+    expect(itemAtPosition([[], []], { column: 0, row: 0 })).toBeNull()
+  })
+})
+
+describe("planBookmarkReorder", () => {
+  // A sub-folder among the bookmarks: the card can express no position for
+  // it, so a whole-folder order has to leave it where it is.
+  const target: BookmarkNode = {
+    id: "work",
+    title: "Work",
+    children: [
+      { id: "b1", title: "One", url: "https://one.example" },
+      { id: "sub", title: "Sub", children: [] },
+      { id: "b2", title: "Two", url: "https://two.example" },
+      { id: "b3", title: "Three", url: "https://three.example" },
+    ],
+  }
+
+  function plan(
+    bookmarkId: string,
+    delta: 1 | -1,
+    capabilities: { reorder: boolean; setChildOrder: boolean },
+    folder: BookmarkNode | null = target
+  ) {
+    return planBookmarkReorder({ folder, bookmarkId, delta, capabilities })
+  }
+
+  it("positions through move() when the adapter can reorder", () => {
+    expect(plan("b1", 1, { reorder: true, setChildOrder: false })).toEqual({
+      kind: "move",
+      id: "b1",
+      parentId: "work",
+      index: 1,
+    })
+  })
+
+  it("writes a whole-folder order when that is the only ordering the adapter has", () => {
+    expect(plan("b1", 1, { reorder: false, setChildOrder: true })).toEqual({
+      kind: "child-order",
+      folderId: "work",
+      // The sub-folder keeps its absolute position; only the bookmark
+      // subsequence is permuted.
+      orderedChildIds: ["b2", "sub", "b1", "b3"],
+    })
+  })
+
+  it("prefers move() over a whole-folder order when both are available", () => {
+    expect(plan("b1", 1, { reorder: true, setChildOrder: true })?.kind).toBe(
+      "move"
+    )
+  })
+
+  it("offers nothing when the adapter can express no order at all", () => {
+    expect(plan("b1", 1, { reorder: false, setChildOrder: false })).toBeNull()
+    expect(plan("b1", -1, { reorder: false, setChildOrder: false })).toBeNull()
+  })
+
+  it("offers nothing for a folder whose child order is frozen", () => {
+    const frozen = { ...target, orderReadOnly: true }
+
+    expect(
+      plan("b1", 1, { reorder: false, setChildOrder: true }, frozen)
+    ).toBeNull()
+  })
+
+  it("offers nothing for a read-only bookmark", () => {
+    const withReadOnly: BookmarkNode = {
+      ...target,
+      children: [
+        { ...target.children![0], readOnly: true },
+        ...target.children!.slice(1),
+      ],
+    }
+
+    expect(
+      plan("b1", 1, { reorder: true, setChildOrder: false }, withReadOnly)
+    ).toBeNull()
+  })
+
+  it("stops at the ends of the folder's own bookmarks", () => {
+    expect(plan("b1", -1, { reorder: true, setChildOrder: false })).toBeNull()
+    expect(plan("b3", 1, { reorder: true, setChildOrder: false })).toBeNull()
+  })
+
+  it("offers nothing when the bookmark is no longer in the folder", () => {
+    expect(plan("gone", 1, { reorder: true, setChildOrder: false })).toBeNull()
+    expect(
+      plan("b1", 1, { reorder: true, setChildOrder: false }, null)
+    ).toBeNull()
+  })
+})

--- a/src/features/bookmark-grid/bookmark-grid.tsx
+++ b/src/features/bookmark-grid/bookmark-grid.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils"
 import { getVisibleFolders } from "./folder-collection"
 import { distributeToColumns, useMeasuredCardHeights } from "./card-heights"
 import { BookmarkGridEmpty } from "./bookmark-grid-empty"
+import { GridNavigationContext, useGridNavigation } from "./use-grid-navigation"
 
 function getColumnCountForWidth(): number {
   const w = window.innerWidth
@@ -118,6 +119,14 @@ export function BookmarkGrid() {
     [folders, columnCount, cardLayouts, heights]
   )
 
+  // The grid is one composite widget: `columns` is the visual order the arrow
+  // keys travel, so the keyboard model is derived from the same distribution
+  // the layout is.
+  const { navigation, containerProps } = useGridNavigation({
+    columns,
+    nestedFolders,
+  })
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center p-12 text-muted-foreground">
@@ -137,35 +146,39 @@ export function BookmarkGrid() {
         containerMode === "contained" && "mx-auto max-w-[1440px]"
       )}
     >
-      <div
-        className="grid w-full min-w-0 items-start gap-4"
-        style={{
-          gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
-        }}
-      >
-        {columns.map((columnFolders, colIndex) => (
-          <div key={colIndex} className="flex min-w-0 flex-col gap-4">
-            {columnFolders.map((folder) => (
-              // The wrapper is what the ResizeObserver watches: it is the only
-              // element that exists in both the draggable and plain variants.
-              <div
-                key={folder.id}
-                ref={measureRefs.get(folder.id)}
-                className="min-w-0"
-              >
-                {experimentalCardDrag ? (
-                  <SortableFolderCard
-                    folder={folder}
-                    sortableIndex={folderIndexMap.get(folder.id) ?? 0}
-                  />
-                ) : (
-                  <BookmarkCard folder={folder} />
-                )}
-              </div>
-            ))}
-          </div>
-        ))}
-      </div>
+      <GridNavigationContext value={navigation}>
+        <div
+          {...containerProps}
+          className="grid w-full min-w-0 items-start gap-4"
+          style={{
+            gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+          }}
+        >
+          {columns.map((columnFolders, colIndex) => (
+            <div key={colIndex} className="flex min-w-0 flex-col gap-4">
+              {columnFolders.map((folder) => (
+                // The wrapper is what the ResizeObserver watches: it is the
+                // only element that exists in both the draggable and plain
+                // variants.
+                <div
+                  key={folder.id}
+                  ref={measureRefs.get(folder.id)}
+                  className="min-w-0"
+                >
+                  {experimentalCardDrag ? (
+                    <SortableFolderCard
+                      folder={folder}
+                      sortableIndex={folderIndexMap.get(folder.id) ?? 0}
+                    />
+                  ) : (
+                    <BookmarkCard folder={folder} />
+                  )}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </GridNavigationContext>
     </div>
   )
 }

--- a/src/features/bookmark-grid/grid-navigation.ts
+++ b/src/features/bookmark-grid/grid-navigation.ts
@@ -1,0 +1,253 @@
+import type { BookmarkNode } from "@/browser"
+import { buildChildOrderForBookmarkReorder } from "@/features/dnd"
+
+/**
+ * The grid's keyboard model, as pure functions over what the grid renders.
+ *
+ * The dashboard is one composite widget: a single tab stop, moved around with
+ * the arrow keys. A collection is 100–200 bookmarks, so one tab stop per
+ * bookmark would mean crossing the page in 200 Tab presses.
+ *
+ * Arrow movement follows the *visual* order, which is not the DOM order of a
+ * single list: `distributeToColumns` hands each card to the shortest column,
+ * and each column is a flex column of cards. So Up/Down walks one column —
+ * across the card boundaries inside it — and Left/Right steps between columns.
+ */
+
+/** One stop in the grid's roving tab order. */
+export type GridNavigationItem =
+  | { kind: "folder"; id: string }
+  | { kind: "bookmark"; id: string; folderId: string }
+
+export interface GridPosition {
+  column: number
+  row: number
+}
+
+/**
+ * The items one card contributes, in the order `BookmarkCard` paints them:
+ * its heading, then its direct bookmarks, then — in nested mode only — each
+ * sub-folder card in full.
+ */
+function collectCardItems(
+  folder: BookmarkNode,
+  nestedFolders: boolean
+): GridNavigationItem[] {
+  const children = folder.children ?? []
+  const items: GridNavigationItem[] = [{ kind: "folder", id: folder.id }]
+
+  for (const child of children) {
+    if (child.url !== undefined) {
+      items.push({ kind: "bookmark", id: child.id, folderId: folder.id })
+    }
+  }
+
+  if (nestedFolders) {
+    for (const child of children) {
+      if (child.url === undefined && child.children !== undefined) {
+        items.push(...collectCardItems(child, nestedFolders))
+      }
+    }
+  }
+
+  return items
+}
+
+/** Flattens each rendered column into the sequence Up/Down walks. */
+export function buildNavigationColumns(
+  columns: BookmarkNode[][],
+  nestedFolders: boolean
+): GridNavigationItem[][] {
+  return columns.map((column) =>
+    column.flatMap((folder) => collectCardItems(folder, nestedFolders))
+  )
+}
+
+export function findItemPosition(
+  columns: GridNavigationItem[][],
+  id: string
+): GridPosition | null {
+  for (let column = 0; column < columns.length; column++) {
+    const row = columns[column].findIndex((item) => item.id === id)
+    if (row !== -1) return { column, row }
+  }
+
+  return null
+}
+
+export function findItem(
+  columns: GridNavigationItem[][],
+  id: string
+): GridNavigationItem | null {
+  for (const column of columns) {
+    const item = column.find((candidate) => candidate.id === id)
+    if (item) return item
+  }
+
+  return null
+}
+
+/**
+ * The item nearest a remembered position, which is how focus survives a
+ * refresh that took the focused item away: a delete leaves whatever moved up
+ * into its place, and a card that vanished entirely leaves the nearest
+ * column. Both coordinates are clamped rather than required to exist, since a
+ * mutation can shorten a column or empty one outright.
+ */
+export function itemAtPosition(
+  columns: GridNavigationItem[][],
+  position: GridPosition
+): GridNavigationItem | null {
+  // Fewer cards than columns leaves trailing columns empty, and clamping onto
+  // one of those would find nothing to focus.
+  const populated = columns
+    .map((items, index) => ({ items, index }))
+    .filter((column) => column.items.length > 0)
+  if (populated.length === 0) return null
+
+  let nearest = populated[0]
+  for (const column of populated) {
+    if (
+      Math.abs(column.index - position.column) <
+      Math.abs(nearest.index - position.column)
+    ) {
+      nearest = column
+    }
+  }
+
+  const row = Math.min(Math.max(position.row, 0), nearest.items.length - 1)
+  return nearest.items[row]
+}
+
+/**
+ * Where a navigation key moves the tab stop, or `null` when it moves nowhere
+ * and the keystroke is none of the grid's business.
+ *
+ * Movement deliberately does not wrap: the columns are a masonry layout, not
+ * a ring, and arriving back at the top after passing the bottom of a column
+ * reads as a jump rather than as travel.
+ */
+export function resolveNavigationTarget(params: {
+  columns: GridNavigationItem[][]
+  activeId: string
+  key: string
+}): string | null {
+  const { columns, activeId, key } = params
+  const from = findItemPosition(columns, activeId)
+  if (!from) return null
+
+  const column = columns[from.column]
+
+  switch (key) {
+    case "ArrowUp":
+      return from.row > 0 ? column[from.row - 1].id : null
+    case "ArrowDown":
+      return from.row < column.length - 1 ? column[from.row + 1].id : null
+    case "Home":
+      return from.row > 0 ? column[0].id : null
+    case "End":
+      return from.row < column.length - 1 ? column[column.length - 1].id : null
+    case "ArrowLeft":
+    case "ArrowRight": {
+      const step = key === "ArrowLeft" ? -1 : 1
+      for (
+        let index = from.column + step;
+        index >= 0 && index < columns.length;
+        index += step
+      ) {
+        const target = columns[index]
+        if (target.length === 0) continue
+        // A shorter neighbouring column keeps the row as close as it can,
+        // which is the only answer that stays on screen.
+        return target[Math.min(from.row, target.length - 1)].id
+      }
+      return null
+    }
+    default:
+      return null
+  }
+}
+
+export interface GridOrderingCapabilities {
+  /** `capabilities.reorder`: a position persists through `move(id, {index})`. */
+  reorder: boolean
+  /**
+   * `capabilities.setChildOrder` *and* the adapter actually exposing the
+   * method — the same pair `DndMonitor` requires before routing anything
+   * through whole-folder ordering.
+   */
+  setChildOrder: boolean
+}
+
+export type GridReorderPlan =
+  | { kind: "move"; id: string; parentId: string; index: number }
+  | { kind: "child-order"; folderId: string; orderedChildIds: string[] }
+
+/**
+ * What Alt+Up / Alt+Down should write, or `null` when the move must not be
+ * offered at all.
+ *
+ * Alt+Arrow reorders a bookmark inside its own folder and nothing else. The
+ * two write paths are the ones the drag already uses, chosen by capability
+ * and never mixed: `reorder` means a position survives `move(id, {index})`
+ * (Chrome, Firefox, Standalone), while `setChildOrder` means whole-folder
+ * ordering is the only way to express it (daemon, whose `move()` has no
+ * notion of an index). With neither, the keystroke does nothing — a gesture
+ * whose ordering half the adapter would drop on the floor is worse than no
+ * gesture.
+ *
+ * The read-only rules are restated here rather than assumed, exactly as
+ * `canDropOnTarget` restates them for the organizer's keyboard drag: the
+ * pointer path withholds a drag by not rendering a handle, and a keystroke
+ * has no handle to withhold.
+ */
+export function planBookmarkReorder(params: {
+  folder: BookmarkNode | null
+  bookmarkId: string
+  delta: 1 | -1
+  capabilities: GridOrderingCapabilities
+}): GridReorderPlan | null {
+  const { folder, bookmarkId, delta, capabilities } = params
+  if (!folder) return null
+  if (!capabilities.reorder && !capabilities.setChildOrder) return null
+
+  const children = folder.children ?? []
+  const bookmarks = children.filter((child) => child.url !== undefined)
+  const index = bookmarks.findIndex((child) => child.id === bookmarkId)
+  if (index === -1) return null
+  if (bookmarks[index].readOnly) return null
+
+  const targetIndex = index + delta
+  if (targetIndex < 0 || targetIndex >= bookmarks.length) return null
+
+  if (capabilities.reorder) {
+    // The bookmarks-only index the card renders, which is what the drag path
+    // already sends to the same `move(id, {index})` call. Handing the two
+    // paths different indices would make one of them wrong.
+    return {
+      kind: "move",
+      id: bookmarkId,
+      parentId: folder.id,
+      index: targetIndex,
+    }
+  }
+
+  // A folder whose order file is frozen accepts renames, moves and deletes
+  // but refuses positional changes, so this one is withheld instead of being
+  // sent and rejected.
+  if (folder.orderReadOnly) return null
+
+  // Reuses the drag path's permutation builder, which re-derives both
+  // positions from the live children and refuses when either id is gone —
+  // the same hardening a keyboard move needs, since the folder can change
+  // between the render that placed the row and the keystroke that moves it.
+  const orderedChildIds = buildChildOrderForBookmarkReorder({
+    children,
+    sourceId: bookmarkId,
+    targetId: bookmarks[targetIndex].id,
+    closestEdge: delta > 0 ? "bottom" : "top",
+  })
+  if (!orderedChildIds) return null
+
+  return { kind: "child-order", folderId: folder.id, orderedChildIds }
+}

--- a/src/features/bookmark-grid/use-grid-navigation.ts
+++ b/src/features/bookmark-grid/use-grid-navigation.ts
@@ -1,0 +1,288 @@
+import * as React from "react"
+import type { BookmarkNode } from "@/browser"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+import { findNodeById } from "@/lib/bookmark-utils"
+import {
+  buildNavigationColumns,
+  findItem,
+  findItemPosition,
+  itemAtPosition,
+  planBookmarkReorder,
+  resolveNavigationTarget,
+  type GridPosition,
+} from "./grid-navigation"
+
+/**
+ * The grid's roving tab order, and the focus it has to keep hold of across a
+ * refresh.
+ *
+ * `bookmark-store.refresh` replaces `tree` wholesale on every create, rename,
+ * delete and move, so the item under the focus can simply stop existing.
+ * Two things have to survive that: the single tab stop, which must still be
+ * on something Tab can reach, and — when the grid was the thing holding the
+ * focus — the focus itself.
+ */
+
+/** The props one grid item needs to take part in the roving tab order. */
+export interface GridItemProps {
+  ref: (element: HTMLElement | null) => void
+  tabIndex: number
+  onFocus: () => void
+  onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void
+}
+
+export interface GridNavigation {
+  subscribe(listener: () => void): () => void
+  isActive(id: string): boolean
+  activate(id: string): void
+  registerItem(id: string, element: HTMLElement | null): void
+  handleKeyDown(id: string, event: React.KeyboardEvent<HTMLElement>): void
+}
+
+export const GridNavigationContext = React.createContext<GridNavigation | null>(
+  null
+)
+
+const NO_SUBSCRIPTION = () => () => {}
+
+/**
+ * Outside a grid there is no roving order to join, so the item reports itself
+ * plainly tabbable — a card rendered on its own still behaves.
+ */
+export function useGridItem(id: string): GridItemProps {
+  const navigation = React.useContext(GridNavigationContext)
+
+  // Each item subscribes to its *own* active flag rather than reading a
+  // context value that changes: an arrow key moves the tab stop between two
+  // items, and re-rendering all 200 bookmarks to move a `tabIndex` twice is
+  // what would make the keys feel slow.
+  const isActive = React.useSyncExternalStore(
+    navigation?.subscribe ?? NO_SUBSCRIPTION,
+    () => navigation?.isActive(id) ?? true
+  )
+
+  const ref = React.useCallback(
+    (element: HTMLElement | null) => navigation?.registerItem(id, element),
+    [navigation, id]
+  )
+  const onFocus = React.useCallback(
+    () => navigation?.activate(id),
+    [navigation, id]
+  )
+  const onKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) =>
+      navigation?.handleKeyDown(id, event),
+    [navigation, id]
+  )
+
+  return { ref, tabIndex: isActive ? 0 : -1, onFocus, onKeyDown }
+}
+
+interface GridNavigationOptions {
+  /** The cards as `distributeToColumns` laid them out, i.e. in visual order. */
+  columns: BookmarkNode[][]
+  nestedFolders: boolean
+}
+
+export function useGridNavigation(options: GridNavigationOptions) {
+  const { columns, nestedFolders } = options
+
+  const navigationColumns = React.useMemo(
+    () => buildNavigationColumns(columns, nestedFolders),
+    [columns, nestedFolders]
+  )
+
+  const tree = useBookmarkStore((s) => s.tree)
+  const moveBookmark = useBookmarkStore((s) => s.moveBookmark)
+  const setChildOrder = useBookmarkStore((s) => s.setChildOrder)
+  const reorderEnabled = useBookmarkStore(
+    (s) => s.adapter?.capabilities.reorder ?? true
+  )
+  // Mirrors `DndMonitor`: the capability flag and the optional method must
+  // agree before anything routes ordering through `setChildOrder`.
+  const setChildOrderEnabled = useBookmarkStore(
+    (s) =>
+      (s.adapter?.capabilities.setChildOrder ?? false) &&
+      s.adapter?.bookmarks.setChildOrder !== undefined
+  )
+
+  const containerRef = React.useRef<HTMLDivElement | null>(null)
+  const elements = React.useRef(new Map<string, HTMLElement>())
+  const listeners = React.useRef(new Set<() => void>())
+  const activeId = React.useRef<string | null>(null)
+  const position = React.useRef<GridPosition | null>(null)
+  const heldFocus = React.useRef(false)
+
+  // Read by the key handler, which is stable and therefore closes over
+  // nothing. Written in a layout effect rather than during render so the
+  // render itself stays pure.
+  const latest = React.useRef({
+    navigationColumns,
+    tree,
+    moveBookmark,
+    setChildOrder,
+    reorderEnabled,
+    setChildOrderEnabled,
+  })
+  React.useLayoutEffect(() => {
+    latest.current = {
+      navigationColumns,
+      tree,
+      moveBookmark,
+      setChildOrder,
+      reorderEnabled,
+      setChildOrderEnabled,
+    }
+  })
+
+  const setActiveId = React.useCallback((id: string | null) => {
+    if (activeId.current !== id) {
+      activeId.current = id
+      for (const listener of listeners.current) listener()
+    }
+    // Remembered even when the id did not change, because the item may have
+    // moved: this position is the only thing left to aim at once the id is
+    // gone.
+    position.current = id
+      ? findItemPosition(latest.current.navigationColumns, id)
+      : null
+  }, [])
+
+  const navigation = React.useMemo<GridNavigation>(
+    () => ({
+      subscribe(listener) {
+        listeners.current.add(listener)
+        return () => listeners.current.delete(listener)
+      },
+      isActive(id) {
+        return activeId.current === id
+      },
+      activate(id) {
+        setActiveId(id)
+      },
+      registerItem(id, element) {
+        if (element) {
+          elements.current.set(id, element)
+        } else {
+          elements.current.delete(id)
+        }
+      },
+      handleKeyDown(id, event) {
+        if (event.defaultPrevented) return
+        // Ctrl/Command are the browser's and Shift is selection's; neither
+        // belongs to the grid.
+        if (event.ctrlKey || event.metaKey || event.shiftKey) return
+
+        const state = latest.current
+
+        if (event.altKey) {
+          // Alt is what is left, and it costs nothing: the palette's
+          // type-ahead already drops any keystroke carrying it, and an arrow
+          // key is not a printable character either way.
+          const delta =
+            event.key === "ArrowDown" ? 1 : event.key === "ArrowUp" ? -1 : 0
+          if (delta === 0) return
+
+          const item = findItem(state.navigationColumns, id)
+          // Folder cards are left out: their order is a client-local
+          // preference over a masonry layout, where "the card above" is not
+          // the previous card in the list being reordered.
+          if (item?.kind !== "bookmark") return
+
+          const plan = planBookmarkReorder({
+            folder: findNodeById(state.tree, item.folderId),
+            bookmarkId: id,
+            delta,
+            capabilities: {
+              reorder: state.reorderEnabled,
+              setChildOrder: state.setChildOrderEnabled,
+            },
+          })
+          if (!plan) return
+
+          event.preventDefault()
+          if (plan.kind === "move") {
+            void state.moveBookmark(plan.id, {
+              parentId: plan.parentId,
+              index: plan.index,
+            })
+          } else {
+            void state.setChildOrder(plan.folderId, plan.orderedChildIds)
+          }
+          return
+        }
+
+        // Enter is deliberately absent: a bookmark row is an `<a href>`, so
+        // opening it is the browser's own default, and claiming the key here
+        // would only reimplement it.
+        const targetId = resolveNavigationTarget({
+          columns: state.navigationColumns,
+          activeId: id,
+          key: event.key,
+        })
+        if (!targetId) return
+
+        event.preventDefault()
+        setActiveId(targetId)
+        elements.current.get(targetId)?.focus()
+      },
+    }),
+    [setActiveId]
+  )
+
+  const containerProps = React.useMemo(
+    () => ({
+      ref: containerRef,
+      onFocus: () => {
+        heldFocus.current = true
+      },
+      onBlur: (event: React.FocusEvent<HTMLElement>) => {
+        const next = event.relatedTarget
+        if (next instanceof Node && containerRef.current?.contains(next)) return
+        // A row unmounting under the focus reports the loss with nothing to
+        // hand focus to and an element already out of the document. That is a
+        // refresh, not the user leaving, and the flag has to survive it —
+        // it is the whole permission to put focus back. (Chrome fires no
+        // event at all in that case, which lands in the same place.)
+        if (next === null && !event.target.isConnected) return
+        heldFocus.current = false
+      },
+    }),
+    []
+  )
+
+  // Runs after every refresh, since `refresh` replaces `tree` and the columns
+  // are derived from it.
+  React.useLayoutEffect(() => {
+    const current = activeId.current
+    const found = current ? findItemPosition(navigationColumns, current) : null
+    if (found) {
+      position.current = found
+      return
+    }
+
+    const replacement = itemAtPosition(
+      navigationColumns,
+      position.current ?? { column: 0, row: 0 }
+    )
+    setActiveId(replacement?.id ?? null)
+    if (!replacement) return
+
+    // Moving focus the user never gave the grid would be worse than the reset
+    // this is fixing, so it happens only when the grid was holding it and the
+    // refresh dropped it on the floor.
+    if (!heldFocus.current) return
+    const active = document.activeElement
+    if (
+      active &&
+      active !== document.body &&
+      containerRef.current?.contains(active)
+    ) {
+      return
+    }
+
+    elements.current.get(replacement.id)?.focus()
+  }, [navigationColumns, setActiveId])
+
+  return { navigation, containerProps }
+}

--- a/src/features/bookmark-item/bookmark-item.tsx
+++ b/src/features/bookmark-item/bookmark-item.tsx
@@ -22,6 +22,9 @@ import type { BookmarkNode } from "@/browser"
 import { useUIStore } from "@/stores/ui-store"
 import { useBookmarkStore } from "@/stores/bookmark-store"
 import { useSortableBookmark, DropIndicator } from "@/features/dnd"
+// Past the grid's barrel on purpose: importing it would pull `BookmarkGrid`,
+// which renders this row, back into the row's own module graph.
+import { useGridItem } from "@/features/bookmark-grid/use-grid-navigation"
 import { cn } from "@/lib/utils"
 import { describeReadOnly } from "@/lib/bookmark-utils"
 
@@ -64,6 +67,11 @@ export const BookmarkItem = React.memo(function BookmarkItem({
     disabled:
       (!moveEnabled && !reorderEnabled && !setChildOrderEnabled) || isReadOnly,
   })
+
+  // The row's stop in the grid's roving tab order. It rides on the anchor the
+  // hover card already renders, so `Enter` stays the browser's own "follow
+  // this link" rather than something re-implemented here.
+  const gridItem = useGridItem(bookmark.id)
 
   const openEditor = useUIStore((s) => s.openEditor)
   const openDeleteConfirm = useUIStore((s) => s.openDeleteConfirm)
@@ -124,7 +132,8 @@ export const BookmarkItem = React.memo(function BookmarkItem({
               <a
                 href={bookmark.url}
                 draggable="false"
-                className="flex items-center justify-center rounded-lg p-2 transition-colors hover:bg-accent"
+                {...gridItem}
+                className="flex items-center justify-center rounded-lg border border-transparent p-2 transition-colors outline-none hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
               />
             }
           >
@@ -164,7 +173,8 @@ export const BookmarkItem = React.memo(function BookmarkItem({
             <a
               href={bookmark.url}
               draggable="false"
-              className="flex min-w-0 items-center gap-2.5 rounded-lg px-2 py-2.5 transition-colors hover:bg-accent sm:py-1.5"
+              {...gridItem}
+              className="flex min-w-0 items-center gap-2.5 rounded-lg border border-transparent px-2 py-2.5 transition-colors outline-none hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 sm:py-1.5"
             />
           }
         >

--- a/tests/ui/keyboard-navigation.spec.ts
+++ b/tests/ui/keyboard-navigation.spec.ts
@@ -1,0 +1,288 @@
+import { expect, test, type Page } from "@playwright/test"
+
+/**
+ * The dashboard grid operated without a pointer.
+ *
+ * The assertions about *where* focus went are geometric on purpose: the point
+ * of the arrow keys here is that they follow the masonry the user is looking
+ * at, and the only way to say that without restating the implementation is to
+ * measure the boxes.
+ */
+
+const GRID_ITEM =
+  '[data-testid="bookmark-card"] a[tabindex], [data-testid="bookmark-card"] h3[tabindex]'
+
+interface FocusedBox {
+  /** Document coordinates, so a scroll caused by focusing does not move them. */
+  x: number
+  y: number
+  tag: string
+}
+
+async function focusedBox(page: Page): Promise<FocusedBox> {
+  return page.evaluate(() => {
+    const element = document.activeElement as HTMLElement
+    const rect = element.getBoundingClientRect()
+    return {
+      x: rect.x + window.scrollX,
+      y: rect.y + window.scrollY,
+      tag: element.tagName,
+    }
+  })
+}
+
+/** Focuses the grid's current tab stop, which is the first card's heading. */
+async function focusGrid(page: Page): Promise<void> {
+  await page.waitForSelector('[data-testid="bookmark-card"]')
+  await page.evaluate(() => {
+    const stop = document.querySelector(
+      '[data-testid="bookmark-card"] h3[tabindex="0"]'
+    ) as HTMLElement | null
+    stop?.focus()
+  })
+}
+
+test("the whole grid is one tab stop, not one per bookmark", async ({
+  page,
+}) => {
+  await page.goto("/")
+  await page.waitForSelector('[data-testid="bookmark-card"]')
+
+  const stops = page.locator(GRID_ITEM).and(page.locator('[tabindex="0"]'))
+  await expect(stops).toHaveCount(1)
+
+  // The rest of the grid is reachable, just not by Tab: crossing this page
+  // was the reason the grid became a composite widget at all.
+  const roved = page.locator(GRID_ITEM).and(page.locator('[tabindex="-1"]'))
+  expect(await roved.count()).toBeGreaterThan(50)
+})
+
+test("arrow keys travel the columns the masonry drew", async ({ page }) => {
+  await page.goto("/")
+  await focusGrid(page)
+
+  const start = await focusedBox(page)
+  expect(start.tag).toBe("H3")
+
+  await page.keyboard.press("ArrowDown")
+  const below = await focusedBox(page)
+  expect(below.y).toBeGreaterThan(start.y)
+  expect(Math.abs(below.x - start.x)).toBeLessThan(40)
+
+  await page.keyboard.press("ArrowUp")
+  expect(await focusedBox(page)).toEqual(start)
+
+  await page.keyboard.press("ArrowRight")
+  const right = await focusedBox(page)
+  expect(right.x).toBeGreaterThan(start.x + 200)
+
+  await page.keyboard.press("ArrowLeft")
+  expect(await focusedBox(page)).toEqual(start)
+
+  // End walks past every card boundary in the column, so it has to land
+  // below everything the column holds.
+  await page.keyboard.press("End")
+  const last = await focusedBox(page)
+  expect(last.y).toBeGreaterThan(below.y)
+  expect(Math.abs(last.x - start.x)).toBeLessThan(40)
+
+  await page.keyboard.press("Home")
+  expect(await focusedBox(page)).toEqual(start)
+})
+
+test("Enter opens the focused bookmark", async ({ page }) => {
+  // Everything off the dev server is stubbed, so the bookmark opens without
+  // the test ever leaving the machine.
+  await page.route(
+    (url) => url.hostname !== "127.0.0.1",
+    (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<title>opened</title>",
+      })
+  )
+
+  await page.goto("/")
+  await page.waitForSelector('[data-testid="bookmark-card"]')
+
+  const href = await page.evaluate(() => {
+    const link = document.querySelector(
+      '[data-testid="bookmark-card"] a[href]'
+    ) as HTMLAnchorElement
+    link.focus()
+    return link.href
+  })
+
+  await page.keyboard.press("Enter")
+  await page.waitForURL(href)
+  expect(page.url()).toBe(href)
+})
+
+test("Alt and an arrow reorder the focused bookmark in its folder", async ({
+  page,
+}) => {
+  await page.goto("/")
+
+  const card = page
+    .getByTestId("bookmark-card")
+    .filter({ has: page.getByRole("heading", { name: "Social", exact: true }) })
+  await expect(card).toBeVisible()
+
+  const hrefs = () =>
+    card
+      .locator("a")
+      .evaluateAll((links) => links.map((link) => link.getAttribute("href")))
+
+  const before = await hrefs()
+  expect(before.length).toBeGreaterThan(2)
+
+  await card.locator("a").first().focus()
+  await page.keyboard.press("Alt+ArrowDown")
+
+  await expect.poll(hrefs).toEqual([before[1], before[0], ...before.slice(2)])
+
+  // And back, so the move is a reorder rather than a one-way shuffle.
+  await page.keyboard.press("Alt+ArrowUp")
+  await expect.poll(hrefs).toEqual(before)
+})
+
+test("the same keys reorder through whole-folder ordering in a Vault", async ({
+  page,
+}) => {
+  await page.goto("/")
+
+  // A Daemon Source has `reorder: false` and `setChildOrder: true`, so this
+  // is the other write path — the one whose absence would be silent.
+  await page
+    .getByRole("tablist", { name: "Bookmark source" })
+    .getByRole("tab")
+    .filter({ hasText: "reading" })
+    .click()
+
+  const card = page.getByTestId("bookmark-card").filter({
+    has: page.getByRole("heading", { name: "Articles", exact: true }),
+  })
+  await expect(card).toBeVisible()
+
+  const titles = () =>
+    card
+      .locator("a span:last-child")
+      .evaluateAll((spans) => spans.map((span) => span.textContent))
+
+  await expect
+    .poll(titles)
+    .toEqual([
+      "SQLite is not a toy database",
+      "The B-tree database",
+      "Writing a simple JSON parser",
+    ])
+
+  await card.locator("a").first().focus()
+  await page.keyboard.press("Alt+ArrowDown")
+
+  await expect
+    .poll(titles)
+    .toEqual([
+      "The B-tree database",
+      "SQLite is not a toy database",
+      "Writing a simple JSON parser",
+    ])
+})
+
+test("typing over a focused bookmark still opens the search palette", async ({
+  page,
+}) => {
+  await page.goto("/")
+  await page.waitForSelector('[data-testid="bookmark-card"]')
+  await page.evaluate(() => {
+    const link = document.querySelector(
+      '[data-testid="bookmark-card"] a[href]'
+    ) as HTMLElement
+    link.focus()
+  })
+
+  await page.keyboard.press("g")
+
+  const search = page.getByRole("combobox", { name: "Search bookmarks" })
+  await expect(search).toBeVisible()
+  await expect(search).toHaveValue("g")
+})
+
+const COLOR_THEMES = [
+  "default",
+  "amber-minimal",
+  "claude",
+  "claymorphism",
+  "solar-dusk",
+  "t3-chat",
+  "vintage-paper",
+  "bubblegum",
+  "caffeine",
+  "cyberpunk",
+]
+
+/** A colour function whose last component is zero, i.e. fully transparent. */
+const INVISIBLE = /[,/]\s*0\)$/
+
+test("the focused item is visibly ringed in every theme, light and dark", async ({
+  page,
+}) => {
+  await page.goto("/")
+
+  await focusGrid(page)
+  // Moving with a key is what makes the browser call this focus visible; the
+  // same element focused by script would not draw the ring.
+  await page.keyboard.press("ArrowDown")
+
+  for (const theme of COLOR_THEMES) {
+    for (const scheme of ["light", "dark"]) {
+      const label = `${theme}/${scheme}`
+      await page.evaluate(
+        ({ theme, scheme }) => {
+          const root = document.documentElement
+          if (theme === "default") {
+            root.removeAttribute("data-color-theme")
+          } else {
+            root.setAttribute("data-color-theme", theme)
+          }
+          root.classList.toggle("dark", scheme === "dark")
+        },
+        { theme, scheme }
+      )
+
+      // Net zero movement, but both presses are real keyboard focus moves,
+      // so the ring is drawn wherever the previous theme left the tab stop.
+      await page.keyboard.press("ArrowDown")
+      await page.keyboard.press("ArrowUp")
+
+      const boxShadow = await page.evaluate(
+        () => getComputedStyle(document.activeElement as Element).boxShadow
+      )
+
+      // Tailwind paints the ring as one 3px spread layer among several
+      // transparent placeholders, so the layer has to be picked out before
+      // its colour means anything.
+      const ring = /(\S+\([^)]*\))\s+0px 0px 0px 3px/.exec(boxShadow)
+      expect(ring, label).not.toBeNull()
+      expect(ring![1], label).not.toMatch(INVISIBLE)
+
+      // `focus-visible:border-ring` is the other half of the convention, and
+      // it is the half that silently does nothing if a theme has no `--ring`.
+      // Polled because the row's `transition-colors` covers border-color: read
+      // on the same tick as the keypress, it is still the transparent value it
+      // is animating away from.
+      await expect
+        .poll(
+          () =>
+            page.evaluate(
+              () =>
+                getComputedStyle(document.activeElement as Element)
+                  .borderTopColor
+            ),
+          { message: label }
+        )
+        .not.toMatch(INVISIBLE)
+    }
+  }
+})


### PR DESCRIPTION
Closes #46. Step 1 (the organizer tree) shipped in #51; this is the rest.

## Summary

- The grid becomes one composite widget with a roving tabindex: **one** tab stop for the whole dashboard, not one per bookmark.
- Arrow keys move in visual order; Home/End reach a column's ends.
- Alt+Arrow reorders a bookmark inside its folder, through the existing store actions.
- Focus survives a mutation instead of resetting to the document.
- Folder headings and bookmark rows carry the organizer's `focus-visible` convention.

## Why one tab stop

The realistic collection is 100–200 bookmarks (the reasoning that closed #47). One tab stop per bookmark would mean up to 200 Tab presses to cross the page. Items subscribe to their own active flag through `useSyncExternalStore`, so an arrow key re-renders two items rather than all of them.

## Visual order, not DOM order

`distributeToColumns` deals cards into masonry columns, so the built order is not the seen order. The navigation model is derived from that same output: per column, for each card in order, heading → its direct bookmarks → (nested mode) each sub-folder card recursively — `BookmarkCard`'s own paint order.

Up/Down move within a column across card boundaries; Left/Right move to the nearest non-empty column with the row clamped; nothing wraps, so an edge keystroke is left unhandled and the page keeps its default.

This is checked geometrically in Playwright against document coordinates, not asserted structurally: Down increases `y` with `x` held within 40px, Right increases `x` by more than 200px, and Up/Left/Home each return to the exact starting box.

## Enter is deliberately not claimed

A bookmark row is an `<a href>`. Enter is the browser's own link activation, and intercepting it would replace working behaviour with a reimplementation of it. A Playwright test proves the navigation happens against a stubbed route.

## Reorder gating

`planBookmarkReorder` is pure; the handler only executes its plan. In order: no `reorder` and no `setChildOrder` → `null`, nothing written and no `preventDefault`; a `readOnly` bookmark → refused; out of bounds → refused; `reorder` → `moveBookmark(id, { parentId, index })`; otherwise `setChildOrder`, which a folder's `orderReadOnly` blocks — the daemon's own rule, withheld rather than sent and rejected.

The `setChildOrder` permutation reuses `buildChildOrderForBookmarkReorder` from the drag path rather than building a second one, so sub-folders keep their absolute positions and both ends are re-derived from live children.

Alt+Left/Right is not bound: that would be a cross-folder move with no predictable destination in a masonry layout. Folder cards are excluded too — their order is a client-local preference over a masonry distribution, where "the card above" is not the previous entry in the list being reordered.

Both write paths are proven end to end in Playwright against the Dev Workbench's real adapters — the Browser source (`reorder: true`) and the `reading` Vault (`reorder: false, setChildOrder: true`) — each asserting the rendered order actually changed.

## Focus after mutation

The controller remembers the active item's `{column, row}`. After a refresh: if the id survives, the position is refreshed and DOM focus is untouched (React reuses the node — this is the reorder case). If it is gone, the tab stop moves to whatever now occupies that visual slot. DOM focus is moved only when the grid was holding it and lost it, so Tab still reaches the grid sensibly without focus ever being stolen.

## Known follow-ups

- **A reorder is silent to a screen reader.** #46 raises this as an open question. Parity with the pointer drag holds — that is silent too — but a live region is the most defensible next step.
- **Folder-card action buttons stay natively tabbable.** Making them `-1` would remove the only keyboard route to rename, delete or organise a folder. Tab order is now roughly one stop per card rather than one per bookmark.
- **Inside a grid-layout card**, bookmarks wrap into icon rows, so Down often moves right. Making Left/Right work within such a card needs the card's wrap count, which is width-dependent through `auto-fill` and not knowable without measurement.
- **The `reorder` path sends the bookmarks-only index**, matching the drag path exactly. That index counts only bookmarks while `chrome.bookmarks.move()` indexes among all children, so a folder with sub-folders can be off — but `dnd-monitor.tsx` documents this as deliberate and required to stay, and diverging would make the two paths disagree. Pre-existing, not a regression.

## Verification

- `bun run check` — pass (79 test files, 735 tests; 697 before).
- `bun run test:ui` — 27 passed (20 before).
- New: 22 tests over the pure navigation model, 16 jsdom tests (roving tabindex, movement, Enter left alone, type-ahead still opening the palette from a focused bookmark, focus after mutation, reorder capability gating), and 7 Playwright tests.
- No existing test modified. `tests/ui/default-scenario.spec.ts` is untouched and still passes: nothing was added to the toolbar.
