### PR TITLE
feat: cache favicon bytes locally and prefer Chrome's native source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Favicons are cached on your machine and Chrome now asks itself first.** Icon
+  bytes are stored locally for 30 days, so a site is asked about roughly once a
+  month instead of on every render, and cached icons keep working offline.
+  Bookmarks sharing a site now cause one lookup between them rather than one
+  each. On Chrome the browser's own `_favicon` database is tried before Google —
+  it used to be the other way round — so a hit discloses nothing at all. The
+  README now documents the provider order and exactly when an origin still
+  reaches Google
+
 ### Added
 
 - **The dashboard is operable from the keyboard.** The bookmark grid is a

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@
 - **Light and dark mode** — Follows system preference or toggle manually
 - **Choose your root folder** — Display bookmarks from any folder
 - **Import and export** — Standard HTML bookmark files
-- **Smart favicons** — Sharp, high-quality site icons with a clean letter fallback when a site has none
+- **Smart favicons** — Sharp, high-quality site icons, cached locally so they load offline, with a clean letter fallback when a site has none
 - **Quick capture** — Save the active tab from the extension popup
 - **Address-bar search** — Search the active source with the `bb` omnibox keyword
 - **Three bookmark sources** — Browser bookmarks, a browser-local standalone collection, or an optional Markdown vault daemon
-- **Private by design** — No account, analytics, tracking, ads, or bookmark-content collection
+- **Private by design** — No account, analytics, tracking, ads, or bookmark-content collection. Favicons are the one thing that leaves your machine; see [Privacy](#privacy)
 
 Existing extension users upgrade in place. Version 4 preserves their selected
 root folder, layouts, themes and completed setup state; the setup wizard is not
@@ -110,6 +110,43 @@ optional localhost access at that moment, not during extension installation.
 <p align="center">
   <img src="marketing/output/04-settings.png" width="700" alt="Settings dialog" />
 </p>
+
+## Privacy
+
+There is no account, no analytics, no tracking and no collection of bookmark
+content. Your bookmarks stay in your browser profile, in your Markdown vault, or
+both — nothing about them is uploaded anywhere.
+
+The one exception is **favicons**, and it is worth being precise about it. Site
+icons are not something a browser extension can generally produce on its own, so
+they come from a short chain of providers, tried in order:
+
+1. **The local cache.** Icon bytes stored in IndexedDB on this machine. A hit
+   contacts nobody at all. Entries live 30 days; "nobody has an icon for this
+   site" is remembered for a day.
+2. **The browser's own icon database**, where it exists. On Chrome that is the
+   `_favicon` API, which answers out of the browser's local store — this is the
+   first thing Chrome tries, and a hit contacts nobody. Firefox exposes no
+   equivalent an extension can read without the `tabs` permission, which this
+   extension deliberately does not request, so it has no native step.
+3. **Google's favicon service** (`t1.gstatic.com`, and `www.google.com/s2` in
+   some builds). This is the step that discloses something: Google is sent the
+   bookmark's **origin** — `https://example.com`, never the path, query or
+   fragment. Over a whole dashboard, the set of origins asked about is
+   effectively your list of bookmarked sites.
+4. **A letter placeholder**, generated locally, when everything above misses.
+
+So: an origin reaches Google only when the cache misses and no local source
+answered. In the Chrome and Firefox extensions the response's bytes are stored
+after the first successful lookup, so a given site is asked about roughly once a
+month rather than on every render. The daemon's own web app, served over
+loopback, is not allowed to read a cross-origin response, so it can display
+Google's icon but not cache it — there, a site with an icon is still fetched from
+Google on each load. Removing that last case needs the daemon to fetch icons
+itself, which is tracked separately.
+
+The daemon binds to `127.0.0.1`/`localhost` and makes no outbound request of its
+own. Every request described above is made by the browser rendering the UI.
 
 ## Development
 

--- a/src/browser/chrome/favicon.ts
+++ b/src/browser/chrome/favicon.ts
@@ -5,19 +5,35 @@ import { ChromeFaviconProvider } from "../favicon/chrome-favicon"
 const googleV2 = new GoogleFaviconV2Provider()
 const chromeFavicon = new ChromeFaviconProvider()
 
+/**
+ * Chrome asks itself first.
+ *
+ * The `_favicon` API answers out of the browser's own icon database, on the
+ * extension's own origin, so a hit tells nobody anything — and because it is
+ * same-origin, the favicon cache can read and store its bytes, which no
+ * third-party provider's response allowed before this. This order used to be
+ * the other way round, with Google primary and `_favicon` as the fallback;
+ * flipping it is the whole privacy gain on Chrome, and it is safe only because
+ * the resolver can now recognize `_favicon`'s placeholder (see
+ * `getPlaceholderProbeUrl`) and move on to Google when Chrome has nothing.
+ */
 export class ChromeFaviconAdapter implements FaviconProvider {
   getUrl(pageUrl: string): string {
+    if (chromeFavicon.isAvailable()) {
+      return chromeFavicon.getUrl(pageUrl)
+    }
     return googleV2.getUrl(pageUrl)
+  }
+
+  getFallbackUrl(pageUrl: string): string {
+    return googleV2.getUrl(pageUrl)
+  }
+
+  getPlaceholderProbeUrl(): string {
+    return chromeFavicon.getPlaceholderProbeUrl()
   }
 
   isAvailable(): boolean {
     return true
-  }
-
-  getFallbackUrl(pageUrl: string): string {
-    if (chromeFavicon.isAvailable()) {
-      return chromeFavicon.getUrl(pageUrl)
-    }
-    return ""
   }
 }

--- a/src/browser/daemon/__tests__/favicon.test.ts
+++ b/src/browser/daemon/__tests__/favicon.test.ts
@@ -92,12 +92,10 @@ describe("provider matrix", () => {
 
   const pageUrl = "https://example.com/page"
 
-  it("shares the primary Google V2 provider across every build", () => {
-    vi.stubGlobal("chrome", { runtime: { id: "abcdef" } })
+  it("shares the primary Google V2 provider everywhere there is no native one", () => {
     const primaries = [
       adapter.getUrl(pageUrl),
       new StandaloneFaviconAdapter().getUrl(pageUrl),
-      new ChromeFaviconAdapter().getUrl(pageUrl),
       new FirefoxFaviconAdapter().getUrl(pageUrl),
     ]
 
@@ -105,15 +103,25 @@ describe("provider matrix", () => {
     expect(primaries[0]).toContain("https://t1.gstatic.com/faviconV2")
   })
 
-  it("does not share the fallback: daemon goes to Google where Chrome stays on-device", () => {
+  it("does not share the primary: Chrome asks itself before it asks Google", () => {
+    vi.stubGlobal("chrome", { runtime: { id: "abcdef" } })
+
+    const chromePrimary = new ChromeFaviconAdapter().getUrl(pageUrl)
+
+    expect(chromePrimary.startsWith("chrome-extension://")).toBe(true)
+    expect(chromePrimary).not.toBe(adapter.getUrl(pageUrl))
+  })
+
+  it("does not share the fallback: daemon's second try is still Google", () => {
     vi.stubGlobal("chrome", { runtime: { id: "abcdef" } })
 
     const daemonFallback = adapter.getFallbackUrl(pageUrl)
     const chromeFallback = new ChromeFaviconAdapter().getFallbackUrl(pageUrl)
 
-    expect(daemonFallback).not.toBe(chromeFallback)
     expect(new URL(daemonFallback).hostname).toBe("www.google.com")
-    expect(chromeFallback.startsWith("chrome-extension://")).toBe(true)
+    // Chrome's second try is Google's V2 service, the one its first try —
+    // the browser's own icon database — could not answer for.
+    expect(new URL(chromeFallback).hostname).toBe("t1.gstatic.com")
   })
 
   it("does not share the fallback: Firefox makes no second attempt at all", () => {
@@ -126,7 +134,7 @@ describe("provider matrix", () => {
   })
 })
 
-describe("extension favicon behaviour is unchanged", () => {
+describe("extension favicon providers", () => {
   afterEach(() => {
     vi.unstubAllGlobals()
   })
@@ -137,23 +145,46 @@ describe("extension favicon behaviour is unchanged", () => {
     expect(firefox.getUrl("https://example.com")).toContain(
       "https://t1.gstatic.com/faviconV2"
     )
-    // Documented in the adapter: Firefox has no `_favicon` equivalent, so it
-    // deliberately offers no fallback.
+    // Documented in the adapter: Firefox has no `_favicon` equivalent, and the
+    // native source it does have needs the `tabs` permission this extension
+    // deliberately does not request. So there is still no second attempt.
     expect(
       (firefox as FirefoxFaviconAdapter & { getFallbackUrl?: unknown })
         .getFallbackUrl
     ).toBeUndefined()
   })
 
-  it("Chrome still falls back to the extension's own _favicon API", () => {
+  it("Chrome asks its own _favicon API first and Google only after", () => {
     vi.stubGlobal("chrome", { runtime: { id: "abcdef" } })
+    const chromeAdapter = new ChromeFaviconAdapter()
+
+    expect(chromeAdapter.getUrl("https://example.com")).toBe(
+      `chrome-extension://abcdef/_favicon/?pageUrl=${encodeURIComponent("https://example.com")}&size=64`
+    )
+    expect(chromeAdapter.getFallbackUrl("https://example.com")).toContain(
+      "https://t1.gstatic.com/faviconV2"
+    )
+  })
+
+  it("Chrome offers a way to recognize its own placeholder", () => {
+    vi.stubGlobal("chrome", { runtime: { id: "abcdef" } })
+
+    // Without this the cache could not store `_favicon` results at all: its
+    // miss is a valid image, so a site Chrome knows nothing about would be
+    // pinned to a generic icon instead of falling through to Google.
+    expect(new ChromeFaviconAdapter().getPlaceholderProbeUrl()).toBe(
+      `chrome-extension://abcdef/_favicon/?pageUrl=${encodeURIComponent("https://favicon-probe.invalid/")}&size=64`
+    )
+  })
+
+  it("Chrome falls back to Google as its primary when _favicon is unavailable", () => {
+    // A Chrome build loaded unprivileged — the dev server — has no
+    // `chrome.runtime`, so there is nothing on-device to ask.
     const chromeAdapter = new ChromeFaviconAdapter()
 
     expect(chromeAdapter.getUrl("https://example.com")).toContain(
       "https://t1.gstatic.com/faviconV2"
     )
-    expect(chromeAdapter.getFallbackUrl("https://example.com")).toBe(
-      `chrome-extension://abcdef/_favicon/?pageUrl=${encodeURIComponent("https://example.com")}&size=64`
-    )
+    expect(chromeAdapter.getPlaceholderProbeUrl()).toBe("")
   })
 })

--- a/src/browser/daemon/favicon.ts
+++ b/src/browser/daemon/favicon.ts
@@ -16,11 +16,19 @@ const googleFavicon = new GoogleFaviconProvider()
  * to Google, and the set of origins one client asks for is, in aggregate, that
  * user's bookmark host list.
  *
+ * The favicon cache narrows this, but does not close it, and the difference
+ * matters. Where the app runs as an extension, `host_permissions` let the
+ * resolver read Google's response and store the bytes, so an origin is
+ * disclosed roughly once a month rather than on every render. The daemon's own
+ * web app is served over loopback with no such grant: it cannot read the
+ * response, only display it, so its Google requests keep happening — the cache
+ * saves it only the requests for sites nobody has an icon for.
+ *
  * What did *not* change is the daemon itself. It still binds loopback only and
  * still makes no outbound request of its own — the disclosure is made by the
- * browser rendering the UI, not by `bookmarks-but-better`. Restoring the old no-disclosure
- * behaviour means a daemon-side proxy that fetches each site's own icon, not a
- * different third-party service.
+ * browser rendering the UI, not by `bookmarks-but-better`. Closing the gap for
+ * the served web app means a daemon-side proxy that fetches each site's own
+ * icon, not a different third-party service.
  */
 export class DaemonFaviconAdapter implements FaviconProvider {
   getUrl(pageUrl: string): string {

--- a/src/browser/favicon/cache.test.ts
+++ b/src/browser/favicon/cache.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { installFakeIndexedDB } from "../__tests__/fake-indexeddb"
+import {
+  FAVICON_MAX_ENTRIES,
+  FAVICON_MISS_TTL_MS,
+  FAVICON_TRIM_TO,
+  FAVICON_TTL_MS,
+  FaviconCache,
+  type ObjectUrlFactory,
+} from "./cache"
+
+function bytes(...values: number[]): ArrayBuffer {
+  return new Uint8Array(values).buffer
+}
+
+/** An object-URL factory that remembers what it handed out and took back. */
+function trackingUrls() {
+  const created: string[] = []
+  const revoked: string[] = []
+  let next = 0
+  const factory: ObjectUrlFactory = {
+    create: () => {
+      const url = `blob:icon-${next++}`
+      created.push(url)
+      return url
+    },
+    revoke: (url) => {
+      revoked.push(url)
+    },
+  }
+  return { factory, created, revoked }
+}
+
+let clock = 1_000_000
+
+function makeCache(objectUrls?: ObjectUrlFactory) {
+  return new FaviconCache({ now: () => clock, objectUrls })
+}
+
+beforeEach(() => {
+  installFakeIndexedDB()
+  clock = 1_000_000
+})
+
+describe("FaviconCache storage", () => {
+  it("round-trips icon bytes", async () => {
+    const cache = makeCache()
+    await cache.putIcon("https://example.com", bytes(1, 2, 3), "image/png")
+
+    const record = await cache.get("https://example.com")
+    expect(record?.mime).toBe("image/png")
+    expect(new Uint8Array(record?.bytes as ArrayBuffer)).toEqual(
+      new Uint8Array([1, 2, 3])
+    )
+  })
+
+  it("returns null for a site it has never seen", async () => {
+    const cache = makeCache()
+    expect(await cache.get("https://example.com")).toBeNull()
+  })
+
+  it("stores a negative entry with no bytes", async () => {
+    const cache = makeCache()
+    await cache.putMiss("https://example.com")
+
+    const record = await cache.get("https://example.com")
+    expect(record).not.toBeNull()
+    expect(record?.bytes).toBeUndefined()
+  })
+})
+
+describe("FaviconCache expiry", () => {
+  it("serves an icon right up to the TTL and not past it", async () => {
+    const cache = makeCache()
+    await cache.putIcon("https://example.com", bytes(1), "image/png")
+
+    clock += FAVICON_TTL_MS - 1
+    expect(await cache.get("https://example.com")).not.toBeNull()
+
+    clock += 1
+    expect(await cache.get("https://example.com")).toBeNull()
+  })
+
+  it("expires a negative entry far sooner than an icon", async () => {
+    const cache = makeCache()
+    await cache.putMiss("https://nothing.example")
+    await cache.putIcon("https://example.com", bytes(1), "image/png")
+
+    clock += FAVICON_MISS_TTL_MS
+    expect(await cache.get("https://nothing.example")).toBeNull()
+    // A site that once had no icon can get one; a site that had one keeps it.
+    expect(await cache.get("https://example.com")).not.toBeNull()
+  })
+})
+
+describe("FaviconCache object URLs", () => {
+  it("creates one URL per site and reuses it", () => {
+    const { factory, created } = trackingUrls()
+    const cache = makeCache(factory)
+    const record = {
+      key: "https://example.com",
+      storedAt: clock,
+      bytes: bytes(1),
+      mime: "image/png",
+    }
+
+    expect(cache.materialize(record)).toBe(cache.materialize(record))
+    expect(created).toHaveLength(1)
+  })
+
+  it("hands out nothing for a negative record", () => {
+    const { factory, created } = trackingUrls()
+    const cache = makeCache(factory)
+
+    expect(
+      cache.materialize({ key: "https://a.example", storedAt: clock })
+    ).toBe("")
+    expect(created).toHaveLength(0)
+  })
+
+  it("revokes a site's URL when its record is replaced", async () => {
+    const { factory, created, revoked } = trackingUrls()
+    const cache = makeCache(factory)
+
+    const first = await cache.putIcon(
+      "https://a.example",
+      bytes(1),
+      "image/png"
+    )
+    const firstUrl = cache.materialize(first)
+    const second = await cache.putIcon(
+      "https://a.example",
+      bytes(2),
+      "image/png"
+    )
+    const secondUrl = cache.materialize(second)
+
+    expect(revoked).toEqual([firstUrl])
+    expect(secondUrl).not.toBe(firstUrl)
+    expect(created).toHaveLength(2)
+  })
+
+  it("revokes a site's URL when the record turns negative", async () => {
+    const { factory, revoked } = trackingUrls()
+    const cache = makeCache(factory)
+
+    const record = await cache.putIcon(
+      "https://a.example",
+      bytes(1),
+      "image/png"
+    )
+    const url = cache.materialize(record)
+    await cache.putMiss("https://a.example")
+
+    expect(revoked).toEqual([url])
+  })
+})
+
+describe("FaviconCache eviction", () => {
+  it("trims the oldest entries once the ceiling is passed, and revokes their URLs", async () => {
+    const { factory, revoked } = trackingUrls()
+    const cache = makeCache(factory)
+
+    for (let i = 0; i < FAVICON_MAX_ENTRIES; i += 1) {
+      clock += 1
+      const record = await cache.putIcon(
+        `https://site-${i}.example`,
+        bytes(i % 256),
+        "image/png"
+      )
+      // Only the oldest entry is rendering, so only its URL should come back.
+      if (i === 0) cache.materialize(record)
+    }
+
+    // Still full, nothing evicted: the ceiling has not been passed yet.
+    expect(await cache.get("https://site-0.example")).not.toBeNull()
+    expect(revoked).toHaveLength(0)
+
+    clock += 1
+    await cache.putIcon("https://one-too-many.example", bytes(9), "image/png")
+
+    // The trim takes the cache down to FAVICON_TRIM_TO, oldest first.
+    const evictedCount = FAVICON_MAX_ENTRIES + 1 - FAVICON_TRIM_TO
+    expect(await cache.get("https://site-0.example")).toBeNull()
+    expect(
+      await cache.get(`https://site-${evictedCount - 1}.example`)
+    ).toBeNull()
+    expect(
+      await cache.get(`https://site-${evictedCount}.example`)
+    ).not.toBeNull()
+    expect(await cache.get("https://one-too-many.example")).not.toBeNull()
+
+    // The evicted site's live object URL went with it.
+    expect(revoked).toHaveLength(1)
+  })
+})

--- a/src/browser/favicon/cache.ts
+++ b/src/browser/favicon/cache.ts
@@ -1,0 +1,246 @@
+/**
+ * The local favicon cache: image *bytes*, in IndexedDB, keyed by site.
+ *
+ * Caching the bytes rather than a provider URL is the whole point. A cached
+ * URL still costs a request to a third party on every render, which is exactly
+ * what makes favicons the one place this product routinely tells someone else
+ * which sites a user has bookmarked. Bytes in IndexedDB render entirely
+ * locally, work offline, and survive a reload.
+ *
+ * Negative entries (a record with no bytes) matter just as much. A site that
+ * has no icon anywhere would otherwise pay one or two failed external requests
+ * on every single render, forever. Remembering "nobody could answer for this
+ * site" turns that into one lookup a day and shows the letter placeholder
+ * instantly.
+ *
+ * Storage is IndexedDB, the same store family the profile preferences and the
+ * standalone source already use, in its own database so that clearing or
+ * corrupting icons can never touch bookmarks or preferences. Bytes are held as
+ * `ArrayBuffer` rather than `Blob`: an `ArrayBuffer` is structured-cloneable
+ * everywhere, including in the test IndexedDB, and the `Blob` is rebuilt at the
+ * moment an object URL is needed.
+ */
+
+/**
+ * How long a cached icon is served without asking anyone again.
+ *
+ * Thirty days. Favicons change on the order of a rebrand, and the cost of
+ * staleness is a month of a slightly old icon; the cost of a short TTL is
+ * paid in third-party requests by every user on every expiry. A daily user
+ * ends up disclosing an origin about twelve times a year instead of hundreds.
+ */
+export const FAVICON_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+/**
+ * How long "no provider could answer for this site" is believed.
+ *
+ * One day, far shorter than a hit. A negative entry is a claim about the
+ * *world* — that the site has no icon, or that Google only offered its generic
+ * globe — and that claim goes stale the moment the site adds a favicon. A day
+ * is short enough that a newly added icon appears the next time the dashboard
+ * is opened tomorrow, and long enough to stop the repeated failed request.
+ */
+export const FAVICON_MISS_TTL_MS = 24 * 60 * 60 * 1000
+
+/**
+ * The entry ceiling, and the level a trim brings the cache back down to.
+ *
+ * A thousand entries is roughly a thousand distinct sites — more than the
+ * distinct-origin count of even a very large bookmark collection — and at the
+ * few kilobytes a favicon weighs it lands around 2-5 MB, comfortably inside any
+ * IndexedDB quota. Trimming to 900 rather than to the ceiling means a full
+ * cache runs one eviction pass per hundred inserts instead of one per insert.
+ */
+export const FAVICON_MAX_ENTRIES = 1000
+export const FAVICON_TRIM_TO = 900
+
+/**
+ * The largest single icon that is worth storing. Anything past a quarter of a
+ * megabyte is not a favicon — it is a provider handing back a full-size image —
+ * and one such response should not be allowed to dominate the cache.
+ */
+export const FAVICON_MAX_BYTES = 256 * 1024
+
+const DB_NAME = "bookmarks-but-better-favicons"
+const DB_VERSION = 1
+const STORE_NAME = "icons"
+const STORED_AT_INDEX = "storedAt"
+
+export interface FaviconRecord {
+  /** The normalized site key, and the store's primary key. */
+  key: string
+  storedAt: number
+  /** Absent on a negative entry: nobody could answer for this site. */
+  bytes?: ArrayBuffer
+  mime?: string
+}
+
+/**
+ * Creating and revoking object URLs, injectable because neither jsdom nor Node
+ * implements them and the tests need to observe that every URL handed out is
+ * eventually revoked.
+ */
+export interface ObjectUrlFactory {
+  create(blob: Blob): string
+  revoke(url: string): void
+}
+
+const defaultObjectUrls: ObjectUrlFactory = {
+  create: (blob) => URL.createObjectURL(blob),
+  revoke: (url) => URL.revokeObjectURL(url),
+}
+
+export interface FaviconCacheOptions {
+  now?: () => number
+  objectUrls?: ObjectUrlFactory
+}
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION)
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: "key" })
+        // Eviction walks this index oldest-first. It is the only ordering the
+        // cache needs, because entries expire in the same order they evict.
+        store.createIndex(STORED_AT_INDEX, "storedAt")
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+}
+
+export class FaviconCache {
+  private db: IDBDatabase | null = null
+  private readonly now: () => number
+  private readonly objectUrls: ObjectUrlFactory
+
+  /**
+   * The live object URL per site key.
+   *
+   * One URL per *site*, created lazily and reused by every bookmark on that
+   * site, for as long as its record stands. The alternative — an object URL per
+   * `<img>` — leaks one blob per bookmark per render, which would cost more
+   * memory than the cache saves in requests. A URL is revoked as soon as its
+   * record stops being the truth: replaced, evicted, or invalidated.
+   */
+  private readonly liveUrls = new Map<string, string>()
+
+  constructor(options: FaviconCacheOptions = {}) {
+    this.now = options.now ?? Date.now
+    this.objectUrls = options.objectUrls ?? defaultObjectUrls
+  }
+
+  private async getDB(): Promise<IDBDatabase> {
+    if (!this.db) {
+      this.db = await openDB()
+    }
+    return this.db
+  }
+
+  /**
+   * The fresh record for a site, or `null` when there is none.
+   *
+   * An expired record reads as `null` and is left in place rather than deleted:
+   * a stale read is always followed by a write for the same key, so deleting
+   * here would only add a transaction. Whatever is never re-resolved is
+   * eventually evicted by age.
+   */
+  async get(key: string): Promise<FaviconRecord | null> {
+    const db = await this.getDB()
+    const record = await new Promise<FaviconRecord | undefined>(
+      (resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, "readonly")
+        const request = tx.objectStore(STORE_NAME).get(key)
+        request.onsuccess = () =>
+          resolve(request.result as FaviconRecord | undefined)
+        request.onerror = () => reject(request.error)
+      }
+    )
+
+    if (!record) return null
+    const ttl = record.bytes ? FAVICON_TTL_MS : FAVICON_MISS_TTL_MS
+    if (this.now() - record.storedAt >= ttl) return null
+    return record
+  }
+
+  /** Stores icon bytes for a site, replacing whatever was there. */
+  async putIcon(
+    key: string,
+    bytes: ArrayBuffer,
+    mime: string
+  ): Promise<FaviconRecord> {
+    const record: FaviconRecord = { key, storedAt: this.now(), bytes, mime }
+    await this.write(record)
+    return record
+  }
+
+  /** Records that no provider could answer for this site. */
+  async putMiss(key: string): Promise<void> {
+    await this.write({ key, storedAt: this.now() })
+  }
+
+  private async write(record: FaviconRecord): Promise<void> {
+    const db = await this.getDB()
+    // The record being replaced may already be rendering somewhere; its URL is
+    // no longer the truth, so it goes with the old bytes.
+    this.releaseUrl(record.key)
+
+    const evicted: string[] = []
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, "readwrite")
+      const store = tx.objectStore(STORE_NAME)
+      store.put(record)
+
+      const countRequest = store.count()
+      countRequest.onsuccess = () => {
+        let remaining = countRequest.result - FAVICON_TRIM_TO
+        if (remaining <= 0 || countRequest.result <= FAVICON_MAX_ENTRIES) return
+
+        const cursorRequest = store.index(STORED_AT_INDEX).openCursor()
+        cursorRequest.onsuccess = () => {
+          const cursor = cursorRequest.result
+          if (!cursor || remaining <= 0) return
+          evicted.push(cursor.primaryKey as string)
+          cursor.delete()
+          remaining -= 1
+          cursor.continue()
+        }
+      }
+
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+      tx.onabort = () => reject(tx.error)
+    })
+
+    for (const key of evicted) this.releaseUrl(key)
+  }
+
+  /**
+   * A URL the UI can put in an `<img>`, for a record that has bytes.
+   *
+   * Returns `""` for a negative record, which is the signal the letter
+   * placeholder is built from.
+   */
+  materialize(record: FaviconRecord): string {
+    if (!record.bytes) return ""
+    const existing = this.liveUrls.get(record.key)
+    if (existing) return existing
+
+    const url = this.objectUrls.create(
+      new Blob([record.bytes], { type: record.mime || "image/png" })
+    )
+    this.liveUrls.set(record.key, url)
+    return url
+  }
+
+  /** Drops a site's object URL, if one is live. */
+  releaseUrl(key: string): void {
+    const url = this.liveUrls.get(key)
+    if (!url) return
+    this.liveUrls.delete(key)
+    this.objectUrls.revoke(url)
+  }
+}

--- a/src/browser/favicon/chrome-favicon.ts
+++ b/src/browser/favicon/chrome-favicon.ts
@@ -1,10 +1,23 @@
 import type { FaviconProvider } from "./types"
 
+/**
+ * A host Chrome cannot have an icon for, used to sample the `_favicon`
+ * placeholder. `.invalid` is reserved by RFC 2606 and can never be registered,
+ * and the request itself never leaves the machine — `_favicon` is served by the
+ * extension's own origin out of the browser's local icon database.
+ */
+const PLACEHOLDER_PROBE_PAGE = "https://favicon-probe.invalid/"
+
 export class ChromeFaviconProvider implements FaviconProvider {
   getUrl(pageUrl: string): string {
     // MV3 requires using _favicon API with the extension's own origin
     const extensionId = chrome.runtime.id
     return `chrome-extension://${extensionId}/_favicon/?pageUrl=${encodeURIComponent(pageUrl)}&size=64`
+  }
+
+  getPlaceholderProbeUrl(): string {
+    if (!this.isAvailable()) return ""
+    return this.getUrl(PLACEHOLDER_PROBE_PAGE)
   }
 
   isAvailable(): boolean {

--- a/src/browser/favicon/detect-default-globe.ts
+++ b/src/browser/favicon/detect-default-globe.ts
@@ -8,7 +8,14 @@ const GOOGLE_FAVICON_HOSTS = [
   "https://www.google.com/s2/favicons",
 ]
 
-function isGoogleFaviconUrl(url: string): boolean {
+/**
+ * Whether a URL is one of Google's favicon endpoints.
+ *
+ * Exported because the globe check below is the only reason the resolver ever
+ * decodes an icon's dimensions, and decoding every icon to ask a question that
+ * can only be true for these five prefixes would be waste.
+ */
+export function isGoogleFaviconUrl(url: string): boolean {
   return GOOGLE_FAVICON_HOSTS.some((prefix) => url.startsWith(prefix))
 }
 

--- a/src/browser/favicon/key.test.ts
+++ b/src/browser/favicon/key.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import { normalizeFaviconKey } from "./key"
+
+describe("normalizeFaviconKey", () => {
+  it("keeps scheme and host and drops everything below the site", () => {
+    expect(normalizeFaviconKey("https://example.com/deep/page?q=1#x")).toBe(
+      "https://example.com"
+    )
+  })
+
+  it("gives every page on one site the same key", () => {
+    expect(normalizeFaviconKey("https://example.com/a")).toBe(
+      normalizeFaviconKey("https://example.com/b")
+    )
+  })
+
+  it("lowercases the host", () => {
+    expect(normalizeFaviconKey("https://EXAMPLE.com")).toBe(
+      "https://example.com"
+    )
+  })
+
+  it("keys an IDN by its Punycode form, so both spellings share an entry", () => {
+    expect(normalizeFaviconKey("https://bücher.example")).toBe(
+      "https://xn--bcher-kva.example"
+    )
+    expect(normalizeFaviconKey("https://xn--bcher-kva.example/page")).toBe(
+      "https://xn--bcher-kva.example"
+    )
+  })
+
+  it("strips the fully-qualified trailing dot", () => {
+    expect(normalizeFaviconKey("https://example.com./page")).toBe(
+      "https://example.com"
+    )
+  })
+
+  it("drops a default port but keeps a non-default one", () => {
+    expect(normalizeFaviconKey("https://example.com:443/")).toBe(
+      "https://example.com"
+    )
+    expect(normalizeFaviconKey("http://example.com:80/")).toBe(
+      "http://example.com"
+    )
+    expect(normalizeFaviconKey("http://localhost:3000/")).toBe(
+      "http://localhost:3000"
+    )
+  })
+
+  it("separates ports, which can serve different icons", () => {
+    expect(normalizeFaviconKey("http://localhost:3000/")).not.toBe(
+      normalizeFaviconKey("http://localhost:8080/")
+    )
+  })
+
+  it("separates schemes, which are different origins", () => {
+    expect(normalizeFaviconKey("http://example.com")).not.toBe(
+      normalizeFaviconKey("https://example.com")
+    )
+  })
+
+  it("ignores credentials in the URL", () => {
+    expect(normalizeFaviconKey("https://user:pw@example.com/x")).toBe(
+      "https://example.com"
+    )
+  })
+
+  it("refuses anything no provider could answer for", () => {
+    expect(normalizeFaviconKey("not a url")).toBeNull()
+    expect(normalizeFaviconKey("")).toBeNull()
+    expect(normalizeFaviconKey("file:///Users/me/private.html")).toBeNull()
+    expect(normalizeFaviconKey("about:blank")).toBeNull()
+    expect(normalizeFaviconKey("javascript:void 0")).toBeNull()
+    expect(normalizeFaviconKey("chrome://bookmarks")).toBeNull()
+  })
+})

--- a/src/browser/favicon/key.ts
+++ b/src/browser/favicon/key.ts
@@ -1,0 +1,55 @@
+/**
+ * The cache key for a bookmark's favicon.
+ *
+ * Favicons are a property of a *site*, not of a page: ten bookmarks under
+ * `https://example.com/...` share one icon, and keying anything finer would
+ * make the cache miss on every deep link. So the key is scheme + host + port,
+ * and everything below it — path, query, fragment, credentials — is discarded
+ * before the key is built.
+ *
+ * The three normalizations worth naming, because each one silently merges
+ * entries that would otherwise be separate:
+ *
+ * - **Case and IDN.** `URL` lowercases the host and converts an
+ *   internationalized name to its Punycode A-label, so `https://BÜCHER.example`
+ *   and `https://xn--bcher-kva.example` produce one key. That is correct: they
+ *   are the same origin, and the A-label is what any provider is asked for.
+ * - **Port.** `URL` drops a port that is the scheme's default, so
+ *   `https://example.com:443` and `https://example.com` share a key, while
+ *   `http://localhost:3000` and `http://localhost:8080` do not. Two ports on
+ *   one host really can serve different icons.
+ * - **Trailing dot.** `example.com.` is the fully-qualified spelling of
+ *   `example.com`; `URL` keeps the dot, so it is stripped here.
+ *
+ * Scheme is *not* normalized away. `http://` and `https://` are different
+ * origins and a site may serve different icons on each, so they get separate
+ * entries even though Google's `s2` provider would answer both from one
+ * hostname.
+ */
+
+/**
+ * The scheme + host + port key for a page URL, or `null` when the page can
+ * have no favicon at all.
+ *
+ * `null` is returned for anything that is not HTTP(S) — an unparsable string, a
+ * `file:` or `about:` or `javascript:` URL — because no favicon provider can
+ * answer for those, and asking one would send a meaningless (and in the case of
+ * a `file:` path, private) string to a third party.
+ */
+export function normalizeFaviconKey(pageUrl: string): string | null {
+  let url: URL
+  try {
+    url = new URL(pageUrl)
+  } catch {
+    return null
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null
+
+  const host = url.hostname.replace(/\.$/, "")
+  if (!host) return null
+
+  return url.port
+    ? `${url.protocol}//${host}:${url.port}`
+    : `${url.protocol}//${host}`
+}

--- a/src/browser/favicon/resolve.test.ts
+++ b/src/browser/favicon/resolve.test.ts
@@ -1,0 +1,439 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { installFakeIndexedDB } from "../__tests__/fake-indexeddb"
+import { ChromeFaviconAdapter } from "../chrome/favicon"
+import { StandaloneFaviconAdapter } from "../standalone/favicon"
+import { FaviconCache, type ObjectUrlFactory } from "./cache"
+import { FaviconResolver } from "./resolve"
+
+/**
+ * The provider order these tests drive is the real one. `StandaloneFaviconAdapter`
+ * is Google V2 then Google s2 — the order daemon, standalone and the served web
+ * app all use — and `ChromeFaviconAdapter` is the extension's own `_favicon`
+ * first. Building the resolver against fakes would have let the two get out of
+ * step silently.
+ */
+
+const V2_HOST = "https://t1.gstatic.com/faviconV2"
+const S2_HOST = "https://www.google.com/s2/favicons"
+const NATIVE_HOST = "chrome-extension://extid/_favicon/"
+const EXTENSION_ORIGIN = "chrome-extension://extid"
+
+/** The probe page is a host Chrome cannot know; see `chrome-favicon.ts`. */
+const PROBE = `${NATIVE_HOST}?pageUrl=${encodeURIComponent("https://favicon-probe.invalid/")}&size=64`
+
+function icon(...values: number[]): Response {
+  return new Response(new Uint8Array(values), {
+    status: 200,
+    headers: { "content-type": "image/png" },
+  })
+}
+
+function missing(): Response {
+  return new Response(null, { status: 404 })
+}
+
+/**
+ * Routes by URL prefix, and *rejects* for anything unrouted — which is what a
+ * fetch this build is not allowed to read actually does.
+ */
+function router(routes: Array<[string, () => Response]>) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    const route = routes.find(([prefix]) => url.startsWith(prefix))
+    if (!route) throw new TypeError("Failed to fetch")
+    return route[1]()
+  })
+}
+
+/** Decodes the first byte as the icon's square size, so 16 is Google's globe. */
+async function decode(bytes: ArrayBuffer) {
+  const size = new Uint8Array(bytes)[0]
+  return { width: size, height: size }
+}
+
+const objectUrls: ObjectUrlFactory = (() => {
+  let next = 0
+  return { create: () => `blob:icon-${next++}`, revoke: () => {} }
+})()
+
+function build(
+  fetchImpl: ReturnType<typeof router>,
+  pageOrigin = "http://127.0.0.1:52222"
+) {
+  const cache = new FaviconCache({ objectUrls })
+  const resolver = new FaviconResolver({
+    cache,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+    decode,
+    pageOrigin,
+  })
+  return { cache, resolver }
+}
+
+const google = new StandaloneFaviconAdapter()
+
+beforeEach(() => {
+  installFakeIndexedDB()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("cache hits", () => {
+  it("serves stored bytes without contacting any provider", async () => {
+    const fetchImpl = router([[V2_HOST, () => icon(64)]])
+    const { cache, resolver } = build(fetchImpl)
+    await cache.putIcon(
+      "https://example.com",
+      new Uint8Array([64]).buffer,
+      "image/png"
+    )
+
+    const { sources } = await resolver.resolve(
+      "https://example.com/page",
+      google
+    )
+
+    expect(sources).toHaveLength(1)
+    expect(sources[0].startsWith("blob:")).toBe(true)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it("stores a provider's bytes so the second load is fully local", async () => {
+    const fetchImpl = router([[V2_HOST, () => icon(64)]])
+    const { resolver } = build(fetchImpl)
+
+    const first = await resolver.resolve("https://example.com/a", google)
+    const second = await resolver.resolve("https://example.com/b", google)
+
+    expect(first.sources[0].startsWith("blob:")).toBe(true)
+    expect(second.sources).toEqual(first.sources)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("deduplication", () => {
+  it("makes one lookup for many bookmarks mounting on one site at once", async () => {
+    const fetchImpl = router([[V2_HOST, () => icon(64)]])
+    const { resolver } = build(fetchImpl)
+
+    const pages = [
+      "https://example.com/one",
+      "https://example.com/two",
+      "https://example.com/three?q=1",
+      "https://EXAMPLE.com/four",
+    ]
+    const results = await Promise.all(
+      pages.map((page) => resolver.resolve(page, google))
+    )
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    for (const result of results) {
+      expect(result.sources).toEqual(results[0].sources)
+    }
+  })
+
+  it("does not merge lookups for different sites", async () => {
+    const fetchImpl = router([[V2_HOST, () => icon(64)]])
+    const { resolver } = build(fetchImpl)
+
+    await Promise.all([
+      resolver.resolve("https://a.example/", google),
+      resolver.resolve("https://b.example/", google),
+    ])
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("Google's default globe", () => {
+  it("never caches the globe, and ends at the placeholder", async () => {
+    const fetchImpl = router([
+      [V2_HOST, () => icon(16)],
+      [S2_HOST, () => icon(16)],
+    ])
+    const { cache, resolver } = build(fetchImpl)
+
+    const { sources } = await resolver.resolve("https://globe.example/", google)
+
+    expect(sources).toEqual([])
+    const record = await cache.get("https://globe.example")
+    expect(record).not.toBeNull()
+    expect(record?.bytes).toBeUndefined()
+  })
+
+  it("keeps the globe out of the cache permanently, not just this render", async () => {
+    const fetchImpl = router([
+      [V2_HOST, () => icon(16)],
+      [S2_HOST, () => icon(16)],
+    ])
+    const { resolver } = build(fetchImpl)
+
+    await resolver.resolve("https://globe.example/", google)
+    const again = await resolver.resolve("https://globe.example/other", google)
+
+    // The negative entry answered; no provider was asked a second time.
+    expect(again.sources).toEqual([])
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it("stores a Google response that is not the globe", async () => {
+    const fetchImpl = router([[V2_HOST, () => icon(64)]])
+    const { cache, resolver } = build(fetchImpl)
+
+    await resolver.resolve("https://real.example/", google)
+
+    const record = await cache.get("https://real.example")
+    expect(new Uint8Array(record?.bytes as ArrayBuffer)).toEqual(
+      new Uint8Array([64])
+    )
+  })
+
+  it("hands the URL to the browser when it cannot measure the bytes itself", async () => {
+    const fetchImpl = router([[V2_HOST, () => icon(16)]])
+    const cache = new FaviconCache({ objectUrls })
+    const resolver = new FaviconResolver({
+      cache,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      decode: async () => null,
+      pageOrigin: "http://127.0.0.1:52222",
+    })
+
+    const { sources } = await resolver.resolve("https://example.com/", google)
+
+    // Unverifiable is not "icon": the bytes are not stored, and the `<img>`
+    // gets the URL so its own globe check can run, exactly as it always did.
+    expect(sources[0].startsWith(V2_HOST)).toBe(true)
+    expect(await cache.get("https://example.com")).toBeNull()
+  })
+})
+
+describe("providers this build may not read", () => {
+  it("falls back to the provider URLs when the bytes are not readable", async () => {
+    const fetchImpl = router([])
+    const { resolver } = build(fetchImpl)
+
+    const { sources } = await resolver.resolve("https://example.com/", google)
+
+    expect(sources).toHaveLength(2)
+    expect(sources[0].startsWith(V2_HOST)).toBe(true)
+    expect(sources[1].startsWith(S2_HOST)).toBe(true)
+  })
+
+  it("learns the limitation once instead of per bookmark", async () => {
+    const fetchImpl = router([])
+    const { resolver } = build(fetchImpl)
+
+    await resolver.resolve("https://a.example/", google)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+
+    await resolver.resolve("https://b.example/", google)
+    await resolver.resolve("https://c.example/", google)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it("writes no cache entry it could not verify", async () => {
+    const fetchImpl = router([])
+    const { cache, resolver } = build(fetchImpl)
+
+    await resolver.resolve("https://example.com/", google)
+
+    expect(await cache.get("https://example.com")).toBeNull()
+  })
+})
+
+describe("provider misses", () => {
+  it("moves to the fallback provider when the first has nothing", async () => {
+    const fetchImpl = router([
+      [V2_HOST, () => missing()],
+      [S2_HOST, () => icon(32)],
+    ])
+    const { cache, resolver } = build(fetchImpl)
+
+    const { sources } = await resolver.resolve("https://example.com/", google)
+
+    expect(sources[0].startsWith("blob:")).toBe(true)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(await cache.get("https://example.com")).not.toBeNull()
+  })
+
+  it("ends at the placeholder and remembers it when every provider misses", async () => {
+    const fetchImpl = router([
+      [V2_HOST, () => missing()],
+      [S2_HOST, () => missing()],
+    ])
+    const { resolver } = build(fetchImpl)
+
+    expect(
+      (await resolver.resolve("https://nothing.example/", google)).sources
+    ).toEqual([])
+
+    const again = await resolver.resolve("https://nothing.example/page", google)
+    expect(again.sources).toEqual([])
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it("refuses a response too large to be a favicon", async () => {
+    const oversized = new Uint8Array(300 * 1024)
+    oversized[0] = 64
+    const fetchImpl = router([
+      [
+        V2_HOST,
+        () =>
+          new Response(oversized, {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          }),
+      ],
+      [S2_HOST, () => icon(32)],
+    ])
+    const { cache, resolver } = build(fetchImpl)
+
+    await resolver.resolve("https://huge.example/", google)
+
+    const record = await cache.get("https://huge.example")
+    expect(record?.bytes?.byteLength).toBe(1)
+  })
+
+  it("reports a page no provider can answer for without asking anyone", async () => {
+    const fetchImpl = router([[V2_HOST, () => icon(64)]])
+    const { resolver } = build(fetchImpl)
+
+    expect((await resolver.resolve("not a url", google)).sources).toEqual([])
+    expect(
+      (await resolver.resolve("file:///Users/me/notes.html", google)).sources
+    ).toEqual([])
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe("a native provider the extension serves itself", () => {
+  beforeEach(() => {
+    vi.stubGlobal("chrome", { runtime: { id: "extid" } })
+  })
+
+  const chrome = new ChromeFaviconAdapter()
+
+  it("prefers the native source and never contacts Google when it answers", async () => {
+    const fetchImpl = router([
+      [PROBE, () => icon(9, 9, 9)],
+      [NATIVE_HOST, () => icon(64, 1, 2)],
+      [V2_HOST, () => icon(64)],
+    ])
+    const { cache, resolver } = build(fetchImpl, EXTENSION_ORIGIN)
+
+    const { sources } = await resolver.resolve("https://example.com/", chrome)
+
+    expect(sources[0].startsWith("blob:")).toBe(true)
+    expect(
+      fetchImpl.mock.calls.some(([url]) => String(url).startsWith(V2_HOST))
+    ).toBe(false)
+    expect(
+      new Uint8Array(
+        (await cache.get("https://example.com"))?.bytes as ArrayBuffer
+      )
+    ).toEqual(new Uint8Array([64, 1, 2]))
+  })
+
+  it("recognizes the native placeholder and goes to Google instead", async () => {
+    const fetchImpl = router([
+      [PROBE, () => icon(9, 9, 9)],
+      [NATIVE_HOST, () => icon(9, 9, 9)],
+      [V2_HOST, () => icon(64)],
+    ])
+    const { cache, resolver } = build(fetchImpl, EXTENSION_ORIGIN)
+
+    await resolver.resolve("https://unknown.example/", chrome)
+
+    // The placeholder was not stored — Google's real icon was.
+    expect(
+      new Uint8Array(
+        (await cache.get("https://unknown.example"))?.bytes as ArrayBuffer
+      )
+    ).toEqual(new Uint8Array([64]))
+  })
+
+  it("samples the placeholder once for the whole session", async () => {
+    const fetchImpl = router([
+      [PROBE, () => icon(9, 9, 9)],
+      [NATIVE_HOST, () => icon(64, 1)],
+    ])
+    const { resolver } = build(fetchImpl, EXTENSION_ORIGIN)
+
+    await resolver.resolve("https://a.example/", chrome)
+    await resolver.resolve("https://b.example/", chrome)
+    await resolver.resolve("https://c.example/", chrome)
+
+    const probeCalls = fetchImpl.mock.calls.filter(
+      ([url]) => String(url) === PROBE
+    )
+    expect(probeCalls).toHaveLength(1)
+  })
+
+  it("skips the native source entirely when the placeholder cannot be sampled", async () => {
+    const fetchImpl = router([
+      [`${NATIVE_HOST}?pageUrl=https%3A%2F%2Fexample.com`, () => icon(1, 2)],
+      [V2_HOST, () => icon(64)],
+    ])
+    const { cache, resolver } = build(fetchImpl, EXTENSION_ORIGIN)
+
+    await resolver.resolve("https://example.com/", chrome)
+
+    // Without a sample a native response cannot be told from a placeholder, so
+    // it is dropped rather than cached as if it were the site's icon.
+    expect(
+      new Uint8Array(
+        (await cache.get("https://example.com"))?.bytes as ArrayBuffer
+      )
+    ).toEqual(new Uint8Array([64]))
+  })
+})
+
+describe("misses reported by the UI", () => {
+  it("remembers a source that only failed once the browser rendered it", async () => {
+    const fetchImpl = router([])
+    const { resolver } = build(fetchImpl)
+
+    const first = await resolver.resolve("https://example.com/", google)
+    expect(first.sources).toHaveLength(2)
+
+    await resolver.reportMiss("https://example.com/page")
+
+    expect(
+      (await resolver.resolve("https://example.com/", google)).sources
+    ).toEqual([])
+  })
+
+  it("ignores a page that has no key", async () => {
+    const { resolver } = build(router([]))
+    await expect(resolver.reportMiss("not a url")).resolves.toBeUndefined()
+  })
+})
+
+describe("failure tolerance", () => {
+  it("still shows the icon when the cache itself is unusable", async () => {
+    const fetchImpl = router([[V2_HOST, () => icon(64)]])
+    const { resolver } = build(fetchImpl)
+    // No IndexedDB at all: a profile with storage locked down.
+    vi.stubGlobal("indexedDB", undefined)
+
+    const { sources } = await resolver.resolve("https://example.com/", google)
+
+    expect(sources[0].startsWith("blob:")).toBe(true)
+  })
+
+  it("still shows the letter when the cache is unusable and nobody answers", async () => {
+    const { resolver } = build(
+      router([
+        [V2_HOST, () => missing()],
+        [S2_HOST, () => missing()],
+      ])
+    )
+    vi.stubGlobal("indexedDB", undefined)
+
+    expect(
+      (await resolver.resolve("https://nothing.example/", google)).sources
+    ).toEqual([])
+  })
+})

--- a/src/browser/favicon/resolve.ts
+++ b/src/browser/favicon/resolve.ts
@@ -1,0 +1,370 @@
+/**
+ * Resolving one bookmark's favicon: cache, then the platform's providers in
+ * order, then the letter placeholder.
+ *
+ * The provider order itself belongs to the source's `FaviconProvider` — this
+ * module never names a browser. What it adds around that order is the three
+ * things a per-card `<img src>` could not do:
+ *
+ * 1. **Bytes.** A provider response whose bytes this build is allowed to read
+ *    is stored locally, and every later render of that site is fully local.
+ * 2. **One lookup per site.** Ten bookmarks on one origin mounting together
+ *    share a single resolution, not ten.
+ * 3. **A verdict.** "Nobody has an icon for this site" is remembered, so the
+ *    failed request is not repeated on every render.
+ *
+ * Whether a provider's bytes can be read is a Platform Capability discovered at
+ * runtime, not a browser name. A `fetch` that *rejects* means this build has no
+ * CORS grant for that origin — true for Google from the daemon web app, false
+ * for Google from the extensions, which declare it in `host_permissions`. The
+ * origin is remembered as opaque so the remaining bookmarks do not each pay a
+ * doomed request, and its URL is handed to the `<img>` instead, which loads it
+ * fine: the response allows cross-origin *embedding*, just not *reading*.
+ */
+
+import type { FaviconProvider } from "../types"
+import { FAVICON_MAX_BYTES, FaviconCache, type FaviconRecord } from "./cache"
+import {
+  isGoogleDefaultGlobe,
+  isGoogleFaviconUrl,
+} from "./detect-default-globe"
+import { normalizeFaviconKey } from "./key"
+
+export interface FaviconResolution {
+  /**
+   * Ordered image sources for the `<img>`, most-preferred first.
+   *
+   * A single `blob:` URL when the cache answered, in which case nothing
+   * external is contacted at all. Otherwise the provider URLs still worth
+   * trying in the browser, in provider order. Empty means the letter
+   * placeholder: either no provider can answer for this page, or all of them
+   * have already been asked and missed.
+   */
+  sources: string[]
+}
+
+const NO_SOURCES: FaviconResolution = { sources: [] }
+
+interface ImageSize {
+  width: number
+  height: number
+}
+
+export interface FaviconResolverOptions {
+  cache?: FaviconCache
+  fetchImpl?: typeof fetch
+  /** Decodes an icon's intrinsic size, or `null` when it cannot be decoded. */
+  decode?: (bytes: ArrayBuffer, mime: string) => Promise<ImageSize | null>
+  /** The document's own origin, used to spot a provider we serve ourselves. */
+  pageOrigin?: string
+}
+
+/**
+ * Decodes intrinsic dimensions through `createImageBitmap`, the one decoder
+ * available without a DOM. A `null` answer is not a failure — it means "this
+ * build cannot measure the icon", and the caller degrades to letting the
+ * `<img>` measure it after load, exactly as the UI did before this cache.
+ */
+async function decodeImageSize(
+  bytes: ArrayBuffer,
+  mime: string
+): Promise<ImageSize | null> {
+  if (typeof createImageBitmap !== "function") return null
+  try {
+    const bitmap = await createImageBitmap(new Blob([bytes], { type: mime }))
+    const size = { width: bitmap.width, height: bitmap.height }
+    bitmap.close()
+    return size
+  } catch {
+    return null
+  }
+}
+
+function currentOrigin(): string {
+  return typeof location === "undefined" ? "" : originOf(location.href)
+}
+
+/**
+ * The origin of a URL, spelled out rather than taken from `URL.origin`.
+ *
+ * `URL.origin` is `"null"` for any scheme the URL parser does not know as
+ * special, which includes `chrome-extension:` outside a browser that registered
+ * it — so the one provider served on the extension's own origin would compare
+ * equal to every other unknown-scheme URL. Scheme plus host is unambiguous for
+ * every scheme this ever sees.
+ */
+function originOf(url: string): string {
+  const parsed = new URL(url)
+  return `${parsed.protocol}//${parsed.host}`
+}
+
+function bytesEqual(a: ArrayBuffer, b: ArrayBuffer): boolean {
+  if (a.byteLength !== b.byteLength) return false
+  const left = new Uint8Array(a)
+  const right = new Uint8Array(b)
+  for (let i = 0; i < left.length; i += 1) {
+    if (left[i] !== right[i]) return false
+  }
+  return true
+}
+
+/**
+ * What one provider response turned out to be.
+ *
+ * `placeholder` and `none` both mean "this provider has no icon for this
+ * site", and the walk moves on. `remote` means the bytes could not be read or
+ * judged here, so the URL is passed to the `<img>` rather than cached.
+ */
+type Verdict = "icon" | "placeholder" | "none" | "remote"
+
+export class FaviconResolver {
+  private readonly cache: FaviconCache
+  private readonly fetchImpl: typeof fetch
+  private readonly decode: (
+    bytes: ArrayBuffer,
+    mime: string
+  ) => Promise<ImageSize | null>
+  private readonly pageOrigin: string
+
+  /** One in-flight resolution per site key — the deduplication itself. */
+  private readonly inFlight = new Map<string, Promise<FaviconResolution>>()
+
+  /** Origins this build turned out not to be allowed to read bytes from. */
+  private readonly opaqueOrigins = new Set<string>()
+
+  /** The placeholder sample per probe URL, fetched at most once per session. */
+  private readonly probes = new Map<string, Promise<ArrayBuffer | null>>()
+
+  constructor(options: FaviconResolverOptions = {}) {
+    this.cache = options.cache ?? new FaviconCache()
+    this.fetchImpl = options.fetchImpl ?? ((...args) => fetch(...args))
+    this.decode = options.decode ?? decodeImageSize
+    this.pageOrigin = options.pageOrigin ?? currentOrigin()
+  }
+
+  /**
+   * The sources to render for a page.
+   *
+   * Never rejects. Every failure below — a closed IndexedDB, an offline
+   * network, a provider that throws — degrades to fewer sources, and no
+   * sources at all is the letter placeholder, which is always a valid answer.
+   */
+  resolve(
+    pageUrl: string,
+    provider: FaviconProvider
+  ): Promise<FaviconResolution> {
+    const key = normalizeFaviconKey(pageUrl)
+    if (!key) return Promise.resolve(NO_SOURCES)
+
+    const existing = this.inFlight.get(key)
+    if (existing) return existing
+
+    const pending = this.run(key, pageUrl, provider)
+      .catch(() => NO_SOURCES)
+      .finally(() => {
+        this.inFlight.delete(key)
+      })
+    this.inFlight.set(key, pending)
+    return pending
+  }
+
+  /**
+   * Records that every source for a page failed in the browser.
+   *
+   * This is the other half of the globe check: a Google response whose bytes
+   * this build could not read is judged by the `<img>` after it loads, and that
+   * judgement has to come back here or the same futile request is made again on
+   * the next render. It writes a *negative* entry, never the globe's bytes.
+   */
+  async reportMiss(pageUrl: string): Promise<void> {
+    const key = normalizeFaviconKey(pageUrl)
+    if (!key) return
+    try {
+      await this.cache.putMiss(key)
+    } catch {
+      // A cache that will not write is a lost optimization, not a failure.
+    }
+  }
+
+  private async run(
+    key: string,
+    pageUrl: string,
+    provider: FaviconProvider
+  ): Promise<FaviconResolution> {
+    const cached = await this.read(key)
+    if (cached) {
+      return { sources: cached.bytes ? [this.cache.materialize(cached)] : [] }
+    }
+
+    const remote: string[] = []
+    for (const url of candidateUrls(pageUrl, provider)) {
+      const outcome = await this.attempt(key, url, provider)
+      if (outcome.verdict === "icon") return { sources: [outcome.src] }
+      if (outcome.verdict === "remote") remote.push(url)
+    }
+
+    if (remote.length > 0) return { sources: remote }
+
+    // Every provider was asked and answered definitively: nothing exists.
+    await this.reportMiss(pageUrl)
+    return NO_SOURCES
+  }
+
+  private async read(key: string): Promise<FaviconRecord | null> {
+    try {
+      return await this.cache.get(key)
+    } catch {
+      return null
+    }
+  }
+
+  private async attempt(
+    key: string,
+    url: string,
+    provider: FaviconProvider
+  ): Promise<{ verdict: Verdict; src: string }> {
+    let origin: string
+    try {
+      origin = originOf(url)
+    } catch {
+      return { verdict: "none", src: "" }
+    }
+
+    /**
+     * A provider whose miss is only recognizable from its bytes must never be
+     * handed to the `<img>` unread: its placeholder loads perfectly well and
+     * would sit there looking like the site's icon, with no error to fall
+     * forward from. So for a guarded candidate, anything short of a verified
+     * icon is "none" — skip it and let the next provider answer, which is the
+     * order the UI had before this cache existed.
+     */
+    const guarded =
+      Boolean(provider.getPlaceholderProbeUrl?.()) && origin === this.pageOrigin
+    const unreadable: Verdict = guarded ? "none" : "remote"
+
+    if (this.opaqueOrigins.has(origin)) return { verdict: unreadable, src: "" }
+
+    let response: Response
+    try {
+      response = await this.fetchImpl(url)
+    } catch {
+      // Not an answer about this site: this build simply may not read that
+      // origin. Remember it, and let the `<img>` do what it always could.
+      this.opaqueOrigins.add(origin)
+      return { verdict: unreadable, src: "" }
+    }
+
+    if (!response.ok) return { verdict: "none", src: "" }
+
+    let bytes: ArrayBuffer
+    try {
+      bytes = await response.arrayBuffer()
+    } catch {
+      return { verdict: unreadable, src: "" }
+    }
+    if (bytes.byteLength === 0 || bytes.byteLength > FAVICON_MAX_BYTES) {
+      return { verdict: "none", src: "" }
+    }
+
+    const mime = response.headers.get("content-type") ?? "image/png"
+    const verdict = await this.classify(url, bytes, mime, provider, unreadable)
+    if (verdict !== "icon") return { verdict, src: "" }
+
+    return {
+      verdict: "icon",
+      src: this.cache.materialize(await this.store(key, bytes, mime)),
+    }
+  }
+
+  /**
+   * Stores an icon, and produces a record either way. A cache that will not
+   * write costs the *next* load its speed and its privacy; it must not cost
+   * this one its icon, which is already in hand.
+   */
+  private async store(
+    key: string,
+    bytes: ArrayBuffer,
+    mime: string
+  ): Promise<FaviconRecord> {
+    try {
+      return await this.cache.putIcon(key, bytes, mime)
+    } catch {
+      return { key, storedAt: Date.now(), bytes, mime }
+    }
+  }
+
+  /**
+   * Whether these bytes are a real icon or a provider's "I have nothing" image.
+   *
+   * Both providers that can miss have a recognizable miss, and caching either
+   * one would pin that site to a generic globe until the entry expired — the
+   * single worst thing a byte cache can do here.
+   *
+   * Google's is recognized by shape, through the same `isGoogleDefaultGlobe`
+   * the UI has always used, now applied to the decoded bytes *before* they are
+   * stored instead of to a rendered `<img>` afterwards.
+   *
+   * A provider we serve ourselves — Chrome's `_favicon`, same-origin to this
+   * page — is recognized by sampling it: `getPlaceholderProbeUrl` asks it about
+   * a site it cannot possibly know, and any response equal to that sample is a
+   * miss. Sampling rather than hard-coding means the check keeps working when
+   * the browser changes its placeholder art.
+   *
+   * "Unverifiable" is deliberately *not* treated as "icon". If the sample could
+   * not be taken, or the bytes could not be decoded, the response is passed to
+   * the `<img>` instead of stored, which is exactly the behavior that existed
+   * before this cache — never a permanently cached maybe-placeholder.
+   */
+  private async classify(
+    url: string,
+    bytes: ArrayBuffer,
+    mime: string,
+    provider: FaviconProvider,
+    unreadable: Verdict
+  ): Promise<Verdict> {
+    const probeUrl = provider.getPlaceholderProbeUrl?.()
+    if (probeUrl && originOf(url) === this.pageOrigin) {
+      const sample = await this.probe(probeUrl)
+      if (!sample) return unreadable
+      return bytesEqual(sample, bytes) ? "placeholder" : "icon"
+    }
+
+    if (!isGoogleFaviconUrl(url)) return "icon"
+
+    const size = await this.decode(bytes, mime)
+    if (!size) return unreadable
+    return isGoogleDefaultGlobe(url, size.width, size.height)
+      ? "placeholder"
+      : "icon"
+  }
+
+  private probe(probeUrl: string): Promise<ArrayBuffer | null> {
+    const existing = this.probes.get(probeUrl)
+    if (existing) return existing
+
+    const pending = this.fetchImpl(probeUrl)
+      .then((response) => (response.ok ? response.arrayBuffer() : null))
+      .catch(() => null)
+    this.probes.set(probeUrl, pending)
+    return pending
+  }
+}
+
+/** The provider's ordered URLs, without empties or a repeated entry. */
+function candidateUrls(pageUrl: string, provider: FaviconProvider): string[] {
+  const urls: string[] = []
+  for (const url of [
+    provider.getUrl(pageUrl),
+    provider.getFallbackUrl?.(pageUrl),
+  ]) {
+    if (url && !urls.includes(url)) urls.push(url)
+  }
+  return urls
+}
+
+/**
+ * The resolver the UI uses. One per document, because the deduplication map,
+ * the opaque-origin set and the placeholder sample are all page-lifetime facts
+ * that would be pointless to rebuild per component.
+ */
+export const faviconResolver = new FaviconResolver()

--- a/src/browser/firefox/favicon.ts
+++ b/src/browser/firefox/favicon.ts
@@ -4,8 +4,20 @@ import { GoogleFaviconV2Provider } from "../favicon/google-favicon-v2"
 const googleV2 = new GoogleFaviconV2Provider()
 
 /**
- * Firefox has no equivalent to Chrome's internal `_favicon` API, so Google Favicon V2
- * is the sole provider. `getFallbackUrl` is intentionally not implemented.
+ * Firefox has no equivalent to Chrome's internal `_favicon` API, so Google
+ * Favicon V2 is the sole provider. `getFallbackUrl` is intentionally not
+ * implemented.
+ *
+ * The one native source Firefox does offer is `tabs.Tab.favIconUrl`, and it is
+ * deliberately not used: reading it needs the `tabs` permission, which this
+ * extension does not request. Adding it would buy icons for the handful of
+ * sites that happen to be open at that moment, in exchange for a permission
+ * that grants the URL and title of every tab — a worse privacy trade than the
+ * one it would fix, and a store-review cost besides.
+ *
+ * Firefox still gains the rest of the cache: `host_permissions` already covers
+ * `t1.gstatic.com`, so the resolver can read and store Google's bytes, and a
+ * site resolved once is rendered locally from then on.
  */
 export class FirefoxFaviconAdapter implements FaviconProvider {
   getUrl(pageUrl: string): string {

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -125,6 +125,18 @@ export interface FaviconProvider {
   getUrl(pageUrl: string): string
   getFallbackUrl?(pageUrl: string): string
   isAvailable(): boolean
+  /**
+   * A URL that returns this provider's own "I have no icon for that" image,
+   * or `""` when it has no such thing.
+   *
+   * Only a provider the extension serves itself needs this. Its miss is not an
+   * HTTP error and not a distinctive size — it is a perfectly valid placeholder
+   * image — so the only way to tell it apart is to ask the provider about a
+   * site it cannot possibly know and compare the bytes. Implementing this is
+   * what lets the favicon cache store the provider's results at all: without a
+   * sample, a placeholder would be cached as if it were the site's icon.
+   */
+  getPlaceholderProbeUrl?(): string
 }
 
 export interface AdapterCapabilities {

--- a/src/features/bookmark-card/bookmark-card.tsx
+++ b/src/features/bookmark-card/bookmark-card.tsx
@@ -200,20 +200,6 @@ export const BookmarkCard = React.memo(function BookmarkCard({
     setCardLayout(folder.id, layout === "list" ? "grid" : "list")
   }, [folder.id, layout, setCardLayout])
 
-  const getFaviconUrl = React.useCallback(
-    (pageUrl: string) => {
-      return adapter?.favicon.getUrl(pageUrl) ?? ""
-    },
-    [adapter]
-  )
-
-  const getFallbackFaviconUrl = React.useCallback(
-    (pageUrl: string) => {
-      return adapter?.favicon.getFallbackUrl?.(pageUrl)
-    },
-    [adapter]
-  )
-
   return (
     <div
       ref={dropRef as React.RefObject<HTMLDivElement>}
@@ -273,8 +259,6 @@ export const BookmarkCard = React.memo(function BookmarkCard({
               key={bookmark.id}
               bookmark={bookmark}
               layout={layout}
-              faviconUrl={getFaviconUrl(bookmark.url!)}
-              faviconFallbackUrl={getFallbackFaviconUrl(bookmark.url!)}
               sortableIndex={index}
               folderId={folder.id}
             />

--- a/src/features/bookmark-item/__tests__/favicon.test.tsx
+++ b/src/features/bookmark-item/__tests__/favicon.test.tsx
@@ -1,97 +1,165 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useBookmarkStore } from "@/stores/bookmark-store"
 import { Favicon } from "../favicon"
 
-afterEach(cleanup)
-
 /**
- * The empty-source contract: Chromium fires neither `load` nor `error` for
- * `<img src="">`, so an empty primary favicon URL can never reach the
- * error-driven letter fallback on its own — it must start there.
+ * The component's half of the contract, with resolution stubbed out: it walks
+ * the sources it is given, and every way of running out of them ends at the
+ * letter placeholder rather than a broken image.
  */
 
-describe("Favicon empty primary source", () => {
-  it("renders the letter avatar immediately for an empty primarySrc, with no img element", () => {
-    const { container } = render(
-      <Favicon url="https://example.com/page" primarySrc="" title="Example" />
-    )
+const resolve = vi.fn<(pageUrl: string) => Promise<{ sources: string[] }>>()
+const reportMiss = vi.fn<(pageUrl: string) => Promise<void>>()
 
-    const letter = screen.getByText("E")
+vi.mock("@/browser/favicon/resolve", () => ({
+  faviconResolver: {
+    resolve: (pageUrl: string) => resolve(pageUrl),
+    reportMiss: (pageUrl: string) => reportMiss(pageUrl),
+  },
+}))
+
+function mount(url: string, title = "Example") {
+  useBookmarkStore.setState({
+    adapter: {
+      bookmarks: {} as never,
+      storage: { get: vi.fn(), set: vi.fn(), remove: vi.fn() },
+      favicon: { getUrl: () => "", isAvailable: () => true },
+      capabilities: {
+        openInManager: false,
+        move: true,
+        reorder: true,
+        setChildOrder: false,
+      },
+    },
+  })
+  return render(<Favicon url={url} title={title} />)
+}
+
+beforeEach(() => {
+  resolve.mockReset()
+  reportMiss.mockReset()
+  resolve.mockResolvedValue({ sources: [] })
+})
+
+afterEach(() => {
+  cleanup()
+  useBookmarkStore.setState({ adapter: null })
+})
+
+describe("Favicon with no usable source", () => {
+  it("renders the letter avatar when resolution finds nothing, with no img", async () => {
+    const { container } = mount("https://example.com/page")
+
+    const letter = await screen.findByText("E")
     expect(letter.getAttribute("aria-label")).toBe("Example")
     expect(container.querySelector("img")).toBeNull()
   })
 
-  it("skips straight to the letter for an empty primarySrc even when a fallback URL exists", () => {
-    const { container } = render(
-      <Favicon
-        url="https://example.com"
-        primarySrc=""
-        fallbackSrc="https://fallback.example/icon.png"
-        title="Example"
-      />
-    )
+  it("falls back to '?' for an unparsable URL without asking the resolver", () => {
+    render(<Favicon url="not a url" title="Broken" />)
 
-    expect(screen.getByText("E")).toBeTruthy()
-    expect(container.querySelector("img")).toBeNull()
-  })
-
-  it("falls back to '?' when the URL cannot be parsed", () => {
-    render(<Favicon url="not a url" primarySrc="" title="Broken" />)
     expect(screen.getByText("?")).toBeTruthy()
+    expect(resolve).not.toHaveBeenCalled()
+  })
+
+  it("never asks the resolver about a non-HTTP page", () => {
+    render(<Favicon url="file:///Users/me/notes.html" title="Notes" />)
+
+    expect(resolve).not.toHaveBeenCalled()
+    expect(document.querySelector("img")).toBeNull()
+  })
+
+  it("shows a letterless placeholder while resolution is pending", () => {
+    resolve.mockReturnValue(new Promise(() => {}))
+    const { container } = mount("https://example.com")
+
+    expect(screen.queryByText("E")).toBeNull()
+    expect(container.querySelector("img")).toBeNull()
+    expect(container.querySelector("[aria-label='Example']")).toBeTruthy()
   })
 })
 
-describe("Favicon primary source transitions", () => {
-  it("loads a real primary once one arrives, and returns to the letter when it empties again", () => {
-    const { rerender } = render(
-      <Favicon url="https://example.com" primarySrc="" title="Example" />
-    )
-    expect(screen.getByText("E")).toBeTruthy()
+describe("Favicon source walk", () => {
+  it("renders a cached blob source directly", async () => {
+    resolve.mockResolvedValue({ sources: ["blob:cached-icon"] })
+    mount("https://example.com")
 
-    rerender(
-      <Favicon
-        url="https://example.com"
-        primarySrc="https://icons.example/example.png"
-        title="Example"
-      />
-    )
-    const img = document.querySelector("img")
-    expect(img?.getAttribute("src")).toBe("https://icons.example/example.png")
+    const img = await screen.findByRole("presentation")
+    expect(img.getAttribute("src")).toBe("blob:cached-icon")
+  })
 
-    rerender(
-      <Favicon url="https://example.com" primarySrc="" title="Example" />
-    )
-    expect(screen.getByText("E")).toBeTruthy()
+  it("advances to the next source when one fails, then lands on the letter", async () => {
+    resolve.mockResolvedValue({
+      sources: ["https://icons.example/a.png", "https://icons.example/b.png"],
+    })
+    mount("https://example.com")
+
+    const first = await screen.findByRole("presentation")
+    expect(first.getAttribute("src")).toBe("https://icons.example/a.png")
+
+    fireEvent.error(first)
+    const second = await screen.findByRole("presentation")
+    expect(second.getAttribute("src")).toBe("https://icons.example/b.png")
+
+    fireEvent.error(second)
+    expect(await screen.findByText("E")).toBeTruthy()
     expect(document.querySelector("img")).toBeNull()
+  })
+
+  it("reports a miss once every source has failed", async () => {
+    resolve.mockResolvedValue({ sources: ["https://icons.example/a.png"] })
+    mount("https://example.com/deep/page")
+
+    const img = await screen.findByRole("presentation")
+    expect(reportMiss).not.toHaveBeenCalled()
+
+    fireEvent.error(img)
+    await screen.findByText("E")
+    expect(reportMiss).toHaveBeenCalledWith("https://example.com/deep/page")
+  })
+
+  it("does not report a miss when resolution simply had nothing to offer", async () => {
+    resolve.mockResolvedValue({ sources: [] })
+    mount("https://example.com")
+
+    await screen.findByText("E")
+    // The resolver already recorded that itself; the component only reports
+    // sources that failed in the browser.
+    expect(reportMiss).not.toHaveBeenCalled()
   })
 })
 
-describe("Favicon error-driven fallback (unchanged for non-empty sources)", () => {
-  it("lands on the letter when the primary fails to load", () => {
-    render(
-      <Favicon
-        url="https://example.com"
-        primarySrc="https://icons.example/broken.png"
-        title="Example"
-      />
-    )
-    fireEvent.error(document.querySelector("img")!)
-    expect(screen.getByText("E")).toBeTruthy()
+describe("Favicon and Google's default globe", () => {
+  it("treats a 16x16 Google response as a failure and falls through", async () => {
+    const globeUrl =
+      "https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https%3A%2F%2Fexample.com&size=64"
+    resolve.mockResolvedValue({ sources: [globeUrl] })
+    mount("https://example.com")
+
+    const img = await screen.findByRole("presentation")
+    Object.defineProperty(img, "naturalWidth", { value: 16 })
+    Object.defineProperty(img, "naturalHeight", { value: 16 })
+    fireEvent.load(img)
+
+    expect(await screen.findByText("E")).toBeTruthy()
+    expect(reportMiss).toHaveBeenCalledWith("https://example.com")
   })
 
-  it("lands on the letter when the primary fails and a fallback exists", () => {
-    render(
-      <Favicon
-        url="https://example.com"
-        primarySrc="https://icons.example/broken.png"
-        fallbackSrc="https://fallback.example/icon.png"
-        title="Example"
-      />
-    )
-    fireEvent.error(document.querySelector("img")!)
-    expect(screen.getByText("E")).toBeTruthy()
-    expect(document.querySelector("img")).toBeNull()
+  it("keeps a Google response that is not the globe", async () => {
+    const iconUrl =
+      "https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https%3A%2F%2Fexample.com&size=64"
+    resolve.mockResolvedValue({ sources: [iconUrl] })
+    mount("https://example.com")
+
+    const img = await screen.findByRole("presentation")
+    Object.defineProperty(img, "naturalWidth", { value: 64 })
+    Object.defineProperty(img, "naturalHeight", { value: 64 })
+    fireEvent.load(img)
+
+    expect(screen.queryByText("E")).toBeNull()
+    expect(img.getAttribute("src")).toBe(iconUrl)
   })
 })

--- a/src/features/bookmark-item/bookmark-item.tsx
+++ b/src/features/bookmark-item/bookmark-item.tsx
@@ -31,8 +31,6 @@ import { describeReadOnly } from "@/lib/bookmark-utils"
 interface BookmarkItemProps {
   bookmark: BookmarkNode
   layout: "list" | "grid"
-  faviconUrl: string
-  faviconFallbackUrl?: string
   sortableIndex: number
   folderId: string
 }
@@ -40,8 +38,6 @@ interface BookmarkItemProps {
 export const BookmarkItem = React.memo(function BookmarkItem({
   bookmark,
   layout,
-  faviconUrl,
-  faviconFallbackUrl,
   sortableIndex,
   folderId,
 }: BookmarkItemProps) {
@@ -139,8 +135,6 @@ export const BookmarkItem = React.memo(function BookmarkItem({
           >
             <Favicon
               url={bookmark.url ?? ""}
-              primarySrc={faviconUrl}
-              fallbackSrc={faviconFallbackUrl}
               title={bookmark.title}
               size={40}
             />
@@ -178,13 +172,7 @@ export const BookmarkItem = React.memo(function BookmarkItem({
             />
           }
         >
-          <Favicon
-            url={bookmark.url ?? ""}
-            primarySrc={faviconUrl}
-            fallbackSrc={faviconFallbackUrl}
-            title={bookmark.title}
-            size={16}
-          />
+          <Favicon url={bookmark.url ?? ""} title={bookmark.title} size={16} />
           <span className="min-w-0 truncate text-base sm:text-sm">
             {bookmark.title}
           </span>

--- a/src/features/bookmark-item/favicon.tsx
+++ b/src/features/bookmark-item/favicon.tsx
@@ -1,57 +1,70 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
 import { isGoogleDefaultGlobe } from "@/browser/favicon/detect-default-globe"
+import { faviconResolver } from "@/browser/favicon/resolve"
+import { useFaviconSources } from "./use-favicon"
 
 interface FaviconProps {
   url: string
-  primarySrc: string
-  fallbackSrc?: string
   title: string
   className?: string
   size?: number
 }
 
-export function Favicon({
-  url,
-  primarySrc,
-  fallbackSrc,
-  title,
-  className,
-  size = 20,
-}: FaviconProps) {
-  const [src, setSrc] = React.useState(primarySrc)
-  const [failed, setFailed] = React.useState(false)
+/**
+ * A bookmark's icon: whatever the resolver offers, then the letter placeholder.
+ *
+ * The component used to be handed a primary and a fallback URL by its parent
+ * and pick between them. It now asks the resolver for an ordered list, because
+ * the first entry may be a `blob:` URL out of the local cache and there may be
+ * no remote entry at all. Walking a list is the same logic as before, one
+ * `<img>` at a time, generalized from two candidates to n.
+ *
+ * The globe check stays here as well as in the resolver, and has to. The
+ * resolver catches Google's generic globe only when it was allowed to read the
+ * bytes; where it was not — the daemon web app, which has no host permission
+ * for gstatic — the response reaches this `<img>` unread, and its rendered size
+ * is the only place the globe is visible. Treating it as an error is what makes
+ * the letter win for sites Google has nothing for.
+ */
+export function Favicon({ url, title, className, size = 20 }: FaviconProps) {
+  const { sources, pending } = useFaviconSources(url)
+  // How far into *this* list of sources the walk has got. Carrying the list
+  // itself in the state is what makes a new list start over at zero without a
+  // reset effect, and without a frame where an old index points past the end.
+  const [attempt, setAttempt] = React.useState({ sources, index: 0 })
+  const active = attempt.sources === sources ? attempt : { sources, index: 0 }
 
+  const src = active.sources[active.index] ?? ""
+  const exhausted = sources.length > 0 && active.index >= sources.length
+
+  // Nothing left to try. Tell the resolver, so the next render shows the
+  // letter straight from the cache instead of repeating a request that has
+  // already failed — and so a `blob:` URL that will not decode drops its
+  // record rather than failing forever.
   React.useEffect(() => {
-    setSrc(primarySrc)
-    setFailed(false)
-  }, [primarySrc])
+    if (exhausted) void faviconResolver.reportMiss(url)
+  }, [exhausted, url])
 
-  const handleError = React.useCallback(() => {
-    if (!failed && fallbackSrc) {
-      setSrc(fallbackSrc)
-      setFailed(true)
-    } else {
-      setFailed(true)
+  const handleError = () => {
+    setAttempt({ sources: active.sources, index: active.index + 1 })
+  }
+
+  const handleLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    const img = e.currentTarget
+    if (isGoogleDefaultGlobe(src, img.naturalWidth, img.naturalHeight)) {
+      handleError()
     }
-  }, [failed, fallbackSrc])
+  }
 
-  const handleLoad = React.useCallback(
-    (e: React.SyntheticEvent<HTMLImageElement>) => {
-      const img = e.currentTarget
-      if (isGoogleDefaultGlobe(src, img.naturalWidth, img.naturalHeight)) {
-        handleError()
-      }
-    },
-    [src, handleError]
-  )
-
-  // An <img src=""> fires neither load nor error in Chromium, so an empty
-  // primary URL can never reach handleError on its own: treat it as failed
-  // from the first render. This is also the production edge for a malformed
-  // page URL, where GoogleFaviconV2Provider.getUrl returns "".
-  if (failed || !primarySrc) {
-    // Final fallback: first letter of domain
+  // An `<img src="">` fires neither load nor error in Chromium, so an empty
+  // source can never reach handleError on its own: it has to start at the
+  // placeholder. That covers three cases at once — a page no provider can
+  // answer for, a cached "nobody has an icon for this site", and every source
+  // having been tried and failed. `pending` renders the same box without a
+  // letter, so the first frame does not flash a letter that is about to be
+  // replaced, and nothing moves when the icon arrives.
+  if (pending || !src) {
     let letter = "?"
     try {
       letter = new URL(url).hostname.charAt(0).toUpperCase()
@@ -68,7 +81,7 @@ export function Favicon({
         style={{ width: size, height: size, minWidth: size, minHeight: size }}
         aria-label={title}
       >
-        {letter}
+        {pending ? "" : letter}
       </span>
     )
   }

--- a/src/features/bookmark-item/use-favicon.ts
+++ b/src/features/bookmark-item/use-favicon.ts
@@ -1,0 +1,51 @@
+/**
+ * The React side of favicon resolution.
+ *
+ * Resolution became asynchronous when it gained a cache, so a row can no longer
+ * be handed a finished URL by its parent. It asks here instead, and the
+ * resolver deduplicates: a folder card with ten bookmarks on one origin
+ * mounting at once produces one lookup, not ten.
+ */
+
+import * as React from "react"
+import { faviconResolver } from "@/browser/favicon/resolve"
+import { normalizeFaviconKey } from "@/browser/favicon/key"
+import { useBookmarkStore } from "@/stores/bookmark-store"
+
+export interface FaviconSources {
+  /** Ordered sources to try, most-preferred first. Empty means the letter. */
+  sources: string[]
+  /** True while the first answer for this page is still being worked out. */
+  pending: boolean
+}
+
+const NOTHING: FaviconSources = { sources: [], pending: false }
+
+export function useFaviconSources(pageUrl: string): FaviconSources {
+  const provider = useBookmarkStore((s) => s.adapter?.favicon)
+  const [resolved, setResolved] = React.useState<{
+    pageUrl: string
+    sources: string[]
+  } | null>(null)
+
+  // A page no provider could ever answer for — not HTTP(S), or not a URL at
+  // all — is settled synchronously, so a malformed bookmark shows its letter
+  // on the first render instead of flickering through a pending frame.
+  const resolvable = normalizeFaviconKey(pageUrl) !== null
+
+  React.useEffect(() => {
+    if (!resolvable || !provider) return
+    let cancelled = false
+    faviconResolver.resolve(pageUrl, provider).then((resolution) => {
+      if (!cancelled) setResolved({ pageUrl, sources: resolution.sources })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [pageUrl, provider, resolvable])
+
+  if (!resolvable || !provider) return NOTHING
+  // Anything resolved for a *previous* URL is not an answer for this one.
+  if (resolved?.pageUrl !== pageUrl) return { sources: [], pending: true }
+  return { sources: resolved.sources, pending: false }
+}

--- a/website/src/pages/privacy.tsx
+++ b/website/src/pages/privacy.tsx
@@ -60,10 +60,21 @@ export function Privacy() {
         <p className={BODY}>
           One kind only, by default: favicon lookups against Google's public
           favicon service. Bookmark origins (the scheme and host) are sent to
-          find site icons; full URL paths are not. Chrome can also fall back to
-          its on-device favicon API. If you connect a local daemon, the
-          extension talks to that loopback address — permission is requested at
-          connect time, never at install time.
+          find site icons; full URL paths are not.
+        </p>
+        <p className={BODY}>
+          Icons are looked up in this order, and each step that answers stops
+          the next from running: a local cache of icon bytes stored on your
+          machine, then the browser's own on-device icon store (Chrome's favicon
+          API — Firefox has no equivalent an extension may read), then Google,
+          then a letter placeholder drawn locally. A successful lookup is cached
+          for 30 days, so a given site is normally asked about once a month
+          rather than on every new tab, and cached icons keep working offline.
+        </p>
+        <p className={BODY}>
+          If you connect a local daemon, the extension talks to that loopback
+          address — permission is requested at connect time, never at install
+          time.
         </p>
       </Section>
 


### PR DESCRIPTION
The first slice of #30, as that issue's own "Suggested delivery" scopes it: cache, deduplication, native preference, Google fallback. **Daemon-side direct-origin fetching is deliberately not here** — the issue's entire "Security requirements" section concerns that path, and it should land only after its security model is reviewed. #30 stays open for it.

## Summary

- A favicon cache holding image **bytes** in its own IndexedDB database, so a hit is fully local.
- Concurrent lookups for one site collapse into one.
- **Chrome asks its own `_favicon` database before Google.** It used to be the other way round.
- The README gains a Privacy section documenting the provider order and when an origin still reaches Google.

## The Chrome ordering was backwards

`ChromeFaviconAdapter` had Google V2 as `getUrl` and `_favicon` only as `getFallbackUrl`. Chrome ships a local, private favicon database on the extension's own origin, and the extension was asking Google first anyway. Flipping it is the single largest privacy gain available here.

That flip is only safe because the resolver can now recognise `_favicon`'s own placeholder: `getPlaceholderProbeUrl()` asks it about `https://favicon-probe.invalid/` (RFC 2606 — never leaves the machine) once per session, and a byte-identical response counts as a miss. Without it, native-first would pin every unknown site to a grey globe.

## Cache design

- **Storage:** its own database, `bookmarks-but-better-favicons`, so icons can never damage bookmarks or preferences. Bytes as `ArrayBuffer`; the `Blob` is rebuilt only when an object URL is needed.
- **Key:** `scheme://host[:non-default-port]`. `URL` gives a lowercase host and Punycode A-labels, so `https://bücher.example` and its `xn--` form share one entry. Non-default ports and schemes stay separate; path, query and credentials are discarded. Non-HTTP(S) returns `null` — no provider can answer, and a `file:` path should never reach one.
- **TTL:** 30 days for icons, 24 hours for misses. A favicon changes on the order of a rebrand, and a short TTL is paid in third-party requests by every user at every expiry. A negative entry is a claim a site can falsify tomorrow, so it expires much sooner.
- **Size:** 1000 entries, trimmed to 900 on overflow so a full cache runs one eviction pass per 100 inserts. Per-entry ceiling 256 KB — past that it is not a favicon.
- **Eviction:** oldest-first by `storedAt`, in the same transaction as the insert. LRU was rejected deliberately: entries only exist for origins the user actually rendered, and oldest-first makes eviction order equal expiry order — one age concept instead of two, and no write per read.
- **Stale-while-revalidate: not implemented, on purpose.** It buys latency, and an IndexedDB hit is already instant. "Revalidate" here means a fresh request to Google — exactly what the cache exists to avoid.

## Keeping the Google globe out of the cache

`isGoogleDefaultGlobe` is unchanged and now used twice. Where bytes are readable, `createImageBitmap` decodes the intrinsic size and the same function runs **before** storing — a 16×16 globe is a miss, so it is never cached and the walk continues. Where bytes are unreadable the response reaches the `<img>` unjudged, so the component keeps its existing check and reports the miss back. "Unverifiable" (no decoder) is deliberately not treated as "icon".

This mattered: cache the globe once and that site is a globe forever.

## Why bytes can be cached at all

Verified by curl: neither Google endpoint sends `Access-Control-Allow-Origin`; they send `cross-origin-resource-policy: cross-origin`, which permits embedding but not reading. Byte caching of Google's responses works **only** because the Chrome and Firefox manifests already declare `host_permissions` for gstatic. Nothing was added to any manifest.

Consequence: the daemon's own web app, served over loopback, can display Google's icon but not read it, so it still fetches per load. That is the case the follow-up slice closes, and the README says so.

## Firefox native capture is not included

`tabs.Tab.favIconUrl` is Firefox's only native source and reading it needs the `tabs` permission, which the manifest does not have. Granting URL and title of every open tab in exchange for icons for whichever sites happen to be open is a worse trade than the one it fixes — and a store-review cost. Not added; documented in `src/browser/firefox/favicon.ts`, the README, and pinned by a test. Firefox still gains the cache.

## Verification

- `bun run check` — pass (82 test files, 785 tests; 735 before).
- `bun run test:ui` — 27 passed.
- No manifest changed (confirmed against the diff).
- Tests cover: key normalisation including IDN and ports, TTL expiry, eviction at the size limit, one lookup for concurrent same-origin resolves, the globe not being cached on either pass, Chrome's placeholder probe fetched once per session and the native candidate dropped when it cannot be taken, object URLs revoked on replacement and eviction, and the placeholder ending every failure path.

## Worth an eye before release

The `_favicon` placeholder probe is the one piece unverifiable from here: that Chrome returns a byte-stable placeholder for an unknown host, rather than a 404. Both outcomes are handled — a 404 advances to Google, an unfetchable probe drops the native candidate — so the failure mode is "behaves as before", not "grey globes". Still worth eyeballing in a real Chrome.

Object URLs are one per site, revoked on replacement, expiry and eviction; those living until the page closes are bounded by the 1000-entry cap.
